### PR TITLE
Add Partial Order design proposal

### DIFF
--- a/design/partial-order/A/Lexicographic.rhm
+++ b/design/partial-order/A/Lexicographic.rhm
@@ -1,0 +1,22 @@
+#lang rhombus
+
+export Lexicographic
+
+import "partial-order.rkt" open
+
+class Lexicographic(elements):
+  constructor(& elements): super(elements)
+  private implements PartialOrder
+  private override partial_compare(other :: Lexicographic, recur):
+    lexicographic_compare_list(elements, other.elements, recur)
+
+fun
+| lexicographic_compare_list([], [], _): 0
+| lexicographic_compare_list([], [_, & _], _): -1
+| lexicographic_compare_list([_, & _], [], _): 1
+| lexicographic_compare_list([f1, & r1], [f2, & r2], recur):
+    let cf: recur(f1, f2)
+    if cf .= 0
+    | lexicographic_compare_list(r1, r2, recur)
+    | cf
+

--- a/design/partial-order/A/Lexicographic.rhm
+++ b/design/partial-order/A/Lexicographic.rhm
@@ -5,18 +5,26 @@ export Lexicographic
 import "partial-order.rkt" open
 
 class Lexicographic(elements):
+  export and
   constructor(& elements): super(elements)
   private implements PartialOrder
   private override partial_compare(other :: Lexicographic, recur):
     lexicographic_compare_list(elements, other.elements, recur)
+
+  macro
+  | 'and: $(c :: Group)': '$c'
+  | 'and: $c; $r; ...':
+      'begin:
+         let cv: $c
+         if cv .= 0
+         | and: $r; ...
+         | cv'
 
 fun
 | lexicographic_compare_list([], [], _): 0
 | lexicographic_compare_list([], [_, & _], _): -1
 | lexicographic_compare_list([_, & _], [], _): 1
 | lexicographic_compare_list([f1, & r1], [f2, & r2], recur):
-    let cf: recur(f1, f2)
-    if cf .= 0
-    | lexicographic_compare_list(r1, r2, recur)
-    | cf
-
+    Lexicographic.and:
+      recur(f1, f2)
+      lexicographic_compare_list(r1, r2, recur)

