### PR TITLE
Dynamic Dot - no closures

### DIFF
--- a/rhombus/private/dot.rkt
+++ b/rhombus/private/dot.rkt
@@ -9,6 +9,9 @@
          "static-info.rkt"
          "dot-provider-key.rkt"
          "realm.rkt"
+         "racket-class.rkt"
+         "parens.rkt"
+         "parse.rkt"
          "racket-class.rkt")
 
 (provide |.|
@@ -58,8 +61,13 @@
                                   #'dot.name
                                   #f
                                   (list form1))
-              (values #`(dot-lookup-by-name #,form1 'field)
-                      #'tail)))
+              (syntax-parse #'tail
+                [((p::parens e ...) . tail)
+                 (values #`(dot-lookup-by-name #,form1 'field #t (rhombus-expression e) ...)
+                         #'tail)]
+                [tail
+                 (values #`(dot-lookup-by-name #,form1 'field #f)
+                         #'tail)])))
         (syntax-parse form1
           [dp::dot-provider
            (define p (syntax-local-value* (in-dot-provider-space #'dp.id) dot-provider-ref))
@@ -103,16 +111,19 @@
                                  (values name
                                          (make-struct-field-accessor gen-acc i name))))))
 
-(define (dot-lookup-by-name v field)
-  (define ht (field-name->accessor-ref v #f))
+(define (dot-lookup-by-name subj field fun? . args)
+  (define ht (field-name->accessor-ref subj #f))
   (define (fail)
     (raise-arguments-error* field
                             rhombus-realm
                             "no such field"
-                            "in value" v))
+                            "in value" subj))
   (cond
-    [(object? v) (object-dot-lookup v field fail)]
+    [(object? subj) (object-dot-lookup subj field fun? args fail)]
     [(not ht) (fail)]
-    [(hash-ref ht field #f) => (lambda (acc) (acc v))]
+    [(hash-ref ht field #f)
+     => (lambda (acc)
+          (define val (acc subj))
+          (if fun? (apply val args) val))]
     [else (fail)]))
 

--- a/rhombus/private/dot.rkt
+++ b/rhombus/private/dot.rkt
@@ -8,7 +8,8 @@
          "expression.rkt"
          "static-info.rkt"
          "dot-provider-key.rkt"
-         "realm.rkt")
+         "realm.rkt"
+         "racket-class.rkt")
 
 (provide |.|
          use_static_dot
@@ -110,8 +111,8 @@
                             "no such field"
                             "in value" v))
   (cond
+    [(object? v) (object-dot-lookup v field fail)]
     [(not ht) (fail)]
     [(hash-ref ht field #f) => (lambda (acc) (acc v))]
     [else (fail)]))
 
-   

--- a/rhombus/private/racket-class.rkt
+++ b/rhombus/private/racket-class.rkt
@@ -1,0 +1,27 @@
+#lang racket/base
+
+(require racket/class)
+
+(provide object?
+         object-dot-lookup)
+
+(define (object-has-field? o field)
+  (and (memq field (field-names o)) #t))
+
+(define (object-has-method? o field)
+  (method-in-interface? field (object-interface o)))
+
+(define (object-dot-lookup o field fail)
+  (cond
+    [(object-has-field? o field)
+     (dynamic-get-field field o)]
+
+    [(object-has-method? o field)
+     (make-keyword-procedure
+       (lambda (kws kwargs . pos-args)
+         (keyword-apply dynamic-send kws kwargs o field pos-args))
+       (lambda pos-args
+         (apply dynamic-send o field pos-args)))]
+
+    [else (fail)]))
+

--- a/rhombus/private/racket-class.rkt
+++ b/rhombus/private/racket-class.rkt
@@ -11,17 +11,20 @@
 (define (object-has-method? o field)
   (method-in-interface? field (object-interface o)))
 
-(define (object-dot-lookup o field fail)
+(define (object-dot-lookup o field fun? args fail)
   (cond
     [(object-has-field? o field)
-     (dynamic-get-field field o)]
+     (define val (dynamic-get-field field o))
+     (if fun? (apply val args) val)]
 
     [(object-has-method? o field)
-     (make-keyword-procedure
-       (lambda (kws kwargs . pos-args)
-         (keyword-apply dynamic-send kws kwargs o field pos-args))
-       (lambda pos-args
-         (apply dynamic-send o field pos-args)))]
+     (if fun?
+         (apply dynamic-send o field args)
+         (make-keyword-procedure
+           (lambda (kws kwargs . pos-args)
+             (keyword-apply dynamic-send kws kwargs o field pos-args))
+           (lambda pos-args
+             (apply dynamic-send o field pos-args))))]
 
     [else (fail)]))
 


### PR DESCRIPTION
This is a light modification of the existing dynamic dot lookup protocol.  When parens follow a dot expression, it sets a `fun?` flag and passes the arguments to `dot-lookup-by-name`.  This avoids the closure allocation but may instead cause a list allocation.