### PR TITLE
Update equality macro for recur and hash-code-combine

### DIFF
--- a/rhombus/data/equality.rhm
+++ b/rhombus/data/equality.rhm
@@ -22,11 +22,11 @@ class_clause.macro 'equality: $key_expr; ...':
    private method $key_id(): $key_expr
    ...
 
-   override method equals(other):
+   override method equals(other, recur):
      (other is_a PrivateForEquals)
-       $$('&& (this . $key_id() == (other -: PrivateForEquals) . $key_id())') ...
+       $('&& (this . $key_id() == (other :~ PrivateForEquals) . $key_id())') ...
 
-   override method hashCode():
+   override method hash_code(recur):
      let code = 1000003
      let code:
        #{unsafe-fx+/wraparound}(

--- a/rhombus/data/equality.rhm
+++ b/rhombus/data/equality.rhm
@@ -9,8 +9,7 @@ import:
   lib("racket/base.rkt"):
     meta
     expose: #{generate-temporaries}
-  lib("racket/unsafe/ops.rkt").#{unsafe-fx+/wraparound}
-  lib("racket/unsafe/ops.rkt").#{unsafe-fx*/wraparound}
+  lib("racket/base.rkt").#{eq-hash-code}
 
 
 class_clause.macro 'equality: $key_expr; ...':
@@ -26,10 +25,8 @@ class_clause.macro 'equality: $key_expr; ...':
        $('&& (recur(this . $key_id(), (other :~ PrivateForEquals) . $key_id()))') ...
 
    private override method hash_code(recur):
-     let code = 1000003
-     let code:
-       #{unsafe-fx+/wraparound}(
-         #{unsafe-fx*/wraparound}(code, 31), recur(this . $key_id()))
+     let code = #{eq-hash-code}(PrivateForEquals)
+     let code: Equatable.hash_code_combine(code, recur(this . $key_id()))
      ...
      code'
 

--- a/rhombus/data/equality.rhm
+++ b/rhombus/data/equality.rhm
@@ -1,0 +1,44 @@
+#lang rhombus/and_meta
+
+
+export:
+  equality
+
+
+import:
+  lib("racket/base.rkt"):
+    meta
+    expose: #{generate-temporaries}
+  lib("racket/base.rkt").#{equal-hash-code}
+  lib("racket/unsafe/ops.rkt").#{unsafe-fx+/wraparound}
+  lib("racket/unsafe/ops.rkt").#{unsafe-fx*/wraparound}
+
+
+class_clause.macro 'equality: $key_expr; ...':
+  def [key_id, ...] = #{generate-temporaries}([key_expr, ...])
+  'internal PrivateForEquals
+   implements Equatable
+
+   private method $key_id(): $key_expr
+   ...
+
+   override method equals(other):
+     (other is_a PrivateForEquals)
+       $$('&& (this . $key_id() == (other -: PrivateForEquals) . $key_id())') ...
+
+   override method hashCode():
+     let code = 1000003
+     let code:
+       #{unsafe-fx+/wraparound}(
+         #{unsafe-fx*/wraparound}(code, 31), #{equal-hash-code}(this . $key_id()))
+     ...
+     code'
+
+
+class Foo(a, b, c):
+  equality:
+    a
+    b + c
+
+Foo(1, 5, 10) == Foo(1, 10, 5) // true
+Foo(1, 5, 10) == Foo(1, 5, 5) // false

--- a/rhombus/data/equality.rhm
+++ b/rhombus/data/equality.rhm
@@ -9,7 +9,6 @@ import:
   lib("racket/base.rkt"):
     meta
     expose: #{generate-temporaries}
-  lib("racket/base.rkt").#{equal-hash-code}
   lib("racket/unsafe/ops.rkt").#{unsafe-fx+/wraparound}
   lib("racket/unsafe/ops.rkt").#{unsafe-fx*/wraparound}
 
@@ -17,28 +16,20 @@ import:
 class_clause.macro 'equality: $key_expr; ...':
   def [key_id, ...] = #{generate-temporaries}([key_expr, ...])
   'internal PrivateForEquals
-   implements Equatable
+   private implements Equatable
 
    private method $key_id(): $key_expr
    ...
 
-   override method equals(other, recur):
+   private override method equals(other, recur):
      (other is_a PrivateForEquals)
-       $('&& (this . $key_id() == (other :~ PrivateForEquals) . $key_id())') ...
+       $('&& (recur(this . $key_id(), (other :~ PrivateForEquals) . $key_id()))') ...
 
-   override method hash_code(recur):
+   private override method hash_code(recur):
      let code = 1000003
      let code:
        #{unsafe-fx+/wraparound}(
-         #{unsafe-fx*/wraparound}(code, 31), #{equal-hash-code}(this . $key_id()))
+         #{unsafe-fx*/wraparound}(code, 31), recur(this . $key_id()))
      ...
      code'
 
