### PR TITLE
WIP: Collection interfaces with mutableSublist producing a write through view

### DIFF
--- a/rhombus/data/collection.rhm
+++ b/rhombus/data/collection.rhm
@@ -14,7 +14,7 @@ import:
 interface CollectionView:
   extends Sequence
   // read-only property
-  property size :: Integer
+  property size :: Int
 
   method isEmpty() :: Boolean: size() == 0
 

--- a/rhombus/data/collection.rhm
+++ b/rhombus/data/collection.rhm
@@ -1,0 +1,47 @@
+#lang rhombus
+
+
+export:
+  Collection
+  ImmutableCollection
+  MutableCollection
+
+
+import:
+  rhombus/data/sequence.Sequence
+
+
+interface Collection:
+  extends Sequence
+  // read-only property
+  property size :: Integer
+
+  method isEmpty() :: Boolean: size() == 0
+
+  method contains(element) :: Boolean:
+    let iterator = iterate()
+    fun loop():
+      iterator.hasNext() && (iterator.next() == element || loop())
+    loop()
+
+
+interface ImmutableCollection:
+  extends Collection
+  method add(element) :: ImmutableCollection
+  method remove(element) :: ImmutableCollection
+
+
+interface MutableCollection:
+  extends Collection
+  method add(element) :: Void
+
+  method addAll(elements :: Sequence) :: Void:
+    let iterator = elements.iterate()
+    fun loop():
+      when iterator.hasNext()
+      | add(iterator.next())
+        loop()
+    loop()
+
+  method remove(element) :: Void
+  method clear() :: Void

--- a/rhombus/data/collection.rhm
+++ b/rhombus/data/collection.rhm
@@ -3,7 +3,7 @@
 
 export:
   Collection
-  ImmutableCollection
+  CollectionView
   MutableCollection
 
 
@@ -11,7 +11,7 @@ import:
   rhombus/data/sequence.Sequence
 
 
-interface Collection:
+interface CollectionView:
   extends Sequence
   // read-only property
   property size :: Integer
@@ -25,14 +25,14 @@ interface Collection:
     loop()
 
 
-interface ImmutableCollection:
-  extends Collection
-  method add(element) :: ImmutableCollection
-  method remove(element) :: ImmutableCollection
+interface Collection:
+  extends CollectionView
+  method add(element) :: Collection
+  method remove(element) :: Collection
 
 
 interface MutableCollection:
-  extends Collection
+  extends CollectionView
   method add(element) :: Void
 
   method addAll(elements :: Sequence) :: Void:

--- a/rhombus/data/list.rhm
+++ b/rhombus/data/list.rhm
@@ -8,77 +8,24 @@ export:
 
 
 import:
-  rhombus/data/collection.Collection
-  rhombus/data/collection.CollectionView
-  rhombus/data/collection.MutableCollection
-  rhombus/private/precondition.checkArgument
+  rhombus/data/private/array_list.ArrayList
+  rhombus/data/private/list.List
+  rhombus/data/private/list.ListView
+  rhombus/data/private/list.MutableList
+  rhombus/data/private/list_builder.ListBuilder
 
 
-interface ListView:
-  extends CollectionView
-
-  method get(index :: Integer)
-  method sublist(start :: Integer, end :: Integer) :: ListView
-
-  method checkIndex(who, index):
-    checkArgument(
-      who,
-      index >= 0 && index < size(),
-      "index out of bounds",
-      "index", index,
-      "size", size())
-
-  method checkInsertionIndex(who, index):
-    checkArgument(
-      who,
-      index >= 0 && index <= size(),
-      "index out of bounds",
-      "index", index,
-      "size", size())
-
-  method checkSublistIndicies(who, start, end):
-    checkArgument(
-      who,
-      start >= 0 && start <= size(),
-      "sublist start index out of bounds",
-      "start index", start,
-      "end index", end,
-      "size", size())
-    checkArgument(
-      who,
-      end >= 0 && end <= size(),
-      "sublist end index out of bounds",
-      "start index", start,
-      "end index", end,
-      "size", size())
-    checkArgument(
-      who,
-      start <= end,
-      "sublist start index occurs after end index",
-      "start index", start,
-      "end index", end,
-      "size", size())
+fun List.builder(): ListBuilder()
 
 
-interface List:
-  extends:
-    ListView
-    Collection
-
-  method set(index :: Integer, element) :: List
-  override add(element) :: List
-  override remove(element) :: List
-  method insert(index :: Integer, element) :: List
-  method delete(index :: Integer) :: List
-  override sublist(start :: Integer, end :: Integer) :: List
+// TODO: make this work as List(...) instead of List.of(...)
+fun List.of(element, ...):
+  let builder = List.builder()
+  for:
+    each v: Array(element, ...)
+    builder.add(v)
+  builder.build()
 
 
-interface MutableList:
-  extends:
-    ListView
-    MutableCollection
-
-  method set(index :: Integer, element) :: Void
-  method insert(index :: Integer, element) :: Void
-  method delete(index :: Integer) :: Void
-  override sublist(start :: Integer, end :: Integer) :: MutableList
+// TODO: make this work as MutableList() instead of MutableList.create()
+fun MutableList.create(): ArrayList()