--- a/design/partial-order/A/partial-order.rkt
+++ b/design/partial-order/A/partial-order.rkt
@@ -1,0 +1,248 @@
+#lang racket/base
+
+(require rhombus/private/provide)
+(provide (for-spaces (rhombus/class
+                      rhombus/namespace)
+                     PartialOrder)
+         (for-spaces (#f
+                      rhombus/repet)
+                     =~
+                     !=~
+                     <~
+                     >~
+                     <=~
+                     >=~))
+
+(require (for-syntax racket/base
+                     "../../../rhombus/private/interface-parse.rkt")
+         racket/fixnum
+         racket/flonum
+         racket/extflonum
+         racket/list
+         racket/math
+         syntax/parse/define
+         rhombus/private/define-operator
+         (only-in rhombus/private/arithmetic
+                  \|\| &&
+                  [+ rhombus+]
+                  [- rhombus-]
+                  [* rhombus*]
+                  [/ rhombus/])
+         "../../../rhombus/private/name-root.rkt"
+         (submod "../../../rhombus/private/annotation.rkt" for-class)
+         (submod "../../../rhombus/private/dot.rkt" for-dot-provider)
+         "../../../rhombus/private/realm.rkt"
+         "../../../rhombus/private/class-dot.rkt"
+         (only-in "../../../rhombus/private/class-desc.rkt" define-class-desc-syntax)
+         "../../../rhombus/private/static-info.rkt")
+
+;; ---------------------------------------------------------
+
+;; Core ordering datatypes and operations
+
+;; A Ordering is a ComparableReal where:
+;;  - zero?     represents =~
+;;  - negative? represents <~
+;;  - positive? represents >~
+;; this excludes NaN
+
+;; ordering-normalize : Ordering -> Ordering
+(define (ordering-normalize c)
+  (cond
+    [(zero? c) 0]
+    [(negative? c) -1]
+    [(positive? c) 1]
+    [else (error 'compare "bad ~v" c)]))
+
+;; A PartialOrdering is a Real where:
+;;  - zero?     represents =~
+;;  - negative? represents <~
+;;  - positive? represents >~
+;;  - nan?      represents incomparable
+
+;; partial-ordering-normalize : PartialOrdering -> PartialOrdering
+(define (partial-ordering-normalize c)
+  (cond
+    [(zero? c) 0]
+    [(negative? c) -1]
+    [(positive? c) 1]
+    [(nan? c) +nan.0]
+    [else (error 'partial_compare "bad ~v" c)]))
+
+;; ord-and/bool : Boolean ... PartialOrdering -> PartialOrdering
+(define-syntax-parser ord-and/bool
+  [(_) #'0]
+  [(_ c) #'c]
+  [(_ b . rst)
+   #'(if b (ord-and/bool . rst) +nan.0)])
+
+;; ord-and/prod2 : PartialOrdering PartialOrdering -> PartialOrdering
+(define (ord-and/prod2 c0 c1)
+  (cond
+    [(zero? c0) c1]
+    [(zero? c1) c0]
+    [(and (negative? c0) (negative? c1)) -1]
+    [(and (positive? c0) (positive? c1)) 1]
+    [else +nan.0]))
+
+;; ord-and/prod : PartialOrdering ... PartialOrdering
+(define-syntax-parser ord-and/prod
+  [(_) #'0]
+  [(_ c) #'c]
+  [(_ c0 c1 . rst)
+   #'(let ([c0v c0])
+       (if (nan? c0v)
+           +nan.0
+           (ord-and/prod (ord-and/prod2 c0v c1) . rst)))])
+
+(define (numeric? v)
+  (or (real? v) (extflonum? v)))
+
+(define (numeric-key x)
+  (cond
+    [(or (eq? x +inf.0) (eq? x +inf.f) (eq? x +inf.t)) +inf.0]
+    [(or (eq? x -inf.0) (eq? x -inf.f) (eq? x -inf.t)) -inf.0]
+    [(or (eq? x +nan.0) (eq? x +nan.f) (eq? x +nan.t)) +nan.0]
+    [(extflonum? x) (extfl->exact x)]
+    [else (inexact->exact x)]))
+
+(define (partial-compare-numeric a b)
+  (cond
+    [(and (real? a) (real? b)) (partial-compare-real a b)]
+    [(and (extflonum? a) (extflonum? b)) (partial-compare-extflonum a b)]
+    [else (partial-compare-real (numeric-key a) (numeric-key b))]))
+
+(define (partial-compare-real a b)
+  (cond
+    [(= a b) 0]
+    [(< a b) -1]
+    [(> a b) 1]
+    [else +nan.0]))
+
+(define (partial-compare-extflonum a b)
+  (cond
+    [(extfl= a b) 0]
+    [(extfl< a b) -1]
+    [(extfl> a b) 1]
+    [else +nan.0]))
+
+;; ---------------------------------------------------------
+
+;; PartialOrder struct type property and interface
+
+(define-values (prop:partial-order partial-order? partial-order-ref)
+  (make-struct-type-property
+   'partial-order
+   (λ (value _type-info)
+     (unless (and (procedure? value)
+                  (procedure-arity-includes? value 3))
+       (raise-argument-error* 'partial_compare
+                              rhombus-realm
+                              "a method of 2 arguments (after this)"
+                              value))
+     (list (gensym) value))))
+
+(define-values (prop:PartialOrder _PartialOrder? PartialOrder-ref)
+  (make-struct-type-property
+   'PartialOrder
+   #false
+   (list (cons prop:partial-order (lambda (v) (vector-ref v 0))))))
+
+(define-class-desc-syntax PartialOrder
+  (interface-desc #'PartialOrder
+                  #'PartialOrder
+                  #'()
+                  #'prop:PartialOrder
+                  #'PartialOrder-ref
+                  (vector-immutable (box-immutable 'partial_compare))
+                  #'#(#:abstract)
+                  (hasheq 'partial_compare 0)
+                  #hasheq()
+                  #t))
+
+;; ---------------------------------------------------------
+
+;; Public operations
+
+(define-name-root PartialOrder
+  #:fields
+  (partial_compare
+   compare))
+
+(define (partial-compare/recur a b recur)
+  (define (cmp ai bi)
+    (partial-ordering-normalize (recur ai bi)))
+  (cond
+    [(partial-order? a)
+     (ord-and/bool
+      (partial-order? b)
+      (let ([av (partial-order-ref a)])
+        (ord-and/bool
+         (eq? av (partial-order-ref b))
+         (partial-ordering-normalize ((cadr av) a b cmp)))))]
+    [(numeric? a)
+     (ord-and/bool (numeric? b) (partial-compare-numeric a b))]
+    [else
+     (product-compare/recur a b cmp)]))
+
+(define (product-compare/recur a b cmp)
+  (cond
+    [(flvector? a)
+     (ord-and/bool
+      (flvector? b)
+      (= (flvector-length a) (flvector-length b))
+      (for/fold ([acc 0])
+                ([ai (in-flvector a)]
+                 [bi (in-flvector b)])
+        #:break (nan? acc)
+        (ord-and/prod acc (cmp ai bi))))]
+    [(extflvector? a)
+     (ord-and/bool
+      (extflvector? b)
+      (= (extflvector-length a) (extflvector-length b))
+      (for/fold ([acc 0])
+                ([ai (in-extflvector a)]
+                 [bi (in-extflvector b)])
+        #:break (nan? acc)
+        (ord-and/prod acc (cmp ai bi))))]
+    [else
+     (define (<=? ai bi) (<= (cmp ai bi) 0))
+     (define le (equal?/recur a b <=?))
+     (define ge (equal?/recur b a <=?))
+     (cond
+       [(and le ge) 0]
+       [le -1]
+       [ge 1]
+       [else +nan.0])]))
+
+(define (partial_compare a b)
+  (partial-compare/recur a b partial_compare))
+
+(define (compare/recur a b recur)
+  (define (cmp ai bi) (ordering-normalize (recur ai bi)))
+  (ordering-normalize (partial-compare/recur a b cmp)))
+
+(define (compare a b)
+  (compare/recur a b compare))
+
+(define (=~? a b) (zero? (partial_compare a b)))
+(define (!=~? a b) (not (zero? (partial_compare a b))))
+
+(define (<~? a b) (negative? (compare a b)))
+(define (>~? a b) (positive? (compare a b)))
+(define (<=~? a b) (<= (compare a b) 0))
+(define (>=~? a b) (>= (compare a b) 0))
+
+(define-syntax-rule (define-comp~-infix name racket-name)
+  (define-infix name racket-name
+    #:weaker-than (rhombus+ rhombus- rhombus* rhombus/)
+    #:same-as (<~ <=~ =~ !=~ >=~ >~)
+    #:stronger-than (\|\| &&)
+    #:associate 'none))
+
+(define-comp~-infix <~ <~?)
+(define-comp~-infix <=~ <=~?)
+(define-comp~-infix =~ =~?)
+(define-comp~-infix !=~ !=~?)
+(define-comp~-infix >=~ >=~?)
+(define-comp~-infix >~ >~?)

--- a/design/partial-order/A/partial-order.rkt
+++ b/design/partial-order/A/partial-order.rkt
@@ -223,8 +223,9 @@
         (ord-and/prod acc (cmp ai bi))))]
     [else
      (define (<=? ai bi) (<= (cmp ai bi) 0))
+     (define (>=? ai bi) (>= (cmp ai bi) 0))
      (define le (equal?/recur a b <=?))
-     (define ge (equal?/recur b a <=?))
+     (define ge (equal?/recur a b >=?))
      (cond
        [(and le ge) 0]
        [le -1]

--- a/design/partial-order/A/partial-order.rkt
+++ b/design/partial-order/A/partial-order.rkt
@@ -85,7 +85,7 @@
     [(realish? a)
      (ord-and/bool (realish? b) (partial-compare-realish a b))]
     [else
-     (product-compare/recur a b cmp)]))
+     (product-compare/recur a b cmp #true)]))
 
 (define (partial_compare a b)
   (partial-compare/recur a b partial_compare))

--- a/design/partial-order/A/partial-order.rkt
+++ b/design/partial-order/A/partial-order.rkt
@@ -15,9 +15,6 @@
 
 (require (for-syntax racket/base
                      rhombus/private/interface-parse)
-         racket/flonum
-         racket/extflonum
-         racket/math
          rhombus/private/define-operator
          (only-in rhombus/private/arithmetic
                   \|\| &&
@@ -89,37 +86,6 @@
      (ord-and/bool (realish? b) (partial-compare-realish a b))]
     [else
      (product-compare/recur a b cmp)]))
-
-(define (product-compare/recur a b cmp)
-  (cond
-    [(flvector? a)
-     (ord-and/bool
-      (flvector? b)
-      (= (flvector-length a) (flvector-length b))
-      (for/fold ([acc 0])
-                ([ai (in-flvector a)]
-                 [bi (in-flvector b)])
-        #:break (nan? acc)
-        (ord-and/prod acc (cmp ai bi))))]
-    [(extflvector? a)
-     (ord-and/bool
-      (extflvector? b)
-      (= (extflvector-length a) (extflvector-length b))
-      (for/fold ([acc 0])
-                ([ai (in-extflvector a)]
-                 [bi (in-extflvector b)])
-        #:break (nan? acc)
-        (ord-and/prod acc (cmp ai bi))))]
-    [else
-     (define (<=? ai bi) (<= (cmp ai bi) 0))
-     (define (>=? ai bi) (>= (cmp ai bi) 0))
-     (define le (equal?/recur a b <=?))
-     (define ge (equal?/recur a b >=?))
-     (cond
-       [(and le ge) 0]
-       [le -1]
-       [ge 1]
-       [else +nan.0])]))
 
 (define (partial_compare a b)
   (partial-compare/recur a b partial_compare))

--- a/design/partial-order/A/test-partial-order.rhm
+++ b/design/partial-order/A/test-partial-order.rhm
@@ -1,6 +1,8 @@
 #lang rhombus
 
-import "partial-order.rkt" open
+import:
+  "partial-order.rkt" open
+  "Lexicographic.rhm".Lexicographic
 
 class UnredRatio(n :: Integer, d :: PositiveInteger):
   private implements PartialOrder
@@ -18,6 +20,28 @@ check:
 check:
   [UnredRatio(1, 2), UnredRatio(-1, 2)] >~ [UnredRatio(1, 4), UnredRatio(-3, 4)]
   ~is #true
+
+check:
+  Lexicographic(UnredRatio(1, 2), UnredRatio(-1, 2)) <~ Lexicographic(UnredRatio(3, 4), UnredRatio(-1, 4))
+  ~is #true
+check:
+  Lexicographic(UnredRatio(1, 2), UnredRatio(-1, 2)) >~ Lexicographic(UnredRatio(1, 4), UnredRatio(-3, 4))
+  ~is #true
+
+check: Lexicographic(5, 8, 3, 13, 2) =~ Lexicographic(5, 8, 3, 13, 2) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) =~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) !=~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(6, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(6, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <~ Lexicographic(6, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(4, 18) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(4, 18) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >~ Lexicographic(4, 18) ~is #true
 
 check: PartialOrder.within([6, 10], [6.02, 9.99], 0.05) ~is #true
 check: PartialOrder.within({#'C: 20, #'F: 68}, {#'C: 25, #'F: 77}, 10) ~is #true

--- a/design/partial-order/A/test-partial-order.rhm
+++ b/design/partial-order/A/test-partial-order.rhm
@@ -1,6 +1,7 @@
 #lang rhombus
 
 import:
+  lib("racket/flonum.rkt").flvector
   "partial-order.rkt" open
   "Lexicographic.rhm".Lexicographic
 
@@ -48,4 +49,14 @@ check: PartialOrder.within({#'C: 20, #'F: 68}, {#'C: 25, #'F: 77}, 10) ~is #true
 
 check: PartialOrder.within([6e+23, 10.0], [6.02e+23, 9.8], 0.05) ~is #false
 check: PartialOrder.within({#'C: 18, #'F: 64}, {#'C: 25, #'F: 77}, 10) ~is #false
+
+check: flvector(0.0) =~ flvector(-0.0) ~is #true
+check: flvector(0.0, -0.0) =~ flvector(-0.0, 0.0) ~is #true
+check: flvector(0.0, 1.0) =~ flvector(-0.0, 2.0) ~is #false
+check: flvector(0.0, 1.0) !=~ flvector(-0.0, 2.0) ~is #true
+check: flvector(0.0, 1.0) <=~ flvector(-0.0, 2.0) ~is #true
+check: flvector(0.0, 1.0) <~ flvector(-0.0, 2.0) ~is #true
+check: flvector(2.0, -0.0) <=~ flvector(1.0, 0.0) ~is #false
+check: flvector(2.0, -0.0) >=~ flvector(1.0, 0.0) ~is #true
+check: flvector(2.0, -0.0) >~ flvector(1.0, 0.0) ~is #true
 

--- a/design/partial-order/A/test-partial-order.rhm
+++ b/design/partial-order/A/test-partial-order.rhm
@@ -1,0 +1,21 @@
+#lang rhombus
+
+import "partial-order.rkt" open
+
+class UnredRatio(n :: Integer, d :: PositiveInteger):
+  private implements PartialOrder
+  private override partial_compare(other :: UnredRatio, recur):
+    recur(n * other.d, other.n * d)
+
+check UnredRatio(1, 2) =~ UnredRatio(2, 4) ~is #true
+check UnredRatio(1, 2) =~ UnredRatio(3, 4) ~is #false
+check UnredRatio(1, 2) <~ UnredRatio(3, 4) ~is #true
+check UnredRatio(1, 2) <~ UnredRatio(1, 4) ~is #false
+check UnredRatio(1, 2) >~ UnredRatio(1, 4) ~is #true
+check:
+  [UnredRatio(1, 2), UnredRatio(-1, 2)] <~ [UnredRatio(3, 4), UnredRatio(-1, 4)]
+  ~is #true
+check:
+  [UnredRatio(1, 2), UnredRatio(-1, 2)] >~ [UnredRatio(1, 4), UnredRatio(-3, 4)]
+  ~is #true
+

--- a/design/partial-order/A/test-partial-order.rhm
+++ b/design/partial-order/A/test-partial-order.rhm
@@ -19,3 +19,9 @@ check:
   [UnredRatio(1, 2), UnredRatio(-1, 2)] >~ [UnredRatio(1, 4), UnredRatio(-3, 4)]
   ~is #true
 
+check: PartialOrder.within([6, 10], [6.02, 9.99], 0.05) ~is #true
+check: PartialOrder.within({#'C: 20, #'F: 68}, {#'C: 25, #'F: 77}, 10) ~is #true
+
+check: PartialOrder.within([6e+23, 10.0], [6.02e+23, 9.8], 0.05) ~is #false
+check: PartialOrder.within({#'C: 18, #'F: 64}, {#'C: 25, #'F: 77}, 10) ~is #false
+

--- a/design/partial-order/D-A/Lexicographic.rhm
+++ b/design/partial-order/D-A/Lexicographic.rhm
@@ -1,0 +1,30 @@
+#lang rhombus
+
+export Lexicographic
+
+import "partial-order.rkt" open
+
+class Lexicographic(elements):
+  export and
+  constructor(& elements): super(elements)
+  private implements PartialOrder
+  private override partial_compare(other :: Lexicographic, recur):
+    lexicographic_compare_list(elements, other.elements, recur)
+
+  macro
+  | 'and: $(c :: Group)': '$c'
+  | 'and: $c; $r; ...':
+      'begin:
+         let cv: $c
+         if cv .= 0
+         | and: $r; ...
+         | cv'
+
+fun
+| lexicographic_compare_list([], [], _): 0
+| lexicographic_compare_list([], [_, & _], _): -1
+| lexicographic_compare_list([_, & _], [], _): 1
+| lexicographic_compare_list([f1, & r1], [f2, & r2], recur):
+    Lexicographic.and:
+      recur(f1, f2)
+      lexicographic_compare_list(r1, r2, recur)

--- a/design/partial-order/D-A/partial-order.rkt
+++ b/design/partial-order/D-A/partial-order.rkt
@@ -1,0 +1,149 @@
+#lang racket/base
+
+(require rhombus/private/provide)
+(provide (for-spaces (rhombus/class
+                      rhombus/namespace)
+                     PartialOrder)
+         (for-spaces (#f
+                      rhombus/repet)
+                     =~
+                     !=~
+                     <~
+                     >~
+                     <=~
+                     >=~))
+
+(require (for-syntax racket/base
+                     rhombus/private/interface-parse)
+         rhombus/private/define-operator
+         (only-in rhombus/private/arithmetic
+                  \|\| &&
+                  [+ rhombus+]
+                  [- rhombus-]
+                  [* rhombus*]
+                  [/ rhombus/])
+         rhombus/private/name-root
+         rhombus/private/realm
+         (only-in rhombus/private/class-desc define-class-desc-syntax)
+         "../common/partial-order-util.rkt")
+
+;; ---------------------------------------------------------
+
+;; PartialOrder struct type property and interface
+
+(define-values (prop:partial-order partial-order? partial-order-ref)
+  (make-struct-type-property
+   'partial-order
+   (λ (value _type-info)
+     (unless (and (procedure? value)
+                  (procedure-arity-includes? value 3))
+       (raise-argument-error* 'partial_compare
+                              rhombus-realm
+                              "a method of 2 arguments (after this)"
+                              value))
+     (list (gensym) value))))
+
+(define-values (prop:PartialOrder _PartialOrder? PartialOrder-ref)
+  (make-struct-type-property
+   'PartialOrder
+   #false
+   (list (cons prop:partial-order (lambda (v) (vector-ref v 0))))))
+
+(define-class-desc-syntax PartialOrder
+  (interface-desc #'PartialOrder
+                  #'PartialOrder
+                  #'()
+                  #'prop:PartialOrder
+                  #'PartialOrder-ref
+                  (vector-immutable (box-immutable 'partial_compare))
+                  #'#(#:abstract)
+                  (hasheq 'partial_compare 0)
+                  #hasheq()
+                  #t))
+
+;; ---------------------------------------------------------
+
+;; Public operations
+
+(define-name-root PartialOrder
+  #:fields
+  (partial_compare
+   compare
+   within))
+
+(define (partial-compare/recur a b recur)
+  (define (cmp ai bi)
+    (partial-ordering-normalize (recur ai bi)))
+  (cond
+    [(partial-order? a)
+     (ord-and/bool
+      (partial-order? b)
+      (let ([av (partial-order-ref a)])
+        (ord-and/bool
+         (eq? av (partial-order-ref b))
+         (partial-ordering-normalize ((cadr av) a b cmp)))))]
+    [(realish? a)
+     (ord-and/bool (realish? b) (partial-compare-realish a b))]
+    [else
+     (product-compare/recur a b cmp)]))
+
+(define (partial_compare a b)
+  (partial-compare/recur a b partial_compare))
+
+(define (compare/recur a b recur)
+  (define (cmp ai bi) (ordering-normalize (recur ai bi)))
+  (ordering-normalize (partial-compare/recur a b cmp)))
+
+(define (compare a b)
+  (compare/recur a b compare))
+
+;; ---------------------------------------------------------
+
+;; Short-circuiting via early-NaN
+
+(define (early-nan/= c) (if (zero? c) 0 +nan.0))
+(define (early-nan/<= c) (if (<= c 0) c +nan.0))
+(define (early-nan/>= c) (if (>= c 0) c +nan.0))
+
+(define (partial-compare/= a b)
+  (early-nan/= (partial-compare/recur a b partial-compare/=)))
+
+(define (partial-compare/<= a b)
+  (early-nan/<= (partial-compare/recur a b partial-compare/<=)))
+
+(define (partial-compare/>= a b)
+  (early-nan/>= (partial-compare/recur a b partial-compare/>=)))
+
+(define (partial-compare/within a b epsilon)
+  (early-nan/=
+   (cond
+     [(realish? a)
+      (ord-and/bool (realish? b) (partial-compare-realish/within a b epsilon))]
+     [else
+      (define (cmp ai bi) (partial-compare/within ai bi epsilon))
+      (partial-compare/recur a b cmp)])))
+
+(define (within a b epsilon)
+  (zero? (partial-compare/within a b epsilon)))
+
+(define (=~? a b) (zero? (partial-compare/= a b)))
+(define (!=~? a b) (not (zero? (partial-compare/= a b))))
+
+(define (<~? a b) (negative? (partial-compare/<= a b)))
+(define (>~? a b) (positive? (partial-compare/>= a b)))
+(define (<=~? a b) (<= (partial-compare/<= a b) 0))
+(define (>=~? a b) (>= (partial-compare/>= a b) 0))
+
+(define-syntax-rule (define-comp~-infix name racket-name)
+  (define-infix name racket-name
+    #:weaker-than (rhombus+ rhombus- rhombus* rhombus/)
+    #:same-as (<~ <=~ =~ !=~ >=~ >~)
+    #:stronger-than (\|\| &&)
+    #:associate 'none))
+
+(define-comp~-infix <~ <~?)
+(define-comp~-infix <=~ <=~?)
+(define-comp~-infix =~ =~?)
+(define-comp~-infix !=~ !=~?)
+(define-comp~-infix >=~ >=~?)
+(define-comp~-infix >~ >~?)

--- a/design/partial-order/D-A/partial-order.rkt
+++ b/design/partial-order/D-A/partial-order.rkt
@@ -101,10 +101,6 @@
 
 ;; Short-circuiting via early-NaN
 
-(define (early-nan/= c) (if (zero? c) 0 +nan.0))
-(define (early-nan/<= c) (if (<= c 0) c +nan.0))
-(define (early-nan/>= c) (if (>= c 0) c +nan.0))
-
 (define (partial-compare/= a b)
   (early-nan/= (partial-compare/recur a b partial-compare/=)))
 

--- a/design/partial-order/D-A/partial-order.rkt
+++ b/design/partial-order/D-A/partial-order.rkt
@@ -85,7 +85,7 @@
     [(realish? a)
      (ord-and/bool (realish? b) (partial-compare-realish a b))]
     [else
-     (product-compare/recur a b cmp)]))
+     (product-compare/recur a b cmp #true)]))
 
 (define (partial_compare a b)
   (partial-compare/recur a b partial_compare))

--- a/design/partial-order/D-A/test-partial-order.rhm
+++ b/design/partial-order/D-A/test-partial-order.rhm
@@ -49,15 +49,14 @@ check: PartialOrder.within({#'C: 20, #'F: 68}, {#'C: 25, #'F: 77}, 10) ~is #true
 check: PartialOrder.within([6e+23, 10.0], [6.02e+23, 9.8], 0.05) ~is #false
 check: PartialOrder.within({#'C: 18, #'F: 64}, {#'C: 25, #'F: 77}, 10) ~is #false
 
-let NaN: 0.0 / 0.0
-check: NaN =~ NaN ~is #false
-check: NaN !=~ NaN ~is #true
-check: NaN <~ NaN ~is #false
-check: NaN <=~ NaN ~is #false
+check: #nan =~ #nan ~is #false
+check: #nan !=~ #nan ~is #true
+check: #nan <~ #nan ~is #false
+check: #nan <=~ #nan ~is #false
 
 class AlwaysNaN():
   private implements PartialOrder
-  private override partial_compare(_, _): NaN
+  private override partial_compare(_, _): #nan
 
 let NaNish: AlwaysNaN()
 check: NaNish =~ NaNish ~is #false

--- a/design/partial-order/D-A/test-partial-order.rhm
+++ b/design/partial-order/D-A/test-partial-order.rhm
@@ -49,6 +49,22 @@ check: PartialOrder.within({#'C: 20, #'F: 68}, {#'C: 25, #'F: 77}, 10) ~is #true
 check: PartialOrder.within([6e+23, 10.0], [6.02e+23, 9.8], 0.05) ~is #false
 check: PartialOrder.within({#'C: 18, #'F: 64}, {#'C: 25, #'F: 77}, 10) ~is #false
 
+let NaN: 0.0 / 0.0
+check: NaN =~ NaN ~is #false
+check: NaN !=~ NaN ~is #true
+check: NaN <~ NaN ~is #false
+check: NaN <=~ NaN ~is #false
+
+class AlwaysNaN():
+  private implements PartialOrder
+  private override partial_compare(_, _): NaN
+
+let NaNish: AlwaysNaN()
+check: NaNish =~ NaNish ~is #false
+check: NaNish !=~ NaNish ~is #true
+check: NaNish <~ NaNish ~is #false
+check: NaNish <=~ NaNish ~is #false
+
 class Baddie(value):
   private implements PartialOrder
   private override partial_compare(_, _):

--- a/design/partial-order/D-A/test-partial-order.rhm
+++ b/design/partial-order/D-A/test-partial-order.rhm
@@ -1,0 +1,63 @@
+#lang rhombus
+
+import:
+  "partial-order.rkt" open
+  "Lexicographic.rhm".Lexicographic
+
+class UnredRatio(n :: Integer, d :: PositiveInteger):
+  private implements PartialOrder
+  private override partial_compare(other :: UnredRatio, recur):
+    recur(n * other.d, other.n * d)
+
+check UnredRatio(1, 2) =~ UnredRatio(2, 4) ~is #true
+check UnredRatio(1, 2) =~ UnredRatio(3, 4) ~is #false
+check UnredRatio(1, 2) <~ UnredRatio(3, 4) ~is #true
+check UnredRatio(1, 2) <~ UnredRatio(1, 4) ~is #false
+check UnredRatio(1, 2) >~ UnredRatio(1, 4) ~is #true
+check:
+  [UnredRatio(1, 2), UnredRatio(-1, 2)] <~ [UnredRatio(3, 4), UnredRatio(-1, 4)]
+  ~is #true
+check:
+  [UnredRatio(1, 2), UnredRatio(-1, 2)] >~ [UnredRatio(1, 4), UnredRatio(-3, 4)]
+  ~is #true
+
+check:
+  Lexicographic(UnredRatio(1, 2), UnredRatio(-1, 2)) <~ Lexicographic(UnredRatio(3, 4), UnredRatio(-1, 4))
+  ~is #true
+check:
+  Lexicographic(UnredRatio(1, 2), UnredRatio(-1, 2)) >~ Lexicographic(UnredRatio(1, 4), UnredRatio(-3, 4))
+  ~is #true
+
+check: Lexicographic(5, 8, 3, 13, 2) =~ Lexicographic(5, 8, 3, 13, 2) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) =~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) !=~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(6, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(6, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <~ Lexicographic(6, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(4, 18) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(4, 18) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >~ Lexicographic(4, 18) ~is #true
+
+check: PartialOrder.within([6, 10], [6.02, 9.99], 0.05) ~is #true
+check: PartialOrder.within({#'C: 20, #'F: 68}, {#'C: 25, #'F: 77}, 10) ~is #true
+
+check: PartialOrder.within([6e+23, 10.0], [6.02e+23, 9.8], 0.05) ~is #false
+check: PartialOrder.within({#'C: 18, #'F: 64}, {#'C: 25, #'F: 77}, 10) ~is #false
+
+class Baddie(value):
+  private implements PartialOrder
+  private override partial_compare(_, _):
+    error(#'Baddie, "never compare me to anything!")
+
+check: [1, Baddie(1)] =~ [2, Baddie(2)] ~is #false
+check: [1, Baddie(1)] !=~ [2, Baddie(2)] ~is #true
+check: [1, Baddie(1)] >=~ [2, Baddie(2)] ~is #false
+check: [1, Baddie(1)] >~ [2, Baddie(2)] ~is #false
+check: [2, Baddie(1)] <=~ [1, Baddie(2)] ~is #false
+check: [2, Baddie(1)] <~ [1, Baddie(2)] ~is #false
+

--- a/design/partial-order/D-A/test-partial-order.rhm
+++ b/design/partial-order/D-A/test-partial-order.rhm
@@ -1,6 +1,7 @@
 #lang rhombus
 
 import:
+  lib("racket/flonum.rkt").flvector
   "partial-order.rkt" open
   "Lexicographic.rhm".Lexicographic
 
@@ -75,4 +76,24 @@ check: [1, Baddie(1)] >=~ [2, Baddie(2)] ~is #false
 check: [1, Baddie(1)] >~ [2, Baddie(2)] ~is #false
 check: [2, Baddie(1)] <=~ [1, Baddie(2)] ~is #false
 check: [2, Baddie(1)] <~ [1, Baddie(2)] ~is #false
+
+check: flvector(0.0) =~ flvector(-0.0) ~is #true
+check: flvector(0.0, -0.0) =~ flvector(-0.0, 0.0) ~is #true
+check: flvector(0.0, 1.0) =~ flvector(-0.0, 2.0) ~is #false
+check: flvector(0.0, 1.0) !=~ flvector(-0.0, 2.0) ~is #true
+check: flvector(0.0, 1.0) <=~ flvector(-0.0, 2.0) ~is #true
+check: flvector(0.0, 1.0) <~ flvector(-0.0, 2.0) ~is #true
+check: flvector(2.0, -0.0) <=~ flvector(1.0, 0.0) ~is #false
+check: flvector(2.0, -0.0) >=~ flvector(1.0, 0.0) ~is #true
+check: flvector(2.0, -0.0) >~ flvector(1.0, 0.0) ~is #true
+
+check: flvector(1.0, 20.0) <~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) <=~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) >~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) >=~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) =~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) !=~ flvector(2.0, 10.0) ~is #true
+
+check: flvector() <=~ flvector(0.0) ~is #false
+check: flvector(1.0, 10.0) <=~ flvector(2.0, 20.0, 200.0) ~is #false
 

--- a/design/partial-order/D-C/Lexicographic.rhm
+++ b/design/partial-order/D-C/Lexicographic.rhm
@@ -1,0 +1,31 @@
+#lang rhombus
+
+export Lexicographic
+
+import "partial-order.rkt" open
+
+class Lexicographic(elements):
+  export and
+  constructor(& elements): super(elements)
+  private implements PartialOrder
+  private override compare_key(): elements
+  private override partial_compare(other :: Lexicographic, recur):
+    lexicographic_compare_list(elements, other.elements, recur)
+
+  macro
+  | 'and: $(c :: Group)': '$c'
+  | 'and: $c; $r; ...':
+      'begin:
+         let cv: $c
+         if cv .= 0
+         | and: $r; ...
+         | cv'
+
+fun
+| lexicographic_compare_list([], [], _): 0
+| lexicographic_compare_list([], [_, & _], _): -1
+| lexicographic_compare_list([_, & _], [], _): 1
+| lexicographic_compare_list([f1, & r1], [f2, & r2], recur):
+    Lexicographic.and:
+      recur(f1, f2)
+      lexicographic_compare_list(r1, r2, recur)

--- a/design/partial-order/D-C/equatable.rkt
+++ b/design/partial-order/D-C/equatable.rkt
@@ -1,0 +1,106 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     rhombus/private/interface-parse)
+         racket/hash-code
+         rhombus/private/provide
+         rhombus/private/name-root
+         (submod rhombus/private/annotation for-class)
+         (submod rhombus/private/dot for-dot-provider)
+         rhombus/private/realm
+         rhombus/private/class-dot
+         (only-in rhombus/private/class-desc define-class-desc-syntax)
+         rhombus/private/static-info
+         (submod "partial-order.rkt" private))
+
+(provide (for-spaces (rhombus/class
+                      rhombus/namespace)
+                     Equatable))
+
+(define-values (prop:Equatable Equatable? Equatable-ref)
+  (make-struct-type-property
+   'Equatable
+   #false
+   (list (cons prop:equal+hash (lambda (_) bounced-equal+hash-implementation)))))
+
+(define (bounce-to-equal-mode-proc this other recur mode)
+  (cond
+    [(and mode (PartialOrder? this))
+     (equal-proc/partial-compare this other recur)]
+    [else
+     (equal-recur-internal-method this other recur)]))
+
+(define (bounce-to-hash-mode-proc this recur mode)
+  (cond
+    [(and mode (PartialOrder? this))
+     (hash-proc/compare-key this recur)]
+    [else
+     (hash-recur-internal-method this recur)]))
+
+(define bounced-equal+hash-implementation
+  (list bounce-to-equal-mode-proc bounce-to-hash-mode-proc))
+
+(define-class-desc-syntax Equatable
+  (interface-desc #'Equatable
+                  #'Equatable
+                  #'()
+                  #'prop:Equatable
+                  #'Equatable-ref
+                  (vector-immutable (box-immutable 'equals)
+                                    (box-immutable 'hash_code))
+                  #'#(#:abstract #:abstract)
+                  (hasheq 'equals 0 'hash_code 1)
+                  #hasheq()
+                  #t))
+
+(define (equal-recur-internal-method this other recur)
+  ((vector-ref (Equatable-ref this) 0) this other recur))
+
+(define (hash-recur-internal-method this recur)
+  ((vector-ref (Equatable-ref this) 1) this recur))
+
+(define-name-root Equatable
+  #:fields
+  (hash_code_combine
+   hash_code_combine_unordered))
+
+(define hash_code_combine
+  (case-lambda
+    [() (hash-code-combine)]
+    [(a)
+     (unless (exact-integer? a)
+       (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" a))
+     (hash-code-combine a)]
+    [(a b)
+     (unless (exact-integer? a)
+       (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" a))
+     (unless (exact-integer? b)
+       (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" b))
+     (hash-code-combine a b)]
+    [lst
+     (for ([e (in-list lst)])
+       (unless (exact-integer? e)
+         (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" e)))
+     (hash-code-combine* lst)]))
+
+(define-static-info-syntax hash_code_combine (#%function-arity -1))
+                                                               
+(define hash_code_combine_unordered
+  (case-lambda
+    [() (hash-code-combine-unordered)]
+    [(a)
+     (unless (exact-integer? a)
+       (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" a))
+     (hash-code-combine-unordered a)]
+    [(a b)
+     (unless (exact-integer? a)
+       (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" a))
+     (unless (exact-integer? b)
+       (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" b))
+     (hash-code-combine-unordered a b)]
+    [lst
+     (for ([e (in-list lst)])
+       (unless (exact-integer? e)
+         (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" e)))
+     (hash-code-combine-unordered* lst)]))
+
+(define-static-info-syntax hash_code_combine_unoredered (#%function-arity -1))

--- a/design/partial-order/D-C/partial-order.rkt
+++ b/design/partial-order/D-C/partial-order.rkt
@@ -19,8 +19,6 @@
 
 (require (for-syntax racket/base
                      rhombus/private/interface-parse)
-         racket/flonum
-         racket/hash-code
          rhombus/private/define-operator
          (only-in rhombus/private/arithmetic
                   \|\| &&
@@ -87,14 +85,7 @@
     [(partial-order? x)
      (->fx ((cadr (partial-order-ref x)) x compare-hash-code) 'compare-hash-code)]
     [(realish? x) (equal-hash-code (realish-key x))]
-    [(flvector? x)
-     (let loop ([acc (equal-hash-code (make-flvector 0))] [i 0])
-       (cond
-         [(<= (flvector-length x) i) acc]
-         [else
-          (loop (hash-code-combine acc (compare-hash-code (flvector-ref x i)))
-                (add1 i))]))]
-    [else (equal-hash-code/recur x compare-hash-code)]))
+    [else (product-hash-code/recur x compare-hash-code)]))
 
 (define-values (prop:PartialOrder PartialOrder? PartialOrder-ref)
   (make-struct-type-property
@@ -155,10 +146,6 @@
   (ordering-normalize (partial-compare/recur a b compare)))
 
 (define (compare_hash_code a) (compare-hash-code a))
-
-(define (early-nan/= c) (if (zero? c) 0 +nan.0))
-(define (early-nan/<= c) (if (<= c 0) c +nan.0))
-(define (early-nan/>= c) (if (>= c 0) c +nan.0))
 
 (define (partial-compare/= a b)
   (early-nan/= (partial-compare/recur a b partial-compare/=)))

--- a/design/partial-order/D-C/partial-order.rkt
+++ b/design/partial-order/D-C/partial-order.rkt
@@ -12,6 +12,10 @@
                      >~
                      <=~
                      >=~))
+(module+ private
+  (provide PartialOrder?
+           equal-proc/partial-compare
+           hash-proc/compare-key))
 
 (require (for-syntax racket/base
                      rhombus/private/interface-parse)
@@ -32,7 +36,7 @@
 
 ;; PartialOrder struct type property and interface
 
-(define-values (prop:PartialOrder _PartialOrder? PartialOrder-ref)
+(define-values (prop:PartialOrder PartialOrder? PartialOrder-ref)
   (make-struct-type-property
    'PartialOrder
    #false
@@ -56,6 +60,18 @@
                   (hasheq 'compare_key 0 'partial_compare 1)
                   #hasheq()
                   #t))
+
+(module+ private
+  ;; equal-proc/partial-compare : Self Imp (Any Any -> Boolean) -> Boolean
+  (define (equal-proc/partial-compare a b recur-eql)
+    (define partial_compare (vector-ref (PartialOrder-ref a) 1))
+    (define (recur-cmp ai bi) (if (recur-eql ai bi) 0 +nan.0))
+    (partial_compare a b recur-cmp))
+
+  ;; hash-proc/compare-key : Self (Any -> Integer) -> Integer
+  (define (hash-proc/compare-key a recur-hsh)
+    (define compare_key (vector-ref (PartialOrder-ref a) 0))
+    (recur-hsh (compare_key a))))
 
 ;; ---------------------------------------------------------
 

--- a/design/partial-order/D-C/partial-order.rkt
+++ b/design/partial-order/D-C/partial-order.rkt
@@ -1,0 +1,104 @@
+#lang racket/base
+
+(require rhombus/private/provide)
+(provide (for-spaces (rhombus/class
+                      rhombus/namespace)
+                     PartialOrder)
+         (for-spaces (#f
+                      rhombus/repet)
+                     =~
+                     !=~
+                     <~
+                     >~
+                     <=~
+                     >=~))
+
+(require (for-syntax racket/base
+                     rhombus/private/interface-parse)
+         rhombus/private/define-operator
+         (only-in rhombus/private/arithmetic
+                  \|\| &&
+                  [+ rhombus+]
+                  [- rhombus-]
+                  [* rhombus*]
+                  [/ rhombus/])
+         (prefix-in rkt: (only-in racket/base =~ !=~ <~ >~ <=~ >=~))
+         rhombus/private/name-root
+         rhombus/private/realm
+         (only-in rhombus/private/class-desc define-class-desc-syntax)
+         "../common/partial-order-util.rkt")
+
+;; ---------------------------------------------------------
+
+;; PartialOrder struct type property and interface
+
+(define-values (prop:PartialOrder _PartialOrder? PartialOrder-ref)
+  (make-struct-type-property
+   'PartialOrder
+   #false
+   (list (cons prop:partial-order
+               (lambda (v)
+                 (define compare_key (vector-ref v 0))
+                 (define partial_compare (vector-ref v 1))
+                 (define (compare-hash-code-proc x rec)
+                   (rec (compare_key x)))
+                 (list partial_compare compare-hash-code-proc))))))
+
+(define-class-desc-syntax PartialOrder
+  (interface-desc #'PartialOrder
+                  #'PartialOrder
+                  #'()
+                  #'prop:PartialOrder
+                  #'PartialOrder-ref
+                  (vector-immutable (box-immutable 'compare_key)
+                                    (box-immutable 'partial_compare))
+                  #'#(#:abstract #:abstract)
+                  (hasheq 'compare_key 0 'partial_compare 1)
+                  #hasheq()
+                  #t))
+
+;; ---------------------------------------------------------
+
+;; Public operations
+
+(define-name-root PartialOrder
+  #:fields
+  (partial_compare
+   compare
+   compare_hash_code
+   within))
+
+(define (partial_compare a b) (partial-compare a b))
+
+(define (compare a b)
+  (ordering-normalize (partial-compare/recur a b compare)))
+
+(define (compare_hash_code a) (compare-hash-code a))
+
+(define (early-nan/= c) (if (zero? c) 0 +nan.0))
+
+(define (partial-compare/within a b epsilon)
+  (early-nan/=
+   (cond
+     [(realish? a)
+      (ord-and/bool (realish? b) (partial-compare-realish/within a b epsilon))]
+     [else
+      (define (cmp ai bi) (partial-compare/within ai bi epsilon))
+      (partial-compare/recur a b cmp)])))
+
+(define (within a b epsilon)
+  (zero? (partial-compare/within a b epsilon)))
+
+(define-syntax-rule (define-comp~-infix name racket-name)
+  (define-infix name racket-name
+    #:weaker-than (rhombus+ rhombus- rhombus* rhombus/)
+    #:same-as (<~ <=~ =~ !=~ >=~ >~)
+    #:stronger-than (\|\| &&)
+    #:associate 'none))
+
+(define-comp~-infix <~ rkt:<~)
+(define-comp~-infix <=~ rkt:<=~)
+(define-comp~-infix =~ rkt:=~)
+(define-comp~-infix !=~ rkt:!=~)
+(define-comp~-infix >=~ rkt:>=~)
+(define-comp~-infix >~ rkt:>~)

--- a/design/partial-order/D-C/partial-order.rkt
+++ b/design/partial-order/D-C/partial-order.rkt
@@ -73,7 +73,7 @@
          [(realish? b) (partial-compare-realish a b)]
          [else +nan.0])]
       [else
-       (product-compare/recur a b cmp)])))
+       (product-compare/recur a b cmp #true)])))
 
 ;; partial-compare : Any Any -> PartialOrder
 (define (partial-compare a b)
@@ -85,7 +85,7 @@
     [(partial-order? x)
      (->fx ((cadr (partial-order-ref x)) x compare-hash-code) 'compare-hash-code)]
     [(realish? x) (equal-hash-code (realish-key x))]
-    [else (product-hash-code/recur x compare-hash-code)]))
+    [else (product-hash-code/recur x compare-hash-code #true)]))
 
 (define-values (prop:PartialOrder PartialOrder? PartialOrder-ref)
   (make-struct-type-property

--- a/design/partial-order/D-C/partial-order.rkt
+++ b/design/partial-order/D-C/partial-order.rkt
@@ -56,7 +56,7 @@
                   #'PartialOrder-ref
                   (vector-immutable (box-immutable 'compare_key)
                                     (box-immutable 'partial_compare))
-                  #'#(#:abstract #:abstract)
+                  #'#(#:abstract partial_order/key)
                   (hasheq 'compare_key 0 'partial_compare 1)
                   #hasheq()
                   #t))
@@ -72,6 +72,11 @@
   (define (hash-proc/compare-key a recur-hsh)
     (define compare_key (vector-ref (PartialOrder-ref a) 0))
     (recur-hsh (compare_key a))))
+
+(define (partial_order/key self other recur)
+  (define self.compare_key (vector-ref (PartialOrder-ref self) 0))
+  (define other.compare_key (vector-ref (PartialOrder-ref other) 0))
+  (recur (self.compare_key self) (other.compare_key other)))
 
 ;; ---------------------------------------------------------
 

--- a/design/partial-order/D-C/test-partial-order.rhm
+++ b/design/partial-order/D-C/test-partial-order.rhm
@@ -88,3 +88,24 @@ let hc: PartialOrder.compare_hash_code
 check: flvector(0.0) =~ flvector(-0.0) ~is #true
 check: hc(flvector(0.0)) .= hc(flvector(-0.0)) ~is #true
 
+check: flvector(0.0, -0.0) =~ flvector(-0.0, 0.0) ~is #true
+check: hc(flvector(0.0, -0.0)) .= hc(flvector(-0.0, 0.0)) ~is #true
+
+check: flvector(0.0, 1.0) =~ flvector(-0.0, 2.0) ~is #false
+check: flvector(0.0, 1.0) !=~ flvector(-0.0, 2.0) ~is #true
+check: flvector(0.0, 1.0) <=~ flvector(-0.0, 2.0) ~is #true
+check: flvector(0.0, 1.0) <~ flvector(-0.0, 2.0) ~is #true
+check: flvector(2.0, -0.0) <=~ flvector(1.0, 0.0) ~is #false
+check: flvector(2.0, -0.0) >=~ flvector(1.0, 0.0) ~is #true
+check: flvector(2.0, -0.0) >~ flvector(1.0, 0.0) ~is #true
+
+check: flvector(1.0, 20.0) <~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) <=~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) >~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) >=~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) =~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) !=~ flvector(2.0, 10.0) ~is #true
+
+check: flvector() <=~ flvector(0.0) ~is #false
+check: flvector(1.0, 10.0) <=~ flvector(2.0, 20.0, 200.0) ~is #false
+

--- a/design/partial-order/D-C/test-partial-order.rhm
+++ b/design/partial-order/D-C/test-partial-order.rhm
@@ -164,3 +164,16 @@ begin:
   check: set_count(set_now(ic1, ic3)) ~is 1
   check: equal_now_hash_code(ic1) .= equal_now_hash_code(ic3) ~is #true
 
+class DateViaKey(year :: Integer, month :: PositiveInteger, day :: PositiveInteger):
+  private implements PartialOrder
+  private override compare_key():
+    Lexicographic(year, month, day)
+
+check: DateViaKey(1903, 12, 17) <~ DateViaKey(1969, 07, 16) ~is #true
+check: DateViaKey(1903, 12, 17) =~ DateViaKey(1969, 07, 16) ~is #false
+check: hc(DateViaKey(1903, 12, 17)) .= hc(DateViaKey(1969, 07, 16))
+       ~is #false
+check: DateViaKey(2022, 11, 16) =~ DateViaKey(2022, 11, 16) ~is #true
+check: hc(DateViaKey(2022, 11, 16)) .= hc(DateViaKey(2022, 11, 16))
+       ~is #true
+

--- a/design/partial-order/D-C/test-partial-order.rhm
+++ b/design/partial-order/D-C/test-partial-order.rhm
@@ -2,6 +2,7 @@
 
 import:
   lib("racket/base.rkt").gcd
+  lib("racket/flonum.rkt").flvector
   "partial-order.rkt" open
   "Lexicographic.rhm".Lexicographic
 
@@ -82,4 +83,8 @@ check: [1, Baddie(1)] >=~ [2, Baddie(2)] ~is #false
 check: [1, Baddie(1)] >~ [2, Baddie(2)] ~is #false
 check: [2, Baddie(1)] <=~ [1, Baddie(2)] ~is #false
 check: [2, Baddie(1)] <~ [1, Baddie(2)] ~is #false
+
+let hc: PartialOrder.compare_hash_code
+check: flvector(0.0) =~ flvector(-0.0) ~is #true
+check: hc(flvector(0.0)) .= hc(flvector(-0.0)) ~is #true
 

--- a/design/partial-order/D-C/test-partial-order.rhm
+++ b/design/partial-order/D-C/test-partial-order.rhm
@@ -2,8 +2,14 @@
 
 import:
   lib("racket/base.rkt").gcd
+  lib("racket/base.rkt").#{eq-hash-code} as eq_hash_code
+  lib("racket/base.rkt").#{equal-always-hash-code} as equal_always_hash_code
+  lib("racket/base.rkt").#{equal-hash-code} as equal_now_hash_code
   lib("racket/flonum.rkt").flvector
+  lib("racket/set.rkt").set as set_now
+  lib("racket/set.rkt").#{set-count} as set_count
   "partial-order.rkt" open
+  "equatable.rkt" open
   "Lexicographic.rhm".Lexicographic
 
 class UnredRatio(n :: Integer, d :: PositiveInteger):
@@ -108,4 +114,53 @@ check: flvector(1.0, 20.0) !=~ flvector(2.0, 10.0) ~is #true
 
 check: flvector() <=~ flvector(0.0) ~is #false
 check: flvector(1.0, 10.0) <=~ flvector(2.0, 20.0, 200.0) ~is #false
+
+class IncreasingCell(initial):
+  private field current: 0 // can `init` go here?
+  constructor(initial):
+    let self: super(initial)
+    self.current := initial
+    self
+  property
+  | value: current
+  | value := next:
+      unless next >=~ current
+      | error(#'IncreasingCell, "expected value to increase or stay the same")
+      current := next
+  private implements Equatable
+  private override equals(other, recur): this === other
+  private override hash_code(recur): eq_hash_code(this)
+  private implements PartialOrder
+  private override partial_compare(other :: IncreasingCell, recur):
+    recur(value, other.value)
+  private override compare_key():
+    value
+
+begin:
+  let ic1: IncreasingCell(0)
+  let ic2: IncreasingCell(0)
+  let ic3: IncreasingCell(1)
+
+  check: ic1 == ic2 ~is #false
+  check: {ic1, ic2}.length() ~is 2
+  check: equal_always_hash_code(ic1) .= equal_always_hash_code(ic2) ~is #false
+
+  check: ic1 =~ ic2 ~is #true
+  check: set_count(set_now(ic1, ic2)) ~is 1
+  check: equal_now_hash_code(ic1) .= equal_now_hash_code(ic2) ~is #true
+
+  check: ic1.value == 0 ~is #true
+  check: ic1.value := -1
+         ~raises "IncreasingCell: expected value to increase or stay the same"
+  check: ic1.value == 0 ~is #true
+  ic1.value := 1
+  check: ic1.value == 1 ~is #true
+
+  check: ic1 =~ ic2 ~is #false
+  check: set_count(set_now(ic1, ic2)) ~is 2
+  check: equal_now_hash_code(ic1) .= equal_now_hash_code(ic2) ~is #false
+
+  check: ic1 =~ ic3 ~is #true
+  check: set_count(set_now(ic1, ic3)) ~is 1
+  check: equal_now_hash_code(ic1) .= equal_now_hash_code(ic3) ~is #true
 

--- a/design/partial-order/D-C/test-partial-order.rhm
+++ b/design/partial-order/D-C/test-partial-order.rhm
@@ -1,0 +1,85 @@
+#lang rhombus
+
+import:
+  lib("racket/base.rkt").gcd
+  "partial-order.rkt" open
+  "Lexicographic.rhm".Lexicographic
+
+class UnredRatio(n :: Integer, d :: PositiveInteger):
+  private implements PartialOrder
+  private override compare_key():
+    let c: gcd(n, d)
+    [n/c, d/c]
+  private override partial_compare(other :: UnredRatio, recur):
+    recur(n * other.d, other.n * d)
+
+check UnredRatio(1, 2) =~ UnredRatio(2, 4) ~is #true
+check UnredRatio(1, 2) =~ UnredRatio(3, 4) ~is #false
+check UnredRatio(1, 2) <~ UnredRatio(3, 4) ~is #true
+check UnredRatio(1, 2) <~ UnredRatio(1, 4) ~is #false
+check UnredRatio(1, 2) >~ UnredRatio(1, 4) ~is #true
+check:
+  [UnredRatio(1, 2), UnredRatio(-1, 2)] <~ [UnredRatio(3, 4), UnredRatio(-1, 4)]
+  ~is #true
+check:
+  [UnredRatio(1, 2), UnredRatio(-1, 2)] >~ [UnredRatio(1, 4), UnredRatio(-3, 4)]
+  ~is #true
+
+check:
+  Lexicographic(UnredRatio(1, 2), UnredRatio(-1, 2)) <~ Lexicographic(UnredRatio(3, 4), UnredRatio(-1, 4))
+  ~is #true
+check:
+  Lexicographic(UnredRatio(1, 2), UnredRatio(-1, 2)) >~ Lexicographic(UnredRatio(1, 4), UnredRatio(-3, 4))
+  ~is #true
+
+check: Lexicographic(5, 8, 3, 13, 2) =~ Lexicographic(5, 8, 3, 13, 2) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) =~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) !=~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(6, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(6, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <~ Lexicographic(6, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(4, 18) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(4, 18) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >~ Lexicographic(4, 18) ~is #true
+
+check: PartialOrder.within([6, 10], [6.02, 9.99], 0.05) ~is #true
+check: PartialOrder.within({#'C: 20, #'F: 68}, {#'C: 25, #'F: 77}, 10) ~is #true
+
+check: PartialOrder.within([6e+23, 10.0], [6.02e+23, 9.8], 0.05) ~is #false
+check: PartialOrder.within({#'C: 18, #'F: 64}, {#'C: 25, #'F: 77}, 10) ~is #false
+
+check: #nan =~ #nan ~is #false
+check: #nan !=~ #nan ~is #true
+check: #nan <~ #nan ~is #false
+check: #nan <=~ #nan ~is #false
+
+class AlwaysNaN():
+  private implements PartialOrder
+  private override compare_key(): #nan
+  private override partial_compare(_, _): #nan
+
+let NaNish: AlwaysNaN()
+check: NaNish =~ NaNish ~is #false
+check: NaNish !=~ NaNish ~is #true
+check: NaNish <~ NaNish ~is #false
+check: NaNish <=~ NaNish ~is #false
+
+class Baddie(value):
+  private implements PartialOrder
+  private override compare_key():
+    error(#'Baddie, "never compare me to anything!")
+  private override partial_compare(_, _):
+    error(#'Baddie, "never compare me to anything!")
+
+check: [1, Baddie(1)] =~ [2, Baddie(2)] ~is #false
+check: [1, Baddie(1)] !=~ [2, Baddie(2)] ~is #true
+check: [1, Baddie(1)] >=~ [2, Baddie(2)] ~is #false
+check: [1, Baddie(1)] >~ [2, Baddie(2)] ~is #false
+check: [2, Baddie(1)] <=~ [1, Baddie(2)] ~is #false
+check: [2, Baddie(1)] <~ [1, Baddie(2)] ~is #false
+

--- a/design/partial-order/E/Lexicographic.rhm
+++ b/design/partial-order/E/Lexicographic.rhm
@@ -1,0 +1,31 @@
+#lang rhombus
+
+export Lexicographic
+
+import "partial-order.rkt" open
+
+class Lexicographic(elements):
+  export and
+  constructor(& elements): super(elements)
+  private implements PartialOrder
+  private override compare_key(): elements
+  private override partial_compare(other :: Lexicographic, recur, _):
+    lexicographic_compare_list(elements, other.elements, recur)
+
+  macro
+  | 'and: $(c :: Group)': '$c'
+  | 'and: $c; $r; ...':
+      'begin:
+         let cv: $c
+         if cv .= 0
+         | and: $r; ...
+         | cv'
+
+fun
+| lexicographic_compare_list([], [], _): 0
+| lexicographic_compare_list([], [_, & _], _): -1
+| lexicographic_compare_list([_, & _], [], _): 1
+| lexicographic_compare_list([f1, & r1], [f2, & r2], recur):
+    Lexicographic.and:
+      recur(f1, f2)
+      lexicographic_compare_list(r1, r2, recur)

--- a/design/partial-order/E/equatable.rkt
+++ b/design/partial-order/E/equatable.rkt
@@ -1,0 +1,106 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     rhombus/private/interface-parse)
+         racket/hash-code
+         rhombus/private/provide
+         rhombus/private/name-root
+         (submod rhombus/private/annotation for-class)
+         (submod rhombus/private/dot for-dot-provider)
+         rhombus/private/realm
+         rhombus/private/class-dot
+         (only-in rhombus/private/class-desc define-class-desc-syntax)
+         rhombus/private/static-info
+         (submod "partial-order.rkt" private))
+
+(provide (for-spaces (rhombus/class
+                      rhombus/namespace)
+                     Equatable))
+
+(define-values (prop:Equatable Equatable? Equatable-ref)
+  (make-struct-type-property
+   'Equatable
+   #false
+   (list (cons prop:equal+hash (lambda (_) bounced-equal+hash-implementation)))))
+
+(define (bounce-to-equal-mode-proc this other recur mode)
+  (cond
+    [(and mode (PartialOrder? this))
+     (equal-proc/partial-compare this other recur)]
+    [else
+     (equal-recur-internal-method this other recur)]))
+
+(define (bounce-to-hash-mode-proc this recur mode)
+  (cond
+    [(and mode (PartialOrder? this))
+     (hash-proc/compare-key this recur)]
+    [else
+     (hash-recur-internal-method this recur)]))
+
+(define bounced-equal+hash-implementation
+  (list bounce-to-equal-mode-proc bounce-to-hash-mode-proc))
+
+(define-class-desc-syntax Equatable
+  (interface-desc #'Equatable
+                  #'Equatable
+                  #'()
+                  #'prop:Equatable
+                  #'Equatable-ref
+                  (vector-immutable (box-immutable 'equals)
+                                    (box-immutable 'hash_code))
+                  #'#(#:abstract #:abstract)
+                  (hasheq 'equals 0 'hash_code 1)
+                  #hasheq()
+                  #t))
+
+(define (equal-recur-internal-method this other recur)
+  ((vector-ref (Equatable-ref this) 0) this other recur))
+
+(define (hash-recur-internal-method this recur)
+  ((vector-ref (Equatable-ref this) 1) this recur))
+
+(define-name-root Equatable
+  #:fields
+  (hash_code_combine
+   hash_code_combine_unordered))
+
+(define hash_code_combine
+  (case-lambda
+    [() (hash-code-combine)]
+    [(a)
+     (unless (exact-integer? a)
+       (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" a))
+     (hash-code-combine a)]
+    [(a b)
+     (unless (exact-integer? a)
+       (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" a))
+     (unless (exact-integer? b)
+       (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" b))
+     (hash-code-combine a b)]
+    [lst
+     (for ([e (in-list lst)])
+       (unless (exact-integer? e)
+         (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" e)))
+     (hash-code-combine* lst)]))
+
+(define-static-info-syntax hash_code_combine (#%function-arity -1))
+                                                               
+(define hash_code_combine_unordered
+  (case-lambda
+    [() (hash-code-combine-unordered)]
+    [(a)
+     (unless (exact-integer? a)
+       (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" a))
+     (hash-code-combine-unordered a)]
+    [(a b)
+     (unless (exact-integer? a)
+       (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" a))
+     (unless (exact-integer? b)
+       (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" b))
+     (hash-code-combine-unordered a b)]
+    [lst
+     (for ([e (in-list lst)])
+       (unless (exact-integer? e)
+         (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" e)))
+     (hash-code-combine-unordered* lst)]))
+
+(define-static-info-syntax hash_code_combine_unoredered (#%function-arity -1))

--- a/design/partial-order/E/partial-order.rkt
+++ b/design/partial-order/E/partial-order.rkt
@@ -1,0 +1,247 @@
+#lang racket/base
+
+(require rhombus/private/provide)
+(provide (for-spaces (rhombus/class
+                      rhombus/namespace)
+                     PartialOrder)
+         (for-spaces (#f
+                      rhombus/repet)
+                     =~
+                     !=~
+                     <~
+                     >~
+                     <=~
+                     >=~
+                     =?
+                     !=?
+                     <?
+                     >?
+                     <=?
+                     >=?))
+(module+ private
+  (provide PartialOrder?
+           equal-proc/partial-compare
+           hash-proc/compare-key))
+
+(require (for-syntax racket/base
+                     rhombus/private/interface-parse)
+         rhombus/private/define-operator
+         (only-in rhombus/private/arithmetic
+                  \|\| &&
+                  [+ rhombus+]
+                  [- rhombus-]
+                  [* rhombus*]
+                  [/ rhombus/])
+         rhombus/private/name-root
+         rhombus/private/realm
+         (only-in rhombus/private/class-desc define-class-desc-syntax)
+         "../common/partial-order-util.rkt")
+
+;; ---------------------------------------------------------
+
+;; PartialOrder struct type property and interface
+
+(define-values (prop:partial-order partial-order? partial-order-ref)
+  (make-struct-type-property
+   'partial-order
+   (λ (val _info)
+     (unless (and (list? val)
+                  (= 2 (length val))
+                  (procedure? (car val))
+                  (procedure? (cadr val))
+                  (procedure-arity-includes? (car val) 4)
+                  (procedure-arity-includes? (cadr val) 3))
+       (raise-argument-error* 'prop:partial-compare
+                              rhombus-realm
+                              (string-append
+                               "(list/c (procedure-arity-includes/c 3)\n"
+                               "        (procedure-arity-includes/c 2))")
+                              val))
+     ;; a `cons` here creates a unique identity for each time the
+     ;; property is attached to a structure type
+     (cons (car val) (cdr val)))))
+
+;; partial-compare/recur :
+;; Any Any [Any Any -> PartialOrdering] Boolean -> PartialOrdering
+(define (partial-compare/recur a b recur mode)
+  (let ([cmp (lambda (ai bi) (partial-ordering-normalize (recur ai bi)))])
+    (cond
+      [(partial-order? a)
+       (cond
+         [(partial-order? b)
+          (let ([av (partial-order-ref a)])
+            (cond
+              [(eq? av (partial-order-ref b))
+               (partial-ordering-normalize ((car av) a b cmp mode))]
+              [else +nan.0]))]
+         [else +nan.0])]
+      [(realish? a)
+       (cond
+         [(realish? b) (partial-compare-realish a b)]
+         [else +nan.0])]
+      [else
+       (product-compare/recur a b cmp mode)])))
+
+;; compare-hash-code/recur : Any [Any -> Fixnum] Boolean -> Fixnum
+(define (compare-hash-code/recur x recur mode)
+  (cond
+    [(partial-order? x)
+     (->fx ((cadr (partial-order-ref x)) x recur mode) 'compare-hash-code)]
+    [(realish? x) (equal-hash-code (realish-key x))]
+    [else (product-hash-code/recur x recur #true)]))
+
+(define-values (prop:PartialOrder PartialOrder? PartialOrder-ref)
+  (make-struct-type-property
+   'PartialOrder
+   #false
+   (list (cons prop:partial-order
+               (lambda (v)
+                 (unless (and (vector? v) (= 2 (vector-length v)))
+                   (raise-argument-error* 'PartialOrder
+                                          rhombus-realm
+                                          "method vector"
+                                          v))
+                 (define compare_key (vector-ref v 0))
+                 (define partial_compare (vector-ref v 1))
+                 (unless (and (procedure? compare_key)
+                              (procedure-arity-includes? compare_key 1))
+                   (raise-argument-error* 'compare_key
+                                          rhombus-realm
+                                          "(procedure-arity-includes/c 1)"
+                                          compare_key))
+                 (unless (and (procedure? partial_compare)
+                              (procedure-arity-includes? partial_compare 4))
+                   (raise-argument-error* 'partial_compare
+                                          rhombus-realm
+                                          "(procedure-arity-includes/c 4)"
+                                          partial_compare))
+                 (define (compare-hash-code-proc x rec mode)
+                   (rec (compare_key x)))
+                 (list partial_compare compare-hash-code-proc))))))
+
+(define-class-desc-syntax PartialOrder
+  (interface-desc #'PartialOrder
+                  #'PartialOrder
+                  #'()
+                  #'prop:PartialOrder
+                  #'PartialOrder-ref
+                  (vector-immutable (box-immutable 'compare_key)
+                                    (box-immutable 'partial_compare))
+                  #'#(#:abstract partial_order/key)
+                  (hasheq 'compare_key 0 'partial_compare 1)
+                  #hasheq()
+                  #t))
+
+(module+ private
+  ;; equal-proc/partial-compare : Self Imp (Any Any -> Boolean) -> Boolean
+  (define (equal-proc/partial-compare a b recur-eql)
+    (define partial_compare (vector-ref (PartialOrder-ref a) 1))
+    (define (recur-cmp ai bi) (if (recur-eql ai bi) 0 +nan.0))
+    (partial_compare a b recur-cmp #true))
+
+  ;; hash-proc/compare-key : Self (Any -> Integer) -> Integer
+  (define (hash-proc/compare-key a recur-hsh)
+    (define compare_key (vector-ref (PartialOrder-ref a) 0))
+    (recur-hsh (compare_key a))))
+
+(define (partial_order/key self other recur mode)
+  (define self.compare_key (vector-ref (PartialOrder-ref self) 0))
+  (define other.compare_key (vector-ref (PartialOrder-ref other) 0))
+  (and mode (recur (self.compare_key self) (other.compare_key other))))
+
+;; ---------------------------------------------------------
+
+;; Public operations
+
+(define-name-root PartialOrder
+  #:fields
+  (partial_compare_now
+   partial_compare_always
+   compare_now
+   compare_always
+   compare_now_hash_code
+   compare_always_hash_code
+   within))
+
+(define (partial_compare_now a b)
+  (partial-compare/recur a b partial_compare_now #true))
+
+(define (partial_compare_always a b)
+  (partial-compare/recur a b partial_compare_always #false))
+
+(define (compare_now a b)
+  (ordering-normalize (partial-compare/recur a b compare_now #true)))
+
+(define (compare_always a b)
+  (ordering-normalize (partial-compare/recur a b compare_always #false)))
+
+(define (compare_now_hash_code a)
+  (compare-hash-code/recur a compare_now_hash_code #true))
+
+(define (compare_always_hash_code a)
+  (compare-hash-code/recur a compare_always_hash_code #false))
+
+(define (partial-compare/=~ a b)
+  (early-nan/= (partial-compare/recur a b partial-compare/=~ #true)))
+
+(define (partial-compare/<=~ a b)
+  (early-nan/<= (partial-compare/recur a b partial-compare/<=~ #true)))
+
+(define (partial-compare/>=~ a b)
+  (early-nan/>= (partial-compare/recur a b partial-compare/>=~ #true)))
+
+(define (partial-compare/=? a b)
+  (early-nan/= (partial-compare/recur a b partial-compare/=? #false)))
+
+(define (partial-compare/<=? a b)
+  (early-nan/<= (partial-compare/recur a b partial-compare/<=? #false)))
+
+(define (partial-compare/>=? a b)
+  (early-nan/>= (partial-compare/recur a b partial-compare/>=? #false)))
+
+(define (within a b epsilon)
+  (define (cmp ai bi)
+    (early-nan/=
+     (cond
+       [(realish? ai)
+        (ord-and/bool (realish? bi) (partial-compare-realish/within ai bi epsilon))]
+       [else
+        (partial-compare/recur ai bi cmp #true)])))
+  (zero? (cmp a b)))
+
+(define (op=~ a b) (zero? (partial-compare/=~ a b)))
+(define (op!=~ a b) (not (zero? (partial-compare/=~ a b))))
+
+(define (op<~ a b) (negative? (partial-compare/<=~ a b)))
+(define (op>~ a b) (positive? (partial-compare/>=~ a b)))
+(define (op<=~ a b) (<= (partial-compare/<=~ a b) 0))
+(define (op>=~ a b) (>= (partial-compare/>=~ a b) 0))
+
+(define (op=? a b) (zero? (partial-compare/=? a b)))
+(define (op!=? a b) (not (zero? (partial-compare/=? a b))))
+
+(define (op<? a b) (negative? (partial-compare/<=? a b)))
+(define (op>? a b) (positive? (partial-compare/>=? a b)))
+(define (op<=? a b) (<= (partial-compare/<=? a b) 0))
+(define (op>=? a b) (>= (partial-compare/>=? a b) 0))
+
+(define-syntax-rule (define-comp~-infix name racket-name)
+  (define-infix name racket-name
+    #:weaker-than (rhombus+ rhombus- rhombus* rhombus/)
+    #:same-as (<~ <=~ =~ !=~ >=~ >~ <? <=? =? !=? >=? >?)
+    #:stronger-than (\|\| &&)
+    #:associate 'none))
+
+(define-comp~-infix <~ op<~)
+(define-comp~-infix <=~ op<=~)
+(define-comp~-infix =~ op=~)
+(define-comp~-infix !=~ op!=~)
+(define-comp~-infix >=~ op>=~)
+(define-comp~-infix >~ op>~)
+
+(define-comp~-infix <? op<?)
+(define-comp~-infix <=? op<=?)
+(define-comp~-infix =? op=?)
+(define-comp~-infix !=? op!=?)
+(define-comp~-infix >=? op>=?)
+(define-comp~-infix >? op>?)

--- a/design/partial-order/E/test-partial-order.rhm
+++ b/design/partial-order/E/test-partial-order.rhm
@@ -1,0 +1,179 @@
+#lang rhombus
+
+import:
+  lib("racket/base.rkt").gcd
+  lib("racket/base.rkt").#{eq-hash-code} as eq_hash_code
+  lib("racket/base.rkt").#{equal-always-hash-code} as equal_always_hash_code
+  lib("racket/base.rkt").#{equal-hash-code} as equal_now_hash_code
+  lib("racket/flonum.rkt").flvector
+  lib("racket/set.rkt").set as set_now
+  lib("racket/set.rkt").#{set-count} as set_count
+  "partial-order.rkt" open
+  "equatable.rkt" open
+  "Lexicographic.rhm".Lexicographic
+
+class UnredRatio(n :: Integer, d :: PositiveInteger):
+  private implements PartialOrder
+  private override compare_key():
+    let c: gcd(n, d)
+    [n/c, d/c]
+  private override partial_compare(other :: UnredRatio, recur, _):
+    recur(n * other.d, other.n * d)
+
+check UnredRatio(1, 2) =~ UnredRatio(2, 4) ~is #true
+check UnredRatio(1, 2) =~ UnredRatio(3, 4) ~is #false
+check UnredRatio(1, 2) <~ UnredRatio(3, 4) ~is #true
+check UnredRatio(1, 2) <~ UnredRatio(1, 4) ~is #false
+check UnredRatio(1, 2) >~ UnredRatio(1, 4) ~is #true
+check:
+  [UnredRatio(1, 2), UnredRatio(-1, 2)] <~ [UnredRatio(3, 4), UnredRatio(-1, 4)]
+  ~is #true
+check:
+  [UnredRatio(1, 2), UnredRatio(-1, 2)] >~ [UnredRatio(1, 4), UnredRatio(-3, 4)]
+  ~is #true
+
+check:
+  Lexicographic(UnredRatio(1, 2), UnredRatio(-1, 2)) <~ Lexicographic(UnredRatio(3, 4), UnredRatio(-1, 4))
+  ~is #true
+check:
+  Lexicographic(UnredRatio(1, 2), UnredRatio(-1, 2)) >~ Lexicographic(UnredRatio(1, 4), UnredRatio(-3, 4))
+  ~is #true
+
+check: Lexicographic(5, 8, 3, 13, 2) =~ Lexicographic(5, 8, 3, 13, 2) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) =~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) !=~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <~ Lexicographic(5, 8, 3, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >~ Lexicographic(5, 8, 2, 13, 2, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(6, -1) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(6, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <~ Lexicographic(6, -1) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) <=~ Lexicographic(4, 18) ~is #false
+check: Lexicographic(5, 8, 3, 13, 2) >=~ Lexicographic(4, 18) ~is #true
+check: Lexicographic(5, 8, 3, 13, 2) >~ Lexicographic(4, 18) ~is #true
+
+check: PartialOrder.within([6, 10], [6.02, 9.99], 0.05) ~is #true
+check: PartialOrder.within({#'C: 20, #'F: 68}, {#'C: 25, #'F: 77}, 10) ~is #true
+
+check: PartialOrder.within([6e+23, 10.0], [6.02e+23, 9.8], 0.05) ~is #false
+check: PartialOrder.within({#'C: 18, #'F: 64}, {#'C: 25, #'F: 77}, 10) ~is #false
+
+check: #nan =~ #nan ~is #false
+check: #nan !=~ #nan ~is #true
+check: #nan <~ #nan ~is #false
+check: #nan <=~ #nan ~is #false
+
+class AlwaysNaN():
+  private implements PartialOrder
+  private override compare_key(): #nan
+  private override partial_compare(_, _, _): #nan
+
+let NaNish: AlwaysNaN()
+check: NaNish =~ NaNish ~is #false
+check: NaNish !=~ NaNish ~is #true
+check: NaNish <~ NaNish ~is #false
+check: NaNish <=~ NaNish ~is #false
+
+class Baddie(value):
+  private implements PartialOrder
+  private override compare_key():
+    error(#'Baddie, "never compare me to anything!")
+  private override partial_compare(_, _, _):
+    error(#'Baddie, "never compare me to anything!")
+
+check: [1, Baddie(1)] =~ [2, Baddie(2)] ~is #false
+check: [1, Baddie(1)] !=~ [2, Baddie(2)] ~is #true
+check: [1, Baddie(1)] >=~ [2, Baddie(2)] ~is #false
+check: [1, Baddie(1)] >~ [2, Baddie(2)] ~is #false
+check: [2, Baddie(1)] <=~ [1, Baddie(2)] ~is #false
+check: [2, Baddie(1)] <~ [1, Baddie(2)] ~is #false
+
+let hc: PartialOrder.compare_now_hash_code
+check: flvector(0.0) =~ flvector(-0.0) ~is #true
+check: hc(flvector(0.0)) .= hc(flvector(-0.0)) ~is #true
+
+check: flvector(0.0, -0.0) =~ flvector(-0.0, 0.0) ~is #true
+check: hc(flvector(0.0, -0.0)) .= hc(flvector(-0.0, 0.0)) ~is #true
+
+check: flvector(0.0, 1.0) =~ flvector(-0.0, 2.0) ~is #false
+check: flvector(0.0, 1.0) !=~ flvector(-0.0, 2.0) ~is #true
+check: flvector(0.0, 1.0) <=~ flvector(-0.0, 2.0) ~is #true
+check: flvector(0.0, 1.0) <~ flvector(-0.0, 2.0) ~is #true
+check: flvector(2.0, -0.0) <=~ flvector(1.0, 0.0) ~is #false
+check: flvector(2.0, -0.0) >=~ flvector(1.0, 0.0) ~is #true
+check: flvector(2.0, -0.0) >~ flvector(1.0, 0.0) ~is #true
+
+check: flvector(1.0, 20.0) <~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) <=~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) >~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) >=~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) =~ flvector(2.0, 10.0) ~is #false
+check: flvector(1.0, 20.0) !=~ flvector(2.0, 10.0) ~is #true
+
+check: flvector() <=~ flvector(0.0) ~is #false
+check: flvector(1.0, 10.0) <=~ flvector(2.0, 20.0, 200.0) ~is #false
+
+class IncreasingCell(initial):
+  private field current: 0 // can `init` go here?
+  constructor(initial):
+    let self: super(initial)
+    self.current := initial
+    self
+  property
+  | value: current
+  | value := next:
+      unless next >=~ current
+      | error(#'IncreasingCell, "expected value to increase or stay the same")
+      current := next
+  private implements Equatable
+  private override equals(other, recur): this === other
+  private override hash_code(recur): eq_hash_code(this)
+  private implements PartialOrder
+  private override partial_compare(other :: IncreasingCell, recur, mode):
+    mode && recur(value, other.value)
+  private override compare_key():
+    value
+
+begin:
+  let ic1: IncreasingCell(0)
+  let ic2: IncreasingCell(0)
+  let ic3: IncreasingCell(1)
+
+  check: ic1 == ic2 ~is #false
+  check: {ic1, ic2}.length() ~is 2
+  check: equal_always_hash_code(ic1) .= equal_always_hash_code(ic2) ~is #false
+
+  check: ic1 =~ ic2 ~is #true
+  check: set_count(set_now(ic1, ic2)) ~is 1
+  check: equal_now_hash_code(ic1) .= equal_now_hash_code(ic2) ~is #true
+
+  check: ic1.value == 0 ~is #true
+  check: ic1.value := -1
+         ~raises "IncreasingCell: expected value to increase or stay the same"
+  check: ic1.value == 0 ~is #true
+  ic1.value := 1
+  check: ic1.value == 1 ~is #true
+
+  check: ic1 =~ ic2 ~is #false
+  check: set_count(set_now(ic1, ic2)) ~is 2
+  check: equal_now_hash_code(ic1) .= equal_now_hash_code(ic2) ~is #false
+
+  check: ic1 =~ ic3 ~is #true
+  check: set_count(set_now(ic1, ic3)) ~is 1
+  check: equal_now_hash_code(ic1) .= equal_now_hash_code(ic3) ~is #true
+
+class DateViaKey(year :: Integer, month :: PositiveInteger, day :: PositiveInteger):
+  private implements PartialOrder
+  private override compare_key():
+    Lexicographic(year, month, day)
+
+check: DateViaKey(1903, 12, 17) <~ DateViaKey(1969, 07, 16) ~is #true
+check: DateViaKey(1903, 12, 17) =~ DateViaKey(1969, 07, 16) ~is #false
+check: hc(DateViaKey(1903, 12, 17)) .= hc(DateViaKey(1969, 07, 16))
+       ~is #false
+check: DateViaKey(2022, 11, 16) =~ DateViaKey(2022, 11, 16) ~is #true
+check: hc(DateViaKey(2022, 11, 16)) .= hc(DateViaKey(2022, 11, 16))
+       ~is #true
+

--- a/design/partial-order/common/partial-order-util.rkt
+++ b/design/partial-order/common/partial-order-util.rkt
@@ -126,6 +126,7 @@
 ;; product-compare/recur : Any Any [Any Any -> PartialOrdering] -> PartialOrdering
 (define (product-compare/recur a b cmp)
   (cond
+    [(eq? a b) 0]
     [(flvector? a)
      (ord-and/bool
       (flvector? b)

--- a/design/partial-order/common/partial-order-util.rkt
+++ b/design/partial-order/common/partial-order-util.rkt
@@ -1,0 +1,123 @@
+#lang racket/base
+
+(provide ordering-normalize
+         partial-ordering-normalize
+         ord-and/bool
+         ord-and/prod
+         realish?
+         partial-compare-realish
+         partial-compare-realish/within)
+
+(require (for-syntax racket/base)
+         racket/extflonum
+         racket/math
+         syntax/parse/define)
+
+;; A Ordering is a ComparableReal where:
+;;  - zero?     represents =~
+;;  - negative? represents <~
+;;  - positive? represents >~
+;; this excludes NaN
+
+;; ordering-normalize : Ordering -> Ordering
+(define (ordering-normalize c)
+  (cond
+    [(zero? c) 0]
+    [(negative? c) -1]
+    [(positive? c) 1]
+    [else (error 'compare "bad ~v" c)]))
+
+;; A PartialOrdering is a Real where:
+;;  - zero?     represents =~
+;;  - negative? represents <~
+;;  - positive? represents >~
+;;  - nan?      represents incomparable
+
+;; partial-ordering-normalize : PartialOrdering -> PartialOrdering
+(define (partial-ordering-normalize c)
+  (cond
+    [(zero? c) 0]
+    [(negative? c) -1]
+    [(positive? c) 1]
+    [(nan? c) +nan.0]
+    [else (error 'partial_compare "bad ~v" c)]))
+
+;; ord-and/bool : Boolean ... PartialOrdering -> PartialOrdering
+(define-syntax-parser ord-and/bool
+  [(_) #'0]
+  [(_ c) #'c]
+  [(_ b . rst)
+   #'(if b (ord-and/bool . rst) +nan.0)])
+
+;; ord-and/prod2 : PartialOrdering PartialOrdering -> PartialOrdering
+(define (ord-and/prod2 c0 c1)
+  (cond
+    [(zero? c0) c1]
+    [(zero? c1) c0]
+    [(and (negative? c0) (negative? c1)) -1]
+    [(and (positive? c0) (positive? c1)) 1]
+    [else +nan.0]))
+
+;; ord-and/prod : PartialOrdering ... PartialOrdering
+(define-syntax-parser ord-and/prod
+  [(_) #'0]
+  [(_ c) #'c]
+  [(_ c0 c1 . rst)
+   #'(let ([c0v c0])
+       (if (nan? c0v)
+           +nan.0
+           (ord-and/prod (ord-and/prod2 c0v c1) . rst)))])
+
+;; A Realish is one of:
+;;  - Real
+;;  - Extflonum
+(define (realish? v)
+  (or (real? v) (extflonum? v)))
+
+;; realish-key : Realish -> Real
+(define (realish-key x)
+  (cond
+    [(or (eq? x +inf.0) (eq? x +inf.f) (eq? x +inf.t)) +inf.0]
+    [(or (eq? x -inf.0) (eq? x -inf.f) (eq? x -inf.t)) -inf.0]
+    [(or (eq? x +nan.0) (eq? x +nan.f) (eq? x +nan.t)) +nan.0]
+    [(extflonum? x) (extfl->exact x)]
+    [else (inexact->exact x)]))
+
+;; partial-compare-realish : Realish Realish -> PartialOrdering
+(define (partial-compare-realish a b)
+  (cond
+    [(and (real? a) (real? b)) (partial-compare-real a b)]
+    [(and (extflonum? a) (extflonum? b)) (partial-compare-extflonum a b)]
+    [else (partial-compare-real (realish-key a) (realish-key b))]))
+
+;; partial-compare-real : Real Real -> PartialOrdering
+(define (partial-compare-real a b)
+  (cond
+    [(= a b) 0]
+    [(< a b) -1]
+    [(> a b) 1]
+    [else +nan.0]))
+
+;; partial-compare-extflonum : Extflonum Extflonum -> PartialOrdering
+(define (partial-compare-extflonum a b)
+  (cond
+    [(extfl= a b) 0]
+    [(extfl< a b) -1]
+    [(extfl> a b) 1]
+    [else +nan.0]))
+
+;; partial-compare-realish/within : Realish Realish Real -> PartialOrdering
+(define (partial-compare-realish/within a b epsilon)
+  (cond
+    [(and (real? a) (real? b)) (partial-compare-real/within a b epsilon)]
+    [else (partial-compare-real/within (realish-key a) (realish-key b) epsilon)]))
+
+;; partial-compare-real/within : Real Real Real -> PartialOrdering
+(define (partial-compare-real/within a b epsilon)
+  (define d (- a b))
+  (cond
+    [(<= (- epsilon) d epsilon) 0]
+    [(< d (- epsilon)) -1]
+    [(> d epsilon) 1]
+    [else +nan.0]))
+

--- a/design/partial-order/common/partial-order-util.rkt
+++ b/design/partial-order/common/partial-order-util.rkt
@@ -5,11 +5,14 @@
          ord-and/bool
          ord-and/prod
          realish?
+         realish-key
          partial-compare-realish
          partial-compare-realish/within
-         product-compare/recur)
+         product-compare/recur
+         ->fx)
 
 (require (for-syntax racket/base)
+         racket/fixnum
          racket/flonum
          racket/extflonum
          racket/math
@@ -156,3 +159,9 @@
        [ge 1]
        [else +nan.0])]))
 
+;; maps non-fixnum integers to positive fixnums
+(define (->fx v [who '->fx])
+  (cond
+    [(fixnum? v) v]
+    [(exact-integer? v) (bitwise-and v (most-positive-fixnum))]
+    [else (raise-argument-error who "exact-integer?" v)]))

--- a/design/partial-order/partial-order-D-A.md
+++ b/design/partial-order/partial-order-D-A.md
@@ -1,0 +1,75 @@
+Partial Order
+==========================
+
+### Option D-A: Comparison only, with false and short-circuiting
+
+Data definitions that want to implement partial orders only
+need to implement one method: `partial_compare`.
+Implementations of `partial_compare` are not expected to be
+compatible with with `Equatable`, `==`, or Racket's `equal?`
+in any way, and there is no hash code associated with this.
+
+#### Interface to be implemented by data definitions privately
+
+A `PartialOrdering` is a `Real` number:
+ - Negative represents `<` less than
+ - Zero represents `=` equal to
+ - Positive represents `>` greater than
+ - NaN represents incomparable
+
+The interface `PartialOrder` is intended to be implemented
+privately with the `partial_compare` method:
+
+```
+// Self is implicit
+method partial_compare(other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
+```
+
+The method implementation may assume that `other`'s method
+implementation comes from the same type.
+
+It is expected that mutable data structures can implement
+`partial_compare` in a way that depends on mutable state,
+and so ordering might change after mutation.
+
+#### Operations to be used publicly
+
+An `Ordering` is a comparable real number, excluding NaN:
+ - Negative represents `<` less than
+ - Zero represents `=` equal to
+ - Positive represents `>` greater than
+
+Functions:
+ * `fun partial_compare(a, b) :: PartialOrdering`
+   Follows type-specific `partial_compare` method implementations
+   when the method implementations come from the same type.
+   Produces NaN when they come from different types.
+   When the types don't implement `PartialOrder`, it can
+   use `equal?/recur` for a product order.
+ * `fun compare(a, b) :: Ordering`
+   Errors when `partial_compare` would produce NaN,
+   otherwise produces the `Ordering` it would produce.
+ * `fun within(a, b, epsilon :: Real) :: Boolean`
+   Produces true when they compare equal, while allowing
+   numbers within them to be different by at most epsilon
+   from one another, false otherwise.
+
+Operators:
+ * `operator (a =~ b) :: Boolean` produces true when `partial_compare` produces zero, false when it produces something else (including NaN)
+ * `operator (a !=~ b) :: Boolean` produces true when `partial_compare` produces something other than zero (including NaN), false on zero
+ * `operator (a <~ b) :: Boolean` produces true when `partial_compare` produces negative, false on anything else (including NaN)
+ * `operator (a >~ b) :: Boolean` produces true when `partial_compare` produces positive, false on anything else (including NaN)
+ * `operator (a <=~ b) :: Boolean` produces true when `partial_compare` produces negative or zero, false on anything else (including NaN)
+ * `operator (a >=~ b) :: Boolean` produces true when `partial_compare` produces positive or zero, false on anything else (including NaN)
+
+These operators have short-circuiting behavior, such as:
+
+```
+[2, Baddie(1)] <=~ [1, Baddie(2)]
+[2, Baddie(1)] <~ [1, Baddie(2)]
+```
+
+These should return false immeditately after comparing `2`
+and `1`, without comparing `Baddie1()` and `Baddie2()`.
+Where option A, B, or C would try to compare `Baddie1()`
+and `Baddie2()` to see whether they're comparable or not.

--- a/design/partial-order/partial-order-D-C.md
+++ b/design/partial-order/partial-order-D-C.md
@@ -1,0 +1,79 @@
+Partial Order
+==========================
+
+### Option D-C: Comparison with key, with false and short-circuiting
+
+Data definitions that want to implement partial orders can
+either just implement the `compare_key` method, or
+implement both `compare_key` and `partial_compare`.
+Partial orders interact with Racket's `equal?/recur`
+through product orders (not lexicographic orders).
+
+#### Interface to be implemented by data definitions privately
+
+The interface `PartialOrder` is intended to be implemented
+privately with these methods:
+
+```
+// Self is implicit
+method compare_key() :: Any
+
+// Self is implicit
+method partial_compare(other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
+```
+
+With the `partial_compare` method optional.
+
+The `partial_compare` method may assume that `other`'s
+method implementation comes from the same type.
+
+It is expected that mutable data structures can implement
+partial orders in a way that depends on their mutable state,
+and so ordering might change after mutation.
+
+The `compare_key` method can error when an element isn't
+comparable to anything, not even itself (such as NaN).
+
+#### Operations to be used publicly
+
+Functions:
+ * `fun partial_compare(a, b) :: PartialOrdering`
+   Follows type-specific `partial_compare` method implementations
+   when the method implementations come from the same type.
+   Produces NaN when they come from different types.
+   When the types don't implement `PartialOrder`, it can
+   use `equal?/recur` for a product order.
+ * `fun compare(a, b) :: Ordering`
+   Errors when `partial_compare` would produce NaN,
+   otherwise produces the `Ordering` it would produce.
+ * `fun within(a, b, epsilon :: Real) :: Boolean`
+   Produces true when they compare equal, while allowing
+   numbers within them to be different by at most epsilon
+   from one another, false otherwise.
+ * `fun compare_hash_code(a) :: Integer`
+   Follows type-specific `compare_hash_code` method
+   implementations, behaves compatibly with `.=` on  real
+   numbers, and on other types, follows hash code methods
+   from their equality implementations.
+ * Racket's `equal?` and `equal-hash-code` can use these
+   methods as well.
+
+Operators:
+ * `operator (a =~ b) :: Boolean` produces true when `partial_compare` produces zero, false when it produces something else (including NaN)
+ * `operator (a !=~ b) :: Boolean` produces true when `partial_compare` produces something other than zero (including NaN), false on zero
+ * `operator (a <~ b) :: Boolean` produces true when `partial_compare` produces negative, false on anything else (including NaN)
+ * `operator (a >~ b) :: Boolean` produces true when `partial_compare` produces positive, false on anything else (including NaN)
+ * `operator (a <=~ b) :: Boolean` produces true when `partial_compare` produces negative or zero, false on anything else (including NaN)
+ * `operator (a >=~ b) :: Boolean` produces true when `partial_compare` produces positive or zero, false on anything else (including NaN)
+
+These operators have short-circuiting behavior, such as:
+
+```
+[2, Baddie(1)] <=~ [1, Baddie(2)]
+[2, Baddie(1)] <~ [1, Baddie(2)]
+```
+
+These should return false immeditately after comparing `2`
+and `1`, without comparing `Baddie1()` and `Baddie2()`.
+Where option A, B, or C would try to compare `Baddie1()`
+and `Baddie2()` to see whether they're comparable or not.

--- a/design/partial-order/partial-order.md
+++ b/design/partial-order/partial-order.md
@@ -173,6 +173,34 @@ Functions:
 Operators:
  * All the same operators from Option B: Comparison with hash
 
+### Option D: Comparators produce false on incomparable values
+
+The same as either option A, B, or C, except that when
+values are incomparable, `<~`, `<=~`, `>~`, and `>=~` each
+produce false instead of an error.
+
+This allows some short-circuiting behavior, such as:
+
+```
+[2, Baddie1()] <=~ [1, Baddie2()]
+[2, Baddie1()] <~ [1, Baddie2()]
+```
+
+These should return false immeditately after comparing `2`
+and `1`, without comparing `Baddie1()` and `Baddie2()`.
+Where option A, B, or C would try to compare `Baddie1()`
+and `Baddie2()` to see whether they're comparable or not.
+
+Option D-A provides the same interfaces and operations as
+option A, but with the false results on incomparable values
+and better short-circuiting.
+
+Option D-B provides the same as option B, but with false
+and short-circuiting.
+
+Option D-C provides the same as option C, but with false
+and short-circuiting.
+
 Evaluation and Tradeoffs
 ------------------------
 
@@ -189,6 +217,18 @@ Between B and C, B is simpler to implement but slightly
 harder for users.
 While C is slightly trickier to implement but easier for
 users.
+
+Options A, B, and C can provide error messages where users
+might expect values to be comparable when they're not.
+This can help those users find errors more quickly if they
+either have warped expectations from total orders, or when
+they accidentally mix types that they didn't mean to mix.
+Option D expects users of `<~`, `<=~`, etc. to know that
+it's a partial order where values can be incomparable.
+But option D's short-circuiting is very desirable, and
+producing false results on incomparable values also makes
+it more consistent overall, bringing `<~`, `<=~`, etc. more
+in line with the behavior of `=~` and `!=~`.
 
 Prior art and References
 ------------------------
@@ -218,3 +258,4 @@ Contributors
 ------------
 
 Alex Knauth
+Rocketnia

--- a/design/partial-order/partial-order.md
+++ b/design/partial-order/partial-order.md
@@ -45,7 +45,8 @@ The interface `PartialOrder` is intended to be implemented
 privately with the `partial_compare` method:
 
 ```
-method partial_compare(self :: Self, other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
+// Self is implicit
+method partial_compare(other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
 ```
 
 The method implementation may assume that `other`'s method
@@ -94,9 +95,11 @@ The interface `PartialOrder` is intended to be implemented
 privately with these methods:
 
 ```
-method partial_compare(self :: Self, other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
+// Self is implicit
+method partial_compare(other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
 
-method compare_hash_code(self :: Self, recur :: (Any) -> Integer) :: Integer
+// Self is implicit
+method compare_hash_code(recur :: (Any) -> Integer) :: Integer
 ```
 
 The `partial_compare` method may assume that `other`'s
@@ -138,9 +141,11 @@ The interface `PartialOrder` is intended to be implemented
 privately with these methods:
 
 ```
-method compare_key(self :: Self) :: Any
+// Self is implicit
+method compare_key() :: Any
 
-method partial_compare(self :: Self, other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
+// Self is implicit
+method partial_compare(other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
 ```
 
 With the `partial_compare` method optional.

--- a/design/partial-order/partial-order.md
+++ b/design/partial-order/partial-order.md
@@ -9,9 +9,10 @@ A generic interface for partial orders.
 Motivation
 ----------
 
-I have two main motivations:
+I have 3 main motivations:
  - Ordering for sorted data structures.
  - Customizable equal-now-like behavior within Rhombus.
+ - Equality within tolerance for testing `check-within`.
 
 Note that most sorted data structures expect a total order,
 not a partial order.
@@ -73,6 +74,10 @@ Functions:
  * `fun compare(a, b) :: Ordering`
    Errors when `partial_compare` would produce NaN,
    otherwise produces the `Ordering` it would produce.
+ * `fun within(a, b, epsilon :: Real) :: Boolean`
+   Produces true when they compare equal, while allowing
+   numbers within them to be different by at most epsilon
+   from one another, false otherwise.
 
 Operators:
  * `operator (a =~ b) :: Boolean` produces true when `partial_compare` produces zero, false when it produces something else (including NaN)

--- a/design/partial-order/partial-order.md
+++ b/design/partial-order/partial-order.md
@@ -1,0 +1,210 @@
+Partial Order
+==========================
+
+Summary
+-------
+
+A generic interface for partial orders.
+
+Motivation
+----------
+
+I have two main motivations:
+ - Ordering for sorted data structures.
+ - Customizable equal-now-like behavior within Rhombus.
+
+Note that most sorted data structures expect a total order,
+not a partial order.
+But a key type that implements a partial order can still be
+useful if only a subset of keys are allowed which are all
+comparable to each other: for example `Real` numbers only
+have a partial order because NaN exists, but if they're
+free to accept that and just error when they see NaN is
+incomparable, they can still be very useful.
+
+Design Options
+--------------
+
+### Option A: Comparison only, any resemblance to equality is entirely coincedental
+
+Data definitions that want to implement partial orders only
+need to implement one method: `partial_compare`.
+Implementations of `partial_compare` are not expected to be
+compatible with with `Equatable`, `==`, or Racket's `equal?`
+in any way, and there is no hash code associated with this.
+
+#### Interface to be implemented by data definitions privately
+
+A `PartialOrdering` is a `Real` number:
+ - Negative represents `<` less than
+ - Zero represents `=` equal to
+ - Positive represents `>` greater than
+ - NaN represents incomparable
+
+The interface `PartialOrder` is intended to be implemented
+privately with the `partial_compare` method:
+
+```
+method partial_compare(self :: Self, other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
+```
+
+The method implementation may assume that `other`'s method
+implementation comes from the same type.
+
+It is expected that mutable data structures can implement
+`partial_compare` in a way that depends on mutable state,
+and so ordering might change after mutation.
+
+#### Operations to be used publicly
+
+An `Ordering` is a comparable real number, excluding NaN:
+ - Negative represents `<` less than
+ - Zero represents `=` equal to
+ - Positive represents `>` greater than
+
+Functions:
+ * `fun partial_compare(a, b) :: PartialOrdering`
+   Follows type-specific `partial_compare` method implementations
+   when the method implementations come from the same type.
+   Produces NaN when they come from different types.
+   When the types don't implement `PartialOrder`, it can
+   use `equal?/recur` for a product order.
+ * `fun compare(a, b) :: Ordering`
+   Errors when `partial_compare` would produce NaN,
+   otherwise produces the `Ordering` it would produce.
+
+Operators:
+ * `operator (a =~ b) :: Boolean` produces true when `partial_compare` produces zero, false when it produces something else (including NaN)
+ * `operator (a !=~ b) :: Boolean` produces true when `partial_compare` produces something other than zero (including NaN), false on zero
+ * `operator (a <~ b) :: Boolean` produces true when `compare` produces negative, false on positive or zero, and errors on errors (including errors when `partial_compare` produces NaN)
+ * `operator (a >~ b) :: Boolean` produces true when `compare` produces positive, false on negative or zero, and errors on errors (including errors when `partial_compare` produces NaN)
+ * `operator (a <=~ b) :: Boolean` produces true when `compare` produces negative or zero, false on positive, and errors on errors (including errors when `partial_compare` produces NaN)
+ * `operator (a >=~ b) :: Boolean` produces true when `compare` produces positive or zero, false on negative, and errors on errors (including errors when `partial_compare` produces NaN)
+
+### Option B: Comparison with hash, connected with equal-now
+
+Data definitions that want to implement partial orders need
+two methods: `partial_compare` and `compare_hash_code`.
+Partial orders interact with Racket's `equal?/recur`
+through product orders (not lexicographic orders).
+
+#### Interface to be implemented by data definitions privately
+
+The interface `PartialOrder` is intended to be implemented
+privately with these methods:
+
+```
+method partial_compare(self :: Self, other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
+
+method compare_hash_code(self :: Self, recur :: (Any) -> Integer) :: Integer
+```
+
+The `partial_compare` method may assume that `other`'s
+method implementation comes from the same type.
+
+It is expected that mutable data structures can implement
+partial orders in a way that depends on their mutable state,
+and so ordering might change after mutation.
+
+The `compare_hash_code` method can error when an element
+isn't comparable to anything, not even itself (such as NaN).
+
+#### Operations to be used publicly
+
+Functions:
+ * All the same functions from Option A: Comparison only
+ * `fun compare_hash_code(a) :: Integer`
+   Follows type-specific `compare_hash_code` method
+   implementations, behaves compatibly with `.=` on  real
+   numbers, and on other types, follows hash code methods
+   from their equality implementations.
+ * Racket's `equal?` and `equal-hash-code` can use these
+   methods as well.
+
+Operators:
+ * All the same operators from Option A: Comparison only
+
+### Option C: Comparison with key, connected with equal-now via hash-proc recur
+
+Data definitions that want to implement partial orders can
+either just implement the `compare_key` method, or
+implement both `compare_key` and `partial_compare`.
+Partial orders interact with Racket's `equal?/recur`
+through product orders (not lexicographic orders).
+
+#### Interface to be implemented by data definitions privately
+
+The interface `PartialOrder` is intended to be implemented
+privately with these methods:
+
+```
+method compare_key(self :: Self) :: Any
+
+method partial_compare(self :: Self, other :: Imp, recur :: (Any, Any) -> PartialOrdering) :: PartialOrdering
+```
+
+With the `partial_compare` method optional.
+
+The `partial_compare` method may assume that `other`'s
+method implementation comes from the same type.
+
+It is expected that mutable data structures can implement
+partial orders in a way that depends on their mutable state,
+and so ordering might change after mutation.
+
+The `compare_key` method can error when an element isn't
+comparable to anything, not even itself (such as NaN).
+
+#### Operations to be used publicly
+
+Functions:
+ * All the same functions from Option B: Comparison with hash
+
+Operators:
+ * All the same operators from Option B: Comparison with hash
+
+Evaluation and Tradeoffs
+------------------------
+
+Option A is relatively simple and easier to implement than
+Option B or C.
+
+Option B and C provide more functionality with hash codes
+and support for Racket's `equal?`.
+But options B and C would probably require building this
+into the core of Racket so that they can access `hash-proc`
+methods with their recur arguments.
+
+Between B and C, B is simpler to implement but slightly
+harder for users.
+While C is slightly trickier to implement but easier for
+users.
+
+Prior art and References
+------------------------
+
+The `compare_key` method in Option C is inspired by
+[countvajhula's proposal](https://github.com/racket/rhombus-prototype/tree/master/design/equality)
+to use a `key` method to define equality.
+
+The use of negative/zero/positive numbers for less/equal/greater is inspired by 2 sources:
+ * Gerbil Scheme's
+   [Red-Black Trees](https://cons.io/reference/misc.html#red-black-trees)
+   and their `cmp` argument.
+ * Alexis King's
+   [`alexis/util/comparator`](https://docs.racket-lang.org/alexis-util/Untyped_Utilities.html#%28part._.Comparison_.Predicate_.Generation%29)
+   module, `define-comparison-predicates` macro.
+
+The operater name `=~` is inspired by [Pyret's equal-now](https://www.pyret.org/docs/latest/equality.html).
+
+Drawbacks and Unresolved questions
+----------------------------------
+
+Yet another equality predicate `=~`?
+When there are already several of them, adding another
+might be considered confusing.
+
+Contributors
+------------
+
+Alex Knauth


### PR DESCRIPTION
A `PartialOrder` interface intended to be privately implemented.

Comparison operators like `=~`, `<~`, `>~`, and so on.

Equality within tolerance for testing with `within`.

Markdown-rendered design: https://github.com/AlexKnauth/rhombus-prototype/blob/partial-order/design/partial-order/partial-order.md