-
-class Foo(a, b, c):
-  equality:
-    a
-    b + c
-
-Foo(1, 5, 10) == Foo(1, 10, 5) // true
-Foo(1, 5, 10) == Foo(1, 5, 5) // false

--- a/rhombus/tests/equatable.rhm
+++ b/rhombus/tests/equatable.rhm
@@ -1,5 +1,9 @@
 #lang rhombus
 
+import:
+  rhombus/data/equality.equality
+  lib("racket/base.rkt").#{equal-always-hash-code} as hc
+
 use_static
 
 class AnythingGoes():
@@ -16,6 +20,9 @@ class Fail():
   private implements Equatable
   private override equals(other, recur): error("failure")
   private override hash_code(recur): error("failure")
+
+class OrderedTriple(fst, snd, thd):
+  equality: fst; snd; thd
 
 check AnythingGoes() == AnythingGoes() ~is #true
 check:
@@ -43,4 +50,44 @@ check Fail() == Fail() ~raises "failure"
 begin:
   let f: Fail()
   check f == f ~is #true
+
+check: OrderedTriple("A", "B", "C") == OrderedTriple("A", "B", "C") ~is #true
+check: hc(OrderedTriple("A", "B", "C")) == hc(OrderedTriple("A", "B", "C")) ~is #true
+check: {OrderedTriple("A", "B", "C"), OrderedTriple("A", "B", "C")}.length() ~is 1
+
+check: OrderedTriple("A", "B", "C") == OrderedTriple("C", "A", "B") ~is #false
+check: hc(OrderedTriple("A", "B", "C")) == hc(OrderedTriple("C", "A", "B"))
+       ~is #false
+check: {OrderedTriple("A", "B", "C"), OrderedTriple("C", "A", "B")}.length() ~is 2
+
+begin:
+  class MB(mutable value)
+  let a: MB(1)
+  let b: MB(1)
+  let c: MB(1)
+  check: a == b ~is #false
+  check: OrderedTriple(a, b, c) == OrderedTriple(a, b, c) ~is #true
+  check: hc(OrderedTriple(a, b, c)) == hc(OrderedTriple(a, b, c)) ~is #true
+  check: {OrderedTriple(a, b, c), OrderedTriple(a, b, c)}.length() ~is 1
+
+  check: OrderedTriple(a, b, c) == OrderedTriple(c, a, b) ~is #false
+  check: hc(OrderedTriple(a, b, c)) == hc(OrderedTriple(c, a, b)) ~is #false
+  check: {OrderedTriple(a, b, c), OrderedTriple(c, a, b)}.length() ~is 2
+
+check:
+  use_dynamic
+  OrderedTriple("A", "B", "C").equals(OrderedTriple("A", "B", "C"), fun (& _): #true)
+  ~raises "equals: no such field or method"
+check:
+  use_dynamic
+  OrderedTriple("A", "B", "C").hash_code(fun (_): 0)
+  ~raises "hash_code: no such field or method"
+
+class Foo(a, b, c):
+  equality:
+    a
+    b + c
+
+check: Foo(1, 5, 10) == Foo(1, 10, 5) ~is #true
+check: Foo(1, 5, 10) == Foo(1, 5, 5) ~is #false
 

--- a/rhombus/tests/equatable.rhm
+++ b/rhombus/tests/equatable.rhm
@@ -24,6 +24,9 @@ class Fail():
 class OrderedTriple(fst, snd, thd):
   equality: fst; snd; thd
 
+class OrderedTriple2(fst, snd, thd):
+  equality: fst; snd; thd
+
 check AnythingGoes() == AnythingGoes() ~is #true
 check:
   use_dynamic
@@ -82,6 +85,11 @@ check:
   use_dynamic
   OrderedTriple("A", "B", "C").hash_code(fun (_): 0)
   ~raises "hash_code: no such field or method"
+
+check: OrderedTriple("A", "B", "C") == OrderedTriple2("A", "B", "C") ~is #false
+check: hc(OrderedTriple("A", "B", "C")) == hc(OrderedTriple2("A", "B", "C"))
+       ~is #false
+check: {OrderedTriple("A", "B", "C"), OrderedTriple2("A", "B", "C")}.length() ~is 2
 
 class Foo(a, b, c):
   equality:


### PR DESCRIPTION
Changes from @jackfirth's original #270:
 - [x] Rhombus unsyntax-splicing `$$` is now just `$`
 - [x] Rhombus assume-annotation `-:` is now `:~`
 - [x] Equatable uses recur now
 - [x] `private implements Equatable` is encouraged
 - [x] Uses Rhombus's new `hash_code_combine`
 - [x] Uses type tags in hash codes to distinguish different but similarly-shaped types
 - [x] Adds tests