--- a/rhombus/data/list.rhm
+++ b/rhombus/data/list.rhm
@@ -1,0 +1,84 @@
+#lang rhombus
+
+
+export:
+  List
+  ImmutableList
+  MutableList
+
+
+import:
+  rhombus/data/collection.Collection
+  rhombus/data/collection.ImmutableCollection
+  rhombus/data/collection.MutableCollection
+  rhombus/private/precondition.checkArgument
+
+
+interface List:
+  extends Collection
+
+  method get(index :: Integer)
+  method sublist(start :: Integer, end :: Integer) :: List
+
+  method checkIndex(who, index):
+    checkArgument(
+      who,
+      index >= 0 && index < size(),
+      "index out of bounds",
+      "index", index,
+      "size", size())
+
+  method checkInsertionIndex(who, index):
+    checkArgument(
+      who,
+      index >= 0 && index <= size(),
+      "index out of bounds",
+      "index", index,
+      "size", size())
+
+  method checkSublistIndicies(who, start, end):
+    checkArgument(
+      who,
+      start >= 0 && start <= size(),
+      "sublist start index out of bounds",
+      "start index", start,
+      "end index", end,
+      "size", size())
+    checkArgument(
+      who,
+      end >= 0 && end <= size(),
+      "sublist end index out of bounds",
+      "start index", start,
+      "end index", end,
+      "size", size())
+    checkArgument(
+      who,
+      start <= end,
+      "sublist start index occurs after end index",
+      "start index", start,
+      "end index", end,
+      "size", size())
+
+
+interface ImmutableList:
+  extends:
+    List
+    ImmutableCollection
+
+  method set(index :: Integer, element) :: ImmutableList
+  override add(element) :: ImmutableList
+  override remove(element) :: ImmutableList
+  method insert(index :: Integer, element) :: ImmutableList
+  method delete(index :: Integer) :: ImmutableList
+  override sublist(start :: Integer, end :: Integer) :: ImmutableList
+
+
+interface MutableList:
+  extends:
+    List
+    MutableCollection
+
+  method set(index :: Integer, element) :: Void
+  method insert(index :: Integer, element) :: Void
+  method delete(index :: Integer) :: Void
+  override sublist(start :: Integer, end :: Integer) :: MutableList

--- a/rhombus/data/list.rhm
+++ b/rhombus/data/list.rhm
@@ -3,22 +3,22 @@
 
 export:
   List
-  ImmutableList
+  ListView
   MutableList
 
 
 import:
   rhombus/data/collection.Collection
-  rhombus/data/collection.ImmutableCollection
+  rhombus/data/collection.CollectionView
   rhombus/data/collection.MutableCollection
   rhombus/private/precondition.checkArgument
 
 
-interface List:
-  extends Collection
+interface ListView:
+  extends CollectionView
 
   method get(index :: Integer)
-  method sublist(start :: Integer, end :: Integer) :: List
+  method sublist(start :: Integer, end :: Integer) :: ListView
 
   method checkIndex(who, index):
     checkArgument(
@@ -60,22 +60,22 @@ interface List:
       "size", size())
 
 
-interface ImmutableList:
+interface List:
   extends:
-    List
-    ImmutableCollection
+    ListView
+    Collection
 
-  method set(index :: Integer, element) :: ImmutableList
-  override add(element) :: ImmutableList
-  override remove(element) :: ImmutableList
-  method insert(index :: Integer, element) :: ImmutableList
-  method delete(index :: Integer) :: ImmutableList
-  override sublist(start :: Integer, end :: Integer) :: ImmutableList
+  method set(index :: Integer, element) :: List
+  override add(element) :: List
+  override remove(element) :: List
+  method insert(index :: Integer, element) :: List
+  method delete(index :: Integer) :: List
+  override sublist(start :: Integer, end :: Integer) :: List
 
 
 interface MutableList:
   extends:
-    List
+    ListView
     MutableCollection
 
   method set(index :: Integer, element) :: Void

--- a/rhombus/data/list.rhm
+++ b/rhombus/data/list.rhm
@@ -9,23 +9,27 @@ export:
 
 import:
   rhombus/data/private/array_list.ArrayList
-  rhombus/data/private/list.List
+  rhombus/data/private/list
   rhombus/data/private/list.ListView
-  rhombus/data/private/list.MutableList
   rhombus/data/private/list_builder.ListBuilder
 
 
-fun List.builder(): ListBuilder()
+interface List:
+  extends list.List
+  annotation 'List': 'list.List'
+  expression 'List': 'of'
+  export: builder
+  fun builder(): ListBuilder()
+  fun of(element, ...):
+    let builder = List.builder()
+    for:
+      each v: Array(element, ...)
+      builder.add(v)
+    builder.build()
 
 
-// TODO: make this work as List(...) instead of List.of(...)
-fun List.of(element, ...):
-  let builder = List.builder()
-  for:
-    each v: Array(element, ...)
-    builder.add(v)
-  builder.build()
-
-
-// TODO: make this work as MutableList() instead of MutableList.create()
-fun MutableList.create(): ArrayList()
+interface MutableList:
+  extends list.MutableList
+  annotation 'MutableList': 'list.MutableList'
+  expression 'MutableList': 'create'
+  fun create(): ArrayList()

--- a/rhombus/data/private/array_list.rhm
+++ b/rhombus/data/private/array_list.rhm
@@ -16,11 +16,11 @@ class ArrayList():
   internal PrivateArrayList
 
   private field storage :: Array = Array()
-  private field currentSize :: Integer = 0
+  private field currentSize :: Int = 0
 
   // This field tracks how many structural modifications the list has undergone. Changing an element
   // is not a structural modification, but adding or removing an element is.
-  private field version :: Integer = 0
+  private field version :: Int = 0
 
   override method iterate(): ArrayListIterator(this)
 
@@ -49,7 +49,7 @@ class ArrayList():
     let i = find(element)
     unless i == -1 | delete(i)
 
-  override method insert(index :: Integer, element) :: Void:
+  override method insert(index :: Int, element) :: Void:
     checkInsertionIndex("List.insert", index)
     ensureCapacity(currentSize + 1)
     fun loop(i = currentSize):
@@ -61,7 +61,7 @@ class ArrayList():
     currentSize := currentSize + 1
     version := version + 1
 
-  override method delete(index :: Integer) :: Void:
+  override method delete(index :: Int) :: Void:
     checkIndex("List.delete", index)
     for:
       each i: index + 1 .. currentSize
