### PR TITLE
Add an equality macro

### DIFF
--- a/rhombus/data/equality.rhm
+++ b/rhombus/data/equality.rhm
@@ -1,0 +1,44 @@
+#lang rhombus/and_meta
+
+
+export:
+  equality
+
+
+import:
+  lib("racket/base.rkt"):
+    meta
+    expose: #{generate-temporaries}
+  lib("racket/base.rkt").#{equal-hash-code}
+  lib("racket/unsafe/ops.rkt").#{unsafe-fx+/wraparound}
+  lib("racket/unsafe/ops.rkt").#{unsafe-fx*/wraparound}
+
+
+class_clause.macro 'equality: $key_expr; ...':
+  def [key_id, ...] = #{generate-temporaries}([key_expr, ...])
+  'internal PrivateForEquals
+   implements Equatable
+
+   private method $key_id(): $key_expr
+   ...
+
+   override method equals(other):
+     (other is_a PrivateForEquals)
+       $$('&& (this . $key_id() == (other -: PrivateForEquals) . $key_id())') ...
+
+   override method hashCode():
+     let code = 1000003
+     let code:
+       #{unsafe-fx+/wraparound}(
+         #{unsafe-fx*/wraparound}(code, 31), #{equal-hash-code}(this . $key_id()))
+     ...
+     code'
+
+
+class Foo(a, b, c):
+  equality:
+    a
+    b + c
+
+Foo(1, 5, 10) == Foo(1, 10, 5) // true
+Foo(1, 5, 10) == Foo(1, 5, 5) // false


### PR DESCRIPTION
This is a draft PR I'm leaving up as a reference. It implements a hypothetical `equality:` macro for specifying what components of a class are relevant when comparing its instances for equality. This code:

```
class Foo(a, b, c):
  equality:
    a
    b
    c
```

Expands into this, roughly:

```
class Foo(a, b, c):
  implements Equatable

  override method equals(other):
    (other is_a Foo)
      && (a == other.a)
      && (b == other.b)
      && (c == other.c)

  override method hashCode():
    let code = 1000003
    let code = 31 * code + a.hashCode()
    let code = 31 * code + b.hashCode()
    let code = 31 * code + c.hashCode()
    code
```

You can pass arbitrary expressions into `equality`, not just fields, so this works:

```
class TwoElementIntSet(a :: Integer, b :: Integer):
  equality:
    min(a, b)
    max(a, b)
```

I'm drafting this PR for reference in future discussions. I'm not sure this is the way to go, but I did want to make this code available. Consider it a proof of concept.