@@ -94,7 +94,7 @@ class ArrayList():
       storage := newStorage
 
 
-class ArraySublist(backingList :: PrivateArrayList, start :: Integer, mutable end :: Integer):
+class ArraySublist(backingList :: PrivateArrayList, start :: Int, mutable end :: Int):
   implements MutableList
 
   override method iterate():
@@ -159,10 +159,10 @@ class ArraySublist(backingList :: PrivateArrayList, start :: Integer, mutable en
     loop()
 
 
-class ArrayListIterator(backingList :: ArrayList, private version :: Integer = backingList.version):
+class ArrayListIterator(backingList :: ArrayList, private version :: Int = backingList.version):
   implements Iterator
 
-  private field index :: Integer: 0
+  private field index :: Int: 0
 
   override method hasNext():
     when version < backingList.version | error("concurrent modification")

--- a/rhombus/data/private/array_list.rhm
+++ b/rhombus/data/private/array_list.rhm
@@ -6,7 +6,7 @@ export:
 
 
 import:
-  rhombus/data/list.MutableList
+  rhombus/data/private/list.MutableList
   rhombus/data/sequence.Iterator
   lib("racket/base.rkt").error
 

--- a/rhombus/data/private/array_list.rhm
+++ b/rhombus/data/private/array_list.rhm
@@ -24,7 +24,7 @@ class ArrayList():
 
   override method iterate(): ArrayListIterator(this)
 
-  override property size(): currentSize
+  override property size: currentSize
 
   override method get(index):
     checkIndex("List.get", index)
@@ -100,7 +100,7 @@ class ArraySublist(backingList :: PrivateArrayList, start :: Integer, mutable en
   override method iterate():
     ArraySublistIterator(this)
 
-  override property size():
+  override property size:
     end - start
 
   override method contains(element):
@@ -138,7 +138,7 @@ class ArraySublist(backingList :: PrivateArrayList, start :: Integer, mutable en
 
   override method clear():
     let elementsToShift = backingList.currentSize - end
-    let currentSize = size()
+    let currentSize = size
     for:
       each i: start .. start + elementsToShift
       backingList.storage[i] := backingList.storage[i + currentSize]

--- a/rhombus/data/private/array_list.rhm
+++ b/rhombus/data/private/array_list.rhm
@@ -6,6 +6,7 @@ export:
 
 
 import:
+  rhombus/data/private/list.ListView
   rhombus/data/private/list.MutableList
   rhombus/data/sequence.Iterator
   lib("racket/base.rkt").error
@@ -32,10 +33,14 @@ class ArrayList():
 
   override method sublist(start, end):
     checkSublistIndicies("List.sublist", start, end)
-    ArraySublist(this, start, end)
+    ArrayUnmodifiableSublist(this, start, end)
+
+  override method mutableSublist(start, end):
+    checkSublistIndicies("MutableList.mutableSublist", start, end)
+    ArrayMutableSublist(this, start, end)
 
   override method set(index, element):
-    checkIndex("List.set", index)
+    checkIndex("MutableList.set", index)
     storage[index] := element
 
   override method add(element):
@@ -50,7 +55,7 @@ class ArrayList():
     unless i == -1 | delete(i)
 
   override method insert(index :: Int, element) :: Void:
-    checkInsertionIndex("List.insert", index)
+    checkInsertionIndex("MutableList.insert", index)
     ensureCapacity(currentSize + 1)
     fun loop(i = currentSize):
       unless i == index
@@ -94,8 +99,9 @@ class ArrayList():
       storage := newStorage
 
 
-class ArraySublist(backingList :: PrivateArrayList, start :: Int, mutable end :: Int):
-  implements MutableList
+class ArrayViewSublist(backingList :: PrivateArrayList, start :: Int, mutable end :: Int):
+  nonfinal
+  implements ListView
 
   override method iterate():
     ArraySublistIterator(this)
@@ -112,10 +118,34 @@ class ArraySublist(backingList :: PrivateArrayList, start :: Int, mutable end ::
 
   override method sublist(start, end):
     checkSublistIndicies("List.sublist", start, end)
-    ArraySublist(backingList, this.start + start, this.start + end)
+    ArrayUnmodifiableSublist(backingList, this.start + start, this.start + end)
+
+  method find(element):
+    fun loop(i = start):
+      cond
+      | i == end: -1
+      | backingList.get(i) == element: i - start
+      | ~else: loop(i + 1)
+    loop()
+
+
+class ArrayUnmodifiableSublist():
+  extends ArrayViewSublist
+
+
+class ArrayMutableSublist():
+  extends ArrayViewSublist
+  implements MutableList
+
+  override method contains(element):
+    find(element) != -1
+
+  override method mutableSublist(start, end):
+    checkSublistIndicies("MutableList.mutableSublist", start, end)
+    ArrayMutableSublist(backingList, this.start + start, this.start + end)
 
   override method set(index, element):
-    checkIndex("List.set", index)
+    checkIndex("MutableList.set", index)
     backingList.set(index + start, element)
 
   override method add(element):
@@ -150,14 +180,6 @@ class ArraySublist(backingList :: PrivateArrayList, start :: Int, mutable end ::
     backingList.version := backingList.version + 1
     end := 0
 
-  private method find(element):
-    fun loop(i = start):
-      cond
-      | i == end: -1
-      | backingList.get(i) == element: i - start
-      | ~else: loop(i + 1)
-    loop()
-
 
 class ArrayListIterator(backingList :: ArrayList, private version :: Int = backingList.version):
   implements Iterator
@@ -177,7 +199,7 @@ class ArrayListIterator(backingList :: ArrayList, private version :: Int = backi
 
 
 // TODO
-class ArraySublistIterator(backingSublist :: ArraySublist)
+class ArraySublistIterator(backingSublist :: ArrayViewSublist)
 
 
 fun max(x, y):

--- a/rhombus/data/private/array_list.rhm
+++ b/rhombus/data/private/array_list.rhm
@@ -1,0 +1,184 @@
+#lang rhombus
+
+
+export:
+  ArrayList
+
+
+import:
+  rhombus/data/list.MutableList
+  rhombus/data/sequence.Iterator
+  lib("racket/base.rkt").error
+
+
+class ArrayList():
+  implements MutableList
+  internal PrivateArrayList
+
+  private field storage :: Array = Array()
+  private field currentSize :: Integer = 0
+
+  // This field tracks how many structural modifications the list has undergone. Changing an element
+  // is not a structural modification, but adding or removing an element is.
+  private field version :: Integer = 0
+
+  override method iterate(): ArrayListIterator(this)
+
+  override property size(): currentSize
+
+  override method get(index):
+    checkIndex("List.get", index)
+    storage[index]
+
+  override method sublist(start, end):
+    checkSublistIndicies("List.sublist", start, end)
+    ArraySublist(this, start, end)
+
+  override method set(index, element):
+    checkIndex("List.set", index)
+    storage[index] := element
+
+  override method add(element):
+    version := version + 1
+    ensureCapacity(currentSize + 1)
+    storage[currentSize] := element
+    currentSize := currentSize + 1
+    version := version + 1
+
+  override method remove(element):
+    let i = find(element)
+    unless i == -1 | delete(i)
+
+  override method insert(index :: Integer, element) :: Void:
+    checkInsertionIndex("List.insert", index)
+    ensureCapacity(currentSize + 1)
+    fun loop(i = currentSize):
+      unless i == index
+      | storage[i] := storage[i - 1]
+        loop(i - 1)
+    loop()
+    storage[index] := element
+    currentSize := currentSize + 1
+    version := version + 1
+
+  override method delete(index :: Integer) :: Void:
+    checkIndex("List.delete", index)
+    for:
+      each i: index + 1 .. currentSize
+      storage[i - 1] := storage[i]
+    storage[currentSize - 1] := #false
+    currentSize := currentSize - 1
+    version := version + 1
+
+  override method clear() :: Void:
+    storage := Array()
+    currentSize := 0
+    version := version + 1
+
+  private method find(element):
+    fun loop(i = 0):
+      cond
+      | i == currentSize: -1
+      | storage[i] == element: i
+      | ~else: loop(i + 1)
+    loop()
+
+  method ensureCapacity(requiredSize) :: Void:
+    when storage.length() < requiredSize
+    | let newStorage = Array.make(max(storage.length() * 2, requiredSize))
+      for:
+        each:
+          v: storage
+          i: 0..
+        newStorage[i] := v
+      storage := newStorage
+
+
+class ArraySublist(backingList :: PrivateArrayList, start :: Integer, mutable end :: Integer):
+  implements MutableList
+
+  override method iterate():
+    ArraySublistIterator(this)
+
+  override property size():
+    end - start
+
+  override method contains(element):
+    find(element) != -1
+
+  override method get(index):
+    checkIndex("List.get", index)
+    backingList.get(index + start)
+
+  override method sublist(start, end):
+    checkSublistIndicies("List.sublist", start, end)
+    ArraySublist(backingList, this.start + start, this.start + end)
+
+  override method set(index, element):
+    checkIndex("List.set", index)
+    backingList.set(index + start, element)
+
+  override method add(element):
+    backingList.insert(end, element)
+
+  override method remove(element):
+    let i = find(element)
+    unless i == -1
+    | delete(i)
+
+  override method insert(index, element):
+    checkInsertionIndex("List.insert", index)
+    backingList.insert(index + start, element)
+    end := end + 1
+
+  override method delete(index):
+    checkIndex("List.delete", index)
+    backingList.delete(index + start)
+    end := end - 1
+
+  override method clear():
+    let elementsToShift = backingList.currentSize - end
+    let currentSize = size()
+    for:
+      each i: start .. start + elementsToShift
+      backingList.storage[i] := backingList.storage[i + currentSize]
+    let newSize = backingList.size - currentSize
+    for:
+      each i: newSize .. backingList.currentSize
+      backingList.storage[i] := #false
+    backingList.currentSize := newSize
+    backingList.version := backingList.version + 1
+    end := 0
+
+  private method find(element):
+    fun loop(i = start):
+      cond
+      | i == end: -1
+      | backingList.get(i) == element: i - start
+      | ~else: loop(i + 1)
+    loop()
+
+
+class ArrayListIterator(backingList :: ArrayList, private version :: Integer = backingList.version):
+  implements Iterator
+
+  private field index :: Integer: 0
+
+  override method hasNext():
+    when version < backingList.version | error("concurrent modification")
+    index < backingList.size
+
+  override method next():
+    when version < backingList.version | error("concurrent modification")
+    unless index < backingList.size | error("no such element")
+    let element = backingList.get(index)
+    index := index + 1
+    element
+
+
+// TODO
+class ArraySublistIterator(backingSublist :: ArraySublist)
+
+
+fun max(x, y):
+  if x < y | y | x

--- a/rhombus/data/private/list.rhm
+++ b/rhombus/data/private/list.rhm
@@ -81,4 +81,4 @@ interface MutableList:
   method set(index :: Int, element) :: Void
   method insert(index :: Int, element) :: Void
   method delete(index :: Int) :: Void
-  override sublist(start :: Int, end :: Int) :: MutableList
+  method mutableSublist(start :: Int, end :: Int) :: MutableList

--- a/rhombus/data/private/list.rhm
+++ b/rhombus/data/private/list.rhm
@@ -1,0 +1,84 @@
+#lang rhombus
+
+
+export:
+  List
+  ListView
+  MutableList
+
+
+import:
+  rhombus/data/collection.Collection
+  rhombus/data/collection.CollectionView
+  rhombus/data/collection.MutableCollection
+  rhombus/private/precondition.checkArgument
+
+
+interface ListView:
+  extends CollectionView
+
+  method get(index :: Integer)
+  method sublist(start :: Integer, end :: Integer) :: ListView
+
+  method checkIndex(who, index):
+    checkArgument(
+      who,
+      index >= 0 && index < size,
+      "index out of bounds",
+      "index", index,
+      "size", size)
+
+  method checkInsertionIndex(who, index):
+    checkArgument(
+      who,
+      index >= 0 && index <= size,
+      "index out of bounds",
+      "index", index,
+      "size", size)
+
+  method checkSublistIndicies(who, start, end):
+    checkArgument(
+      who,
+      start >= 0 && start <= size,
+      "sublist start index out of bounds",
+      "start index", start,
+      "end index", end,
+      "size", size)
+    checkArgument(
+      who,
+      end >= 0 && end <= size,
+      "sublist end index out of bounds",
+      "start index", start,
+      "end index", end,
+      "size", size)
+    checkArgument(
+      who,
+      start <= end,
+      "sublist start index occurs after end index",
+      "start index", start,
+      "end index", end,
+      "size", size)
+
+
+interface List:
+  extends:
+    ListView
+    Collection
+
+  method set(index :: Integer, element) :: List
+  override add(element) :: List
+  override remove(element) :: List
+  method insert(index :: Integer, element) :: List
+  method delete(index :: Integer) :: List
+  override sublist(start :: Integer, end :: Integer) :: List
+
+
+interface MutableList:
+  extends:
+    ListView
+    MutableCollection
+
+  method set(index :: Integer, element) :: Void
+  method insert(index :: Integer, element) :: Void
+  method delete(index :: Integer) :: Void
+  override sublist(start :: Integer, end :: Integer) :: MutableList

--- a/rhombus/data/private/list.rhm
+++ b/rhombus/data/private/list.rhm
@@ -17,8 +17,8 @@ import:
 interface ListView:
   extends CollectionView
 
-  method get(index :: Integer)
-  method sublist(start :: Integer, end :: Integer) :: ListView
+  method get(index :: Int)
+  method sublist(start :: Int, end :: Int) :: ListView
 
   method checkIndex(who, index):
     checkArgument(
@@ -65,12 +65,12 @@ interface List:
     ListView
     Collection
 
-  method set(index :: Integer, element) :: List
+  method set(index :: Int, element) :: List
   override add(element) :: List
   override remove(element) :: List
-  method insert(index :: Integer, element) :: List
-  method delete(index :: Integer) :: List
-  override sublist(start :: Integer, end :: Integer) :: List
+  method insert(index :: Int, element) :: List
+  method delete(index :: Int) :: List
+  override sublist(start :: Int, end :: Int) :: List
 
 
 interface MutableList:
@@ -78,7 +78,7 @@ interface MutableList:
     ListView
     MutableCollection
 
-  method set(index :: Integer, element) :: Void
-  method insert(index :: Integer, element) :: Void
-  method delete(index :: Integer) :: Void
-  override sublist(start :: Integer, end :: Integer) :: MutableList
+  method set(index :: Int, element) :: Void
+  method insert(index :: Int, element) :: Void
+  method delete(index :: Int) :: Void
+  override sublist(start :: Int, end :: Int) :: MutableList

--- a/rhombus/data/private/list_builder.rhm
+++ b/rhombus/data/private/list_builder.rhm
@@ -18,9 +18,11 @@ class ListBuilder():
 
   method add(element):
     storage.add(element)
+    this
 
   method addAll(elements):
     storage.addAll(elements)
+    this
 
   method build():
     match storage.size

--- a/rhombus/data/private/list_builder.rhm
+++ b/rhombus/data/private/list_builder.rhm
@@ -1,0 +1,35 @@
+#lang rhombus
+
+
+export:
+  ListBuilder
+
+
+import:
+  rhombus/data/private/array_list.ArrayList
+  rhombus/data/private/regular_immutable_list.RegularImmutableList
+  rhombus/data/private/small_lists.SingletonList
+  rhombus/data/private/small_lists.EmptyList
+
+
+class ListBuilder():
+
+  private field storage :: ArrayList = ArrayList()
+
+  method add(element):
+    storage.add(element)
+
+  method addAll(elements):
+    storage.addAll(elements)
+
+  method build():
+    match storage.size
+    | 0: EmptyList()
+    | 1: SingletonList(storage[0])
+    | n:
+        let copy = Array.make(n)
+        for:
+          each:
+            i: 0..n
+          copy[i] := storage.get(i)
+        RegularImmutableList(copy)

--- a/rhombus/data/private/list_builder.rhm
+++ b/rhombus/data/private/list_builder.rhm
@@ -27,7 +27,7 @@ class ListBuilder():
   method build():
     match storage.size
     | 0: EmptyList()
-    | 1: SingletonList(storage[0])
+    | 1: SingletonList(storage.get(0))
     | n:
         let copy = Array.make(n)
         for:

--- a/rhombus/data/private/persistent_list.rhm
+++ b/rhombus/data/private/persistent_list.rhm
@@ -1,0 +1,11 @@
+#lang rhombus
+
+
+export:
+  PersistentList
+
+
+class PersistentList()
+class PersistentSublist()
+class PersistentListIterator()
+class PersistentSublistIterator()

--- a/rhombus/data/private/regular_immutable_list.rhm
+++ b/rhombus/data/private/regular_immutable_list.rhm
@@ -6,7 +6,7 @@ export:
 
 
 import:
-  rhombus/data/list.List
+  rhombus/data/private/list.List
   rhombus/data/private/persistent_list.PersistentList
   rhombus/data/sequence.Iterator
   lib("racket/base").error
@@ -81,7 +81,7 @@ class RegularImmutableSublist(
   private method toPersistent(): PersistentList().addAll(this)
 
 
-class ImmutableListIterator(backingList :: ImmutableList):
+class ImmutableListIterator(backingList :: List):
   implements Iterator
 
   private field index :: Integer: 0

--- a/rhombus/data/private/regular_immutable_list.rhm
+++ b/rhombus/data/private/regular_immutable_list.rhm
@@ -1,0 +1,95 @@
+#lang rhombus
+
+
+export:
+  RegularImmutableList
+
+
+import:
+  rhombus/data/list.ImmutableList
+  rhombus/data/private/persistent_list.PersistentList
+  rhombus/data/sequence.Iterator
+  lib("racket/base").error
+
+
+class RegularImmutableList(storage :: Array):
+  implements ImmutableList
+  internal PrivateRegularImmutableList
+
+  override method iterate(): ImmutableListIterator(this)
+  override property size(): storage.length
+  override method isEmpty(): #false
+
+  override method get(index):
+    checkIndex("List.get", index)
+    storage[index]
+
+  override method sublist(start, end):
+    checkSublistIndicies("List.sublist", start, end)
+    RegularImmutableSublist(this, start, end)
+
+  override method add(element): toPersistent().add(element)
+  override method remove(element): toPersistent().remove(element)
+
+  override method set(index, element):
+    checkIndex("List.set", index)
+    toPersistent().set(index, element)
+
+  override method insert(index, element):
+    checkInsertionIndex("List.insert", index)
+    toPersistent().insert(index, element)
+
+  override method delete(index):
+    checkIndex("List.delete", index)
+    toPersistent().delete(index)
+
+  private method toPersistent(): PersistentList().addAll(this)
+
+
+class RegularImmutableSublist(
+  backingList :: PrivateRegularImmutableList, start :: Integer, end :: Integer):
+
+  implements ImmutableList
+
+  override method iterate(): ImmutableListIterator(this)
+  override property size(): end - start
+  override method isEmpty(): start < end
+
+  override method get(index):
+    checkIndex("List.get", index)
+    backingList.storage[start + index]
+
+  override method sublist(start, end):
+    checkSublistIndicies("List.sublist", start, end)
+    RegularImmutableSublist(backingList, this.start + start, this.start + end)
+
+  override method add(element): toPersistent().add(element)
+  override method remove(element): toPersistent().remove(element)
+
+  override method set(index, element):
+    checkIndex("List.set", index)
+    toPersistent().set(index, element)
+
+  override method insert(index, element):
+    checkInsertionIndex("List.insert", index)
+    toPersistent().insert(index, element)
+
+  override method delete(index):
+    checkIndex("List.delete", index)
+    toPersistent().delete(index)
+
+  private method toPersistent(): PersistentList().addAll(this)
+
+
+class ImmutableListIterator(backingList :: ImmutableList):
+  implements Iterator
+
+  private field index :: Integer: 0
+
+  override method hasNext(): index < backingList.size
+
+  override method next():
+    unless index < backingList.size | error("no such element")
+    let element = backingList.get(index)
+    index := index + 1
+    element

--- a/rhombus/data/private/regular_immutable_list.rhm
+++ b/rhombus/data/private/regular_immutable_list.rhm
@@ -9,7 +9,7 @@ import:
   rhombus/data/private/list.List
   rhombus/data/private/persistent_list.PersistentList
   rhombus/data/sequence.Iterator
-  lib("racket/base").error
+  lib("racket/base.rkt").error
 
 
 class RegularImmutableList(storage :: Array):

--- a/rhombus/data/private/regular_immutable_list.rhm
+++ b/rhombus/data/private/regular_immutable_list.rhm
@@ -6,18 +6,18 @@ export:
 
 
 import:
-  rhombus/data/list.ImmutableList
+  rhombus/data/list.List
   rhombus/data/private/persistent_list.PersistentList
   rhombus/data/sequence.Iterator
   lib("racket/base").error
 
 
 class RegularImmutableList(storage :: Array):
-  implements ImmutableList
+  implements List
   internal PrivateRegularImmutableList
 
   override method iterate(): ImmutableListIterator(this)
-  override property size(): storage.length
+  override property size: storage.length
   override method isEmpty(): #false
 
   override method get(index):
@@ -49,10 +49,10 @@ class RegularImmutableList(storage :: Array):
 class RegularImmutableSublist(
   backingList :: PrivateRegularImmutableList, start :: Integer, end :: Integer):
 
-  implements ImmutableList
+  implements List
 
   override method iterate(): ImmutableListIterator(this)
-  override property size(): end - start
+  override property size: end - start
   override method isEmpty(): start < end
 
   override method get(index):

--- a/rhombus/data/private/regular_immutable_list.rhm
+++ b/rhombus/data/private/regular_immutable_list.rhm
@@ -17,7 +17,7 @@ class RegularImmutableList(storage :: Array):
   internal PrivateRegularImmutableList
 
   override method iterate(): ImmutableListIterator(this)
-  override property size: storage.length
+  override property size: storage.length()
   override method isEmpty(): #false
 
   override method get(index):

--- a/rhombus/data/private/regular_immutable_list.rhm
+++ b/rhombus/data/private/regular_immutable_list.rhm
@@ -47,7 +47,7 @@ class RegularImmutableList(storage :: Array):
 
 
 class RegularImmutableSublist(
-  backingList :: PrivateRegularImmutableList, start :: Integer, end :: Integer):
+  backingList :: PrivateRegularImmutableList, start :: Int, end :: Int):
 
   implements List
 
@@ -84,7 +84,7 @@ class RegularImmutableSublist(
 class ImmutableListIterator(backingList :: List):
   implements Iterator
 
-  private field index :: Integer: 0
+  private field index :: Int: 0
 
   override method hasNext(): index < backingList.size
 

--- a/rhombus/data/private/small_lists.rhm
+++ b/rhombus/data/private/small_lists.rhm
@@ -7,16 +7,16 @@ export:
 
 
 import:
-  rhombus/data/list.ImmutableList
+  rhombus/data/list.List
   rhombus/data/private/persistent_list.PersistentList
   rhombus/data/sequence.Iterator
   lib("racket/base.rkt").error
 
 
 class SingletonList(onlyElement):
-  implements ImmutableList
+  implements List
   override method iterate(): SingletonIterator(onlyElement)
-  override property size(): 1
+  override property size: 1
   override method isEmpty(): #false
   override method contains(element): element == onlyElement
 
@@ -58,9 +58,9 @@ class SingletonIterator(element):
 
 
 class EmptyList():
-  implements ImmutableList
+  implements List
   override method iterate(): EmptyIterator()
-  override property size(): 0
+  override property size: 0
   override method isEmpty(): #true
   override method contains(_): #false
   override method get(index): checkIndex("List.get", index)

--- a/rhombus/data/private/small_lists.rhm
+++ b/rhombus/data/private/small_lists.rhm
@@ -7,7 +7,7 @@ export:
 
 
 import:
-  rhombus/data/list.List
+  rhombus/data/private/list.List
   rhombus/data/private/persistent_list.PersistentList
   rhombus/data/sequence.Iterator
   lib("racket/base.rkt").error

--- a/rhombus/data/private/small_lists.rhm
+++ b/rhombus/data/private/small_lists.rhm
@@ -1,0 +1,86 @@
+#lang rhombus
+
+
+export:
+  SingletonList
+  EmptyList
+
+
+import:
+  rhombus/data/list.ImmutableList
+  rhombus/data/private/persistent_list.PersistentList
+  rhombus/data/sequence.Iterator
+  lib("racket/base.rkt").error
+
+
+class SingletonList(onlyElement):
+  implements ImmutableList
+  override method iterate(): SingletonIterator(onlyElement)
+  override property size(): 1
+  override method isEmpty(): #false
+  override method contains(element): element == onlyElement
+
+  override method get(index):
+    checkIndex("List.get", index)
+    onlyElement
+
+  override method sublist(start, end):
+    checkSublistIndicies("List.sublist", start, end)
+    if start == end | EmptyList() | this
+
+  override method add(element): PersistentList().add(onlyElement).add(element)
+  override method remove(element): if element == onlyElement | EmptyList() | this
+
+  override method set(index, element):
+    checkIndex("List.set", index)
+    SingletonList(element)
+
+  override method insert(index, element):
+    checkInsertionIndex("List.insert", index)
+    if index == 0
+    | PersistentList().add(element).add(onlyElement)
+    | PersistentList().add(onlyElement).add(element)
+
+  override method delete(index):
+    checkIndex("List.delete", index)
+    EmptyList()
+
+
+class SingletonIterator(element):
+  implements Iterator
+  private field exhausted = #false
+  override method hasNext(): !exhausted
+
+  override method next():
+    when exhausted | error("no such element")
+    exhausted := #true
+    element
+
+
+class EmptyList():
+  implements ImmutableList
+  override method iterate(): EmptyIterator()
+  override property size(): 0
+  override method isEmpty(): #true
+  override method contains(_): #false
+  override method get(index): checkIndex("List.get", index)
+
+  override method sublist(start, end):
+    checkSublistIndicies("List.sublist", start, end)
+    this
+
+  override method add(element): SingletonList(element)
+  override method remove(_): this
+  override method set(index, _): checkIndex("List.set", index)
+
+  override method insert(index, element):
+    checkInsertionIndex("List.insert", index)
+    add(element)
+
+  override method delete(index): checkIndex("List.delete", index)
+
+
+class EmptyIterator():
+  implements Iterator
+  override method hasNext(): #false
+  override method next(): error("no such element")

--- a/rhombus/data/sequence.rhm
+++ b/rhombus/data/sequence.rhm
@@ -1,0 +1,16 @@
+#lang rhombus
+
+
+export:
+  Sequence
+  Iterator
+
+
+class.together:
+
+  interface Sequence:
+    method iterate() :: Iterator
+
+  interface Iterator:
+    method hasNext() :: Boolean
+    method next()

--- a/rhombus/data/tests/list.rhm
+++ b/rhombus/data/tests/list.rhm
@@ -1,0 +1,51 @@
+#lang rhombus
+
+
+import:
+  rhombus/data/list.List
+  rhombus/tests/check.check
+
+
+check:
+  List.of().size
+  0
+
+check:
+  List.of("foo").size
+  1
+
+check:
+  List.of("foo", "bar", "baz").size
+  3
+
+check:
+  List.of("foo").get(0)
+  "foo"
+  
+check:
+  List.of("foo", "bar", "baz").get(0)
+  "foo"
+
+check:
+  List.of("foo", "bar", "baz").get(1)
+  "bar"
+
+check:
+  List.of("foo", "bar", "baz").get(2)
+  "baz"
+
+check:
+  List.of().isEmpty()
+  #true
+
+check:
+  List.of(1, 2, 3).contains(2)
+  #true
+
+check:
+  List.of(1, 2, 3).contains(4)
+  #false
+
+check:
+  List.builder().build().size
+  0

--- a/rhombus/data/tests/list.rhm
+++ b/rhombus/data/tests/list.rhm
@@ -2,7 +2,9 @@
 
 
 import:
+  rhombus/data/list.ListView
   rhombus/data/list.List
+  rhombus/data/list.MutableList
 
 
 check:
@@ -48,3 +50,43 @@ check:
 check:
   List.builder().build().size
   ~is 0
+
+check:
+  List(1, 2, 3, 4, 5).sublist(1, 4) is_a List
+  ~is #true
+
+check:
+  List(1, 2, 3, 4, 5).sublist(1, 4).get(1)
+  ~is 3
+
+block:
+  let ml: MutableList()
+  check: ml is_a List ~is #false
+  check: ml is_a MutableList ~is #true
+  ml.addAll(List(1, 2, 3, 4, 5))
+  check: ml.get(0) ~is 1
+  check: ml.get(1) ~is 2
+  check: ml.get(2) ~is 3
+  check: ml.get(3) ~is 4
+  check: ml.get(4) ~is 5
+  // backing list mutated, read-through view sees mutation
+  let sl: ml.sublist(1, 4)
+  check: sl is_a List ~is #false
+  check: sl is_a ListView ~is #true
+  check: sl.get(0) ~is 2
+  check: sl.get(1) ~is 3
+  check: sl.get(2) ~is 4
+  // MUTATE backing list
+  ml.set(2, 30)
+  check: sl.get(1) ~is 30
+  // TODO: make this test about mutableSublist, not sublist
+  let msl: ml.sublist(1, 4)
+  check: msl is_a List ~is #false
+  check: msl is_a MutableList ~is #true
+  check: msl.get(0) ~is 2
+  check: msl.get(1) ~is 30
+  check: msl.get(2) ~is 4
+  // MUTATE mutable sublist, write-through view
+  msl.set(1, 300)
+  check: ml.get(2) ~is 300
+  check: sl.get(1) ~is 300

--- a/rhombus/data/tests/list.rhm
+++ b/rhombus/data/tests/list.rhm
@@ -79,9 +79,9 @@ block:
   // MUTATE backing list
   ml.set(2, 30)
   check: sl.get(1) ~is 30
-  // TODO: make this test about mutableSublist, not sublist
-  let msl: ml.sublist(1, 4)
+  let msl: ml.mutableSublist(1, 4)
   check: msl is_a List ~is #false
+  check: msl is_a ListView ~is #true
   check: msl is_a MutableList ~is #true
   check: msl.get(0) ~is 2
   check: msl.get(1) ~is 30

--- a/rhombus/data/tests/list.rhm
+++ b/rhombus/data/tests/list.rhm
@@ -3,49 +3,48 @@
 
 import:
   rhombus/data/list.List
-  rhombus/tests/check.check
 
 
 check:
   List.of().size
-  0
+  ~is 0
 
 check:
   List.of("foo").size
-  1
+  ~is 1
 
 check:
   List.of("foo", "bar", "baz").size
-  3
+  ~is 3
 
 check:
   List.of("foo").get(0)
-  "foo"
+  ~is "foo"
   
 check:
   List.of("foo", "bar", "baz").get(0)
-  "foo"
+  ~is "foo"
 
 check:
   List.of("foo", "bar", "baz").get(1)
-  "bar"
+  ~is "bar"
 
 check:
   List.of("foo", "bar", "baz").get(2)
-  "baz"
+  ~is "baz"
 
 check:
   List.of().isEmpty()
-  #true
+  ~is #true
 
 check:
   List.of(1, 2, 3).contains(2)
-  #true
+  ~is #true
 
 check:
   List.of(1, 2, 3).contains(4)
-  #false
+  ~is #false
 
 check:
   List.builder().build().size
-  0
+  ~is 0

--- a/rhombus/data/tests/list.rhm
+++ b/rhombus/data/tests/list.rhm
@@ -6,43 +6,43 @@ import:
 
 
 check:
-  List.of().size
+  List().size
   ~is 0
 
 check:
-  List.of("foo").size
+  List("foo").size
   ~is 1
 
 check:
-  List.of("foo", "bar", "baz").size
+  List("foo", "bar", "baz").size
   ~is 3
 
 check:
-  List.of("foo").get(0)
-  ~is "foo"
-  
-check:
-  List.of("foo", "bar", "baz").get(0)
+  List("foo").get(0)
   ~is "foo"
 
 check:
-  List.of("foo", "bar", "baz").get(1)
+  List("foo", "bar", "baz").get(0)
+  ~is "foo"
+
+check:
+  List("foo", "bar", "baz").get(1)
   ~is "bar"
 
 check:
-  List.of("foo", "bar", "baz").get(2)
+  List("foo", "bar", "baz").get(2)
   ~is "baz"
 
 check:
-  List.of().isEmpty()
+  List().isEmpty()
   ~is #true
 
 check:
-  List.of(1, 2, 3).contains(2)
+  List(1, 2, 3).contains(2)
   ~is #true
 
 check:
-  List.of(1, 2, 3).contains(4)
+  List(1, 2, 3).contains(4)
   ~is #false
 
 check:

--- a/rhombus/private/precondition.rhm
+++ b/rhombus/private/precondition.rhm
@@ -1,0 +1,9 @@
+#lang racket/base
+
+
+(provide checkArgument)
+
+
+(define (checkArgument who condition message . args)
+  (unless condition
+    (apply raise-arguments-error (string->symbol who) message args)))


### PR DESCRIPTION
An updated version of https://github.com/racket/rhombus-prototype/pull/259, rebased onto https://github.com/racket/rhombus-prototype/pull/329 to fix an issue that came up while working on it, with some of the ideas from the `mutableSublist` discussion implemented into it.

From a discord discussion on 2023-05-03:
 * Branching off from a discussion about naming interfaces like `ListView`, `StringView`, etc. into a discussion about `sublist` and copies vs. unmodifiable read-through views vs. write-thorugh views around here: https://discord.com/channels/571040468092321801/871953739982995547/1103365932753113149
 * The option for the `sublist` method to produce an unmodifiable read-through view while a separate method `mutableSublist` produces a write-thorugh view was first brought up here: https://discord.com/channels/571040468092321801/871953739982995547/1103395023845855293