### PR TITLE
Initial methods for Port.Input

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/builtin-dot.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/builtin-dot.rkt
@@ -38,6 +38,7 @@
      [(path? v) path-method-table]
      [(srcloc? v) srcloc-method-table]
      [(exn? v) (get-exn-method-table v)]
+     [(input-port? v) input-port-method-table]
      [(output-port? v) output-port-method-table]
      [(box? v) box-method-table]
      [(mutable-treelist? v) mutable-treelist-method-table]

--- a/rhombus-lib/rhombus/private/amalgam/builtin-dot.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/builtin-dot.rkt
@@ -12,6 +12,7 @@
          (submod "pair.rkt" for-builtin)
          (submod "string.rkt" for-builtin)
          (submod "bytes.rkt" for-builtin)
+         (submod "char.rkt" for-builtin)
          (submod "function.rkt" for-builtin)
          (submod "path-object.rkt" for-builtin)
          (submod "srcloc-object.rkt" for-builtin)
@@ -34,6 +35,7 @@
      [(pair? v) pair-method-table]
      [(string? v) string-method-table]
      [(bytes? v) bytes-method-table]
+     [(char? v) char-method-table]
      [(procedure? v) function-method-table]
      [(path? v) path-method-table]
      [(srcloc? v) srcloc-method-table]

--- a/rhombus-lib/rhombus/private/amalgam/char.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/char.rkt
@@ -10,7 +10,8 @@
          (submod "literal.rkt" for-info)
          (submod "symbol.rkt" for-static-info)
          "realm.rkt"
-         "static-info.rkt")
+         "static-info.rkt"
+         "class-primitive.rkt")
 
 (provide (for-spaces (rhombus/annot
                       rhombus/namespace)
@@ -18,32 +19,30 @@
          (for-space rhombus/annot
                     CharCI))
 
+(module+ for-builtin
+  (provide char-method-table))
+
 (module+ for-static-info
   (provide (for-syntax get-char-static-infos)))
 
-(define-static-info-getter get-char-static-infos
-  (#%compare ((< char<?)
-              (<= char<=?)
-              (= char=?)
-              (!= char!=?)
-              (>= char>=?)
-              (> char>?))))
-
-(define-annotation-syntax Char
-  (identifier-annotation char? #,(get-char-static-infos)))
-(define-annotation-syntax CharCI
-  (identifier-annotation char? ((#%compare ((< char-ci<?)
-                                            (<= char-ci<=?)
-                                            (= char-ci=?)
-                                            (!= char-ci!=?)
-                                            (>= char-ci>=?)
-                                            (> char-ci>?))))
-                         #:static-only))
-
-(define-name-root Char
-  #:fields
+(define-primitive-class Char char
+  #:lift-declaration
+  #:no-constructor-static-info
+  #:instance-static-info ((#%compare ((< char<?)
+                                      (<= char<=?)
+                                      (= char=?)
+                                      (!= char!=?)
+                                      (>= char>=?)
+                                      (> char>?))))
+  #:existing
+  #:opaque
+  #:fields ()
+  #:namespace-fields
+  ([from_int Char.from_int])
+  #:properties
+  ()
+  #:methods
   (to_int
-   from_int
    utf8_length
    is_alphabetic
    is_lowercase
@@ -64,75 +63,107 @@
    titlecase
    grapheme_step))
 
-(define/arity (to_int c)
+(define-annotation-syntax Char (identifier-annotation char? #,(get-char-static-infos)))
+
+(define-annotation-syntax CharCI
+  (identifier-annotation char? ((#%compare ((< char-ci<?)
+                                            (<= char-ci<=?)
+                                            (= char-ci=?)
+                                            (!= char-ci!=?)
+                                            (>= char-ci>=?)
+                                            (> char-ci>?))))
+                         #:static-only))
+
+(define/method (Char.to_int c)
+  #:primitive (char->integer)
   #:static-infos ((#%call-result #,(get-int-static-infos)))
   (char->integer c))
 
-(define/arity (from_int i)
+(define/arity (Char.from_int i)
+  #:primitive (integer->char)
   #:static-infos ((#%call-result #,(get-char-static-infos)))
   (integer->char i))
 
-(define/arity (utf8_length c)
+(define/method (Char.utf8_length c)
+  #:primitive (char-utf-8-length)
   (char-utf-8-length c))
 
-(define/arity (is_alphabetic c)
+(define/method (Char.is_alphabetic c)
+  #:primitive (char-alphabetic?)
   (char-alphabetic? c))
 
-(define/arity (is_lowercase c)
+(define/method (Char.is_lowercase c)
+  #:primitive (char-lower-case?)
   (char-lower-case? c))
 
-(define/arity (is_uppercase c)
+(define/method (Char.is_uppercase c)
+  #:primitive (char-upper-case?)
   (char-upper-case? c))
 
-(define/arity (is_titlecase c)
+(define/method (Char.is_titlecase c)
+  #:primitive (char-title-case?)
   (char-title-case? c))
 
-(define/arity (is_numeric c)
+(define/method (Char.is_numeric c)
+  #:primitive (char-numberic?)
   (char-numeric? c))
 
-(define/arity (is_symbolic c)
+(define/method (Char.is_symbolic c)
+  #:primitive (char-symbolic?)
   (char-symbolic? c))
 
-(define/arity (is_punctuation c)
+(define/method (Char.is_punctuation c)
+  #:primitive (char-punctuation?)
   (char-punctuation? c))
 
-(define/arity (is_graphic c)
+(define/method (Char.is_graphic c)
+  #:primitive (char-graphics?)
   (char-graphic? c))
 
-(define/arity (is_whitespace c)
+(define/method (Char.is_whitespace c)
+  #:primitive (char-whitespace?)
   (char-whitespace? c))
 
-(define/arity (is_blank c)
+(define/method (Char.is_blank c)
+  #:primitive (char-blank?)
   (char-blank? c))
 
-(define/arity (is_extended_pictographic c)
+(define/method (Char.is_extended_pictographic c)
+  #:primitive (char-extended-pictographic?)
   (char-extended-pictographic? c))
 
-(define/arity (general_category c)
+(define/method (Char.general_category c)
+  #:primitive (char-general-category)
   #:static-infos ((#%call-result #,(get-symbol-static-infos)))
   (char-general-category c))
 
-(define/arity (grapheme_break_property c)
+(define/method (Char.grapheme_break_property c)
+  #:primitive (char-grapheme-break-property)
   #:static-infos ((#%call-result #,(get-symbol-static-infos)))
   (char-grapheme-break-property c))
 
-(define/arity (upcase c)
+(define/method (Char.upcase c)
+  #:primitive (char-upcase)
   #:static-infos ((#%call-result #,(get-char-static-infos)))
   (char-upcase c))
 
-(define/arity (downcase c)
+(define/method (Char.downcase c)
+  #:primitive (char-downcase)
   #:static-infos ((#%call-result #,(get-char-static-infos)))
   (char-downcase c))
 
-(define/arity (foldcase c)
+(define/method (Char.foldcase c)
+  #:primitive (char-foldcase)
   #:static-infos ((#%call-result #,(get-char-static-infos)))
   (char-foldcase c))
 
-(define/arity (titlecase c)
+(define/method (Char.titlecase c)
+  #:primitive (char-titlecase)
   #:static-infos ((#%call-result #,(get-char-static-infos)))
   (char-titlecase c))
 
-(define/arity (grapheme_step c state)
+(define/method (Char.grapheme_step c state)
+  #:primitive (char-grapheme-step)
   (char-grapheme-step c state))
 
 (define (char!=? a b)

--- a/rhombus-lib/rhombus/private/amalgam/enum.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/enum.rkt
@@ -1,0 +1,30 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre)
+         (submod "annotation.rkt" for-class)
+         (submod "symbol.rkt" for-static-info)
+         "name-root.rkt")
+
+(provide define-simple-symbol-enum)
+
+(define-syntax (define-simple-symbol-enum stx)
+  (syntax-parse stx
+    [(_ name:id val:id ...)
+     #:with (val-name ...) (generate-temporaries #'(val ...))
+     #:with name? (datum->syntax #'name (string->symbol
+                                         (format "~a?" (syntax-e #'name))))
+     #'(begin
+         (define val-name 'val) ...
+
+         (define (name? v)
+           (and (symbol? v)
+                (case v
+                  [(val ...) #t]
+                  [else #f])))
+
+         (define-annotation-syntax name
+           (identifier-annotation name? #,(get-symbol-static-infos)))
+
+         (define-name-root name
+           #:fields
+           ([val val-name] ...)))]))

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -138,12 +138,12 @@
     [() (open-output-string)]
     [(name) (open-output-string name)]))
 
-(define/method (Port.Input.peek_byte port [skip 0])
+(define/method (Port.Input.peek_byte port #:skip_bytes [skip 0])
   #:inline
   #:primitive (peek-byte)
   (peek-byte port skip))
 
-(define/method (Port.Input.peek_char port [skip 0])
+(define/method (Port.Input.peek_char port #:skip_bytes [skip 0])
   #:inline
   #:primitive (peek-char)
   (peek-char port skip))

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -143,10 +143,10 @@
   #:primitive (peek-byte)
   (peek-byte port skip))
 
-(define/method (Port.Input.peek_char port)
+(define/method (Port.Input.peek_char port [skip 0])
   #:inline
   #:primitive (peek-char)
-  (peek-char port))
+  (peek-char port skip))
 
 (define/method (Port.Input.read_byte port)
   #:inline

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -135,13 +135,18 @@
   #:primitive (read-char)
   (read-char port))
 
+(define (coerce-read-result v)
+  (cond
+    [(string? v) (string->immutable-string v)]
+    [else v]))
+
 (define/method Port.Input.read_line
   #:inline
   #:primitive (read-line)
   (case-lambda
-    [(port) (string->immutable-string (read-line port))]
+    [(port) (coerce-read-result (read-line port))]
     [(port mode)
-     (string->immutable-string
+     (coerce-read-result
       (read-line port
                  (case/eq mode
                   [(return_linefeed) 'return-linefeed]

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -1,14 +1,18 @@
 #lang racket/base
-(require (for-syntax racket/base)
+(require (for-syntax racket/base
+                     racket/syntax)
          racket/case
+         syntax/parse/define
          "provide.rkt"
          (submod "annotation.rkt" for-class)
          "call-result-key.rkt"
          "function-arity-key.rkt"
          (submod "bytes.rkt" static-infos)
          (submod "string.rkt" static-infos)
+         (submod "symbol.rkt" for-static-info)
          "static-info.rkt"
          "define-arity.rkt"
+         "name-root.rkt"
          (submod "function.rkt" for-info)
          "class-primitive.rkt"
          "realm.rkt")
@@ -18,6 +22,29 @@
                      Port))
 
 (define-annotation-syntax EOF (identifier-annotation eof-object? ()))
+
+(define-syntax-parse-rule (define-simple-symbol-enum name:id vals:id ...)
+  #:with (val-names ...) (for/list ([v (attribute vals)])
+                           (format-id v "~a.~a" #'name v))
+  #:with name? (format-id #'name "~a?" #'name)
+  (begin
+    (define val-names 'vals) ...
+
+    (define (name? v)
+      (and (symbol? v)
+           (case/eq v
+             [(vals ...) #t]
+             [else #f])))
+
+    (define-annotation-syntax name
+      (identifier-annotation name? #,(get-symbol-static-infos)))
+
+    (define-name-root name
+      #:fields
+      ([vals val-names] ...))))
+
+(define-simple-symbol-enum ReadLineMode
+  any any_one linefeed return return_linefeed)
 
 (module+ for-builtin
   (provide input-port-method-table
@@ -32,6 +59,7 @@
    Output
    EOF
    eof
+   ReadLineMode
    ;; TEMP see `Input` and `Output`
    [current_input current-input-port]
    [current_output current-output-port]

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -76,17 +76,21 @@
   (#%function-arity 3)
   . #,(get-function-static-infos))
 
-(define/arity (Port.Input.open_bytes bstr)
+(define/arity Port.Input.open_bytes
   #:inline
   #:primitive (open-input-bytes)
   #:static-infos ((#%call-result #,(get-input-port-static-infos)))
-  (open-input-bytes bstr))
+  (case-lambda
+    [(bstr) (open-input-bytes bstr)]
+    [(bstr name) (open-input-bytes bstr name)]))
 
-(define/arity (Port.Input.open_string str)
+(define/arity Port.Input.open_string
   #:inline
   #:primitive (open-input-string)
   #:static-infos ((#%call-result #,(get-input-port-static-infos)))
-  (open-input-string str))
+  (case-lambda
+    [(str) (open-input-string str)]
+    [(str name) (open-input-string str name)]))
 
 ;; TODO these need a more specific annotation
 (define/arity Port.Output.open_bytes

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -123,7 +123,7 @@
 (define/method (Port.Input.read_bytes port amt)
   #:inline
   #:primitive (read-bytes)
-  (bytes->immutable-bytes (read-bytes amt port)))
+  (read-bytes amt port))
 
 (define/method (Port.Input.read_char port)
   #:inline

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -17,7 +17,7 @@
                       rhombus/namespace)
                      Port))
 
-(define-annotation-syntax Eof (identifier-annotation eof-object? ()))
+(define-annotation-syntax EOF (identifier-annotation eof-object? ()))
 
 (module+ for-builtin
   (provide input-port-method-table
@@ -30,7 +30,7 @@
   #:namespace-fields
   (Input
    Output
-   Eof
+   EOF
    eof
    ;; TEMP see `Input` and `Output`
    [current_input current-input-port]

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -53,7 +53,8 @@
    [peek_char Port.Input.peek_char]
    [read_byte Port.Input.read_byte]
    [read_bytes Port.Input.read_bytes]
-   [read_char Port.Input.read_char]))
+   [read_char Port.Input.read_char]
+   [read_line Port.Input.read_line]))
 
 (define-primitive-class Output output-port
   #:lift-declaration
@@ -128,6 +129,11 @@
   #:inline
   #:primitive (read-char)
   (read-char port))
+
+(define/method (Port.Input.read_line port [mode 'linefeed])
+  #:inline
+  #:primitive (read-line)
+  (string->immutable-string (read-line port mode)))
 
 (define/method (Port.Output.get_bytes port)
   #:inline

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -172,7 +172,7 @@
   #:inline
   #:primitive (read-line)
   (case-lambda
-    [(port) (coerce-read-result (read-line port))]
+    [(port) (coerce-read-result (read-line port 'any))]
     [(port mode)
      (coerce-read-result
       (read-line port

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -14,8 +14,7 @@
 
 (provide (for-spaces (rhombus/annot
                       rhombus/namespace)
-                     Port)
-         (for-space rhombus/annot Eof))
+                     Port))
 
 (define-annotation-syntax Eof (identifier-annotation eof-object? ()))
 
@@ -30,6 +29,7 @@
   #:namespace-fields
   (Input
    Output
+   Eof
    eof
    ;; TEMP see `Input` and `Output`
    [current_input current-input-port]

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -151,6 +151,10 @@
   (case-lambda
     [(port) (coerce-read-result (read-line port 'any))]
     [(port mode)
+     (unless (ReadLineMode? mode)
+       (unless (input-port? port)
+         (raise-argument-error* who rhombus-realm "Port.Input" port))
+       (raise-argument-error* who rhombus-realm "Port.Input.ReadLineMode" mode))
      (coerce-read-result
       (read-line port
                  (case mode

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
 (require (for-syntax racket/base)
+         racket/case
          "provide.rkt"
          (submod "annotation.rkt" for-class)
          "call-result-key.rkt"
@@ -134,10 +135,18 @@
   #:primitive (read-char)
   (read-char port))
 
-(define/method (Port.Input.read_line port [mode 'linefeed])
+(define/method Port.Input.read_line
   #:inline
   #:primitive (read-line)
-  (string->immutable-string (read-line port mode)))
+  (case-lambda
+    [(port) (string->immutable-string (read-line port))]
+    [(port mode)
+     (string->immutable-string
+      (read-line port
+                 (case/eq mode
+                  [(return_linefeed) 'return-linefeed]
+                  [(any_one) 'any-one]
+                  [else mode])))]))
 
 (define/method (Port.Output.get_bytes port)
   #:inline

--- a/rhombus-lib/rhombus/private/amalgam/print.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/print.rkt
@@ -136,6 +136,8 @@
     [(and (identifier? v)
           (display?))
      (display (syntax->datum v) op)]
+    [(eof-object? v)
+     (display "Port.eof" op)]
     [(namespace? v) (display "#<evaluator>" op)]
     [else (other v mode op)]))
 

--- a/rhombus/rhombus/scribblings/ref-char.scrbl
+++ b/rhombus/rhombus/scribblings/ref-char.scrbl
@@ -11,6 +11,30 @@ A @deftech{character} is Unicode code point.
 Characters are @tech{comparable}, which means that generic operations
 like @rhombus(<) and @rhombus(>) work on characters.
 
+@dispatch_table(
+  "character"
+  Char
+  ch.to_int()
+  ch.upcase()
+  ch.downcase()
+  ch.foldcase()
+  ch.titlecase()
+  ch.is_alphabetic()
+  ch.is_lowercase()
+  ch.is_uppercase()
+  ch.is_titlecase()
+  ch.is_numeric()
+  ch.is_symbolic()
+  ch.is_punctuation()
+  ch.is_graphic()
+  ch.is_whitespace()
+  ch.is_blank()
+  ch.is_extended_pictographic()
+  ch.general_category()
+  ch.grapheme_break_property()
+  ch.grapheme_step(state)
+)
+
 @doc(
   annot.macro 'Char'
 ){

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -9,6 +9,17 @@ connection, terminal, etc. An @deftech{input port} is specifically for
 input, while an @deftech{output port} is specifically for output.
 
 @dispatch_table(
+  "input port"
+  Port.Input
+  in.peek_byte(arg, ...)
+  in.peek_char(arg, ...)
+  in.read_byte()
+  in.read_bytes(arg, ...)
+  in.read_char()
+  in.read_line(arg, ...)
+)
+
+@dispatch_table(
   "output port"
   Port.Output
   out.get_bytes()
@@ -94,6 +105,19 @@ input, while an @deftech{output port} is specifically for output.
 
 }
 
+@doc(
+  fun Port.Input.open_bytes(bstr :: Bytes) :: Port.Input
+  fun Port.Input.open_string(str :: ReadableString) :: Port.Input
+){}
+
+@doc(
+  fun Port.Input.peek_byte(in :: Port.Input, skip :: NonnegInt = 0) :: Byte || Eof
+  fun Port.Input.peek_char(in :: Port.Input, skip :: NonnegInt = 0) :: Char || Eof
+  fun Port.Input.read_byte(in :: Port.Input) :: Byte || Eof
+  fun Port.Input.read_bytes(in :: Port.Input, amount :: NonnegInt) :: Bytes || Eof
+  fun Port.Input.read_char(in :: Port.Input) :: Char || Eof
+  fun Port.Input.read_line(in :: Port.Input, mode :: Symbol = #'linefeed) :: String || Eof
+){}
 
 @doc(
   fun Port.Output.open_bytes(name :: Symbol) :: Port.Output

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -114,17 +114,21 @@ input, while an @deftech{output port} is specifically for output.
 }
 
 @doc(
-  fun Port.Input.open_bytes(bstr :: Bytes) :: Port.Input
+  fun Port.Input.open_bytes(bstr :: Bytes,
+                            name :: Symbol = #'string) :: Port.Input
 ){
  Creates an @tech{input port} that reads bytes from @rhombus(bstr), a
- @tech{byte string}.
+ @tech{byte string}.  The optional @rhombus(name) is used as the name for the
+ returned port.
 }
 
 @doc(
-  fun Port.Input.open_string(str :: ReadableString) :: Port.Input
+  fun Port.Input.open_string(str :: ReadableString,
+                             name :: Symbol = #'string) :: Port.Input
 ){
  Creates an @tech{input port} that reads @tech{characters} from @rhombus(str), a
- @tech{string}.
+ @tech{string}.  The optional @rhombus(name) is used as the name for the
+ returned port.
 }
 
 @doc(

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -134,7 +134,8 @@ input, while an @deftech{output port} is specifically for output.
 
 @doc(
   fun Port.Input.peek_byte(in :: Port.Input,
-                           skip :: NonnegInt = 0) :: Byte || Port.EOF
+                           ~skip_bytes: skip :: NonnegInt = 0)
+    :: Byte || Port.EOF
 ){
  Like @rhombus(Port.Input.read_byte), but peeks instead of reading, and skips
  @rhombus(skip) bytes at the start of the port.
@@ -142,7 +143,8 @@ input, while an @deftech{output port} is specifically for output.
 
 @doc(
   fun Port.Input.peek_char(in :: Port.Input,
-                           skip :: NonnegInt = 0) :: Char || Port.EOF
+                           ~skip_bytes: skip :: NonnegInt = 0)
+    :: Char || Port.EOF
 ){
  Like @rhombus(Port.Input.read_char), but peeks instead of reading, and skips
  @rhombus(skip) bytes (not characters) at the start of the port.

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -181,7 +181,7 @@ input, while an @deftech{output port} is specifically for output.
 
 @doc(
   fun Port.Input.read_line(in :: Port.Input,
-                           mode :: ReadLineMode = ReadLineMode.any)
+                           mode :: Port.ReadLineMode = #'any)
     :: String || Port.EOF
 ){
  Returns a string containing the next line of characters from @rhombus(in).
@@ -197,28 +197,28 @@ input, while an @deftech{output port} is specifically for output.
 
  @itemlist(
    @item{
-     @rhombus(Port.ReadLineMode.linefeed) breaks lines on linefeed characters.
+     @rhombus(#'linefeed) breaks lines on linefeed characters.
    }
 
    @item{
-     @rhombus(Port.ReadLineMode.return) breaks lines on return characters.
+     @rhombus(#'return) breaks lines on return characters.
    }
 
    @item{
-     @rhombus(Port.ReadLineMode.return_linefeed) breaks lines on
+     @rhombus(#'return_linefeed) breaks lines on
      return-linefeed combinations.  If a return character is not followed by a
      linefeed character, it is included in the result string; similarly, a
      linefeed that is not preceded by a return is included in the result string.
    }
 
    @item{
-     @rhombus(Port.ReadLineMode.any) breaks lines on any of a return character,
+     @rhombus(#'any) breaks lines on any of a return character,
      linefeed character, or return-linefeed combination. If a return character
      is followed by a linefeed character, the two are treated as a combination.
    }
 
    @item{
-     @rhombus(Port.ReadLineMode.any_one) breaks lines on either a return or
+     @rhombus(#'any_one) breaks lines on either a return or
      linefeed character, without recognizing return-linefeed combinations.
    }
  )
@@ -232,7 +232,7 @@ input, while an @deftech{output port} is specifically for output.
     any
     any_one
 ){
- Line reading modes.
+ Line reading modes for @rhombus(Port.Input.read_line).
 }
 
 @doc(

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -31,7 +31,7 @@ input, while an @deftech{output port} is specifically for output.
   annot.macro 'Port'
   annot.macro 'Port.Input'
   annot.macro 'Port.Output'
-  annot.macro 'Eof'
+  annot.macro 'Port.Eof'
 ){
 
  The @rhombus(Port, ~annot) annotation is satisified by a @tech{port}.
@@ -39,7 +39,7 @@ input, while an @deftech{output port} is specifically for output.
  recognizes input ports specifically, while @rhombus(Port.Output, ~annot)
  recognizes output ports, and it is possible for a port to be both.
 
- The @rhombus(Eof, ~annot) annotation is satisfied by the @rhombus(Eof.eof) value.
+ The @rhombus(Port.Eof, ~annot) annotation is satisfied by the @rhombus(Port.eof) value.
 }
 
 @doc(
@@ -99,6 +99,12 @@ input, while an @deftech{output port} is specifically for output.
 
 
 @doc(
+ def Port.eof :: Eof
+){
+ A value (distinct from all other values) that represents an end-of-file.
+}
+
+@doc(
   Parameter.def Port.Output.current_error :: Port.Output
 ){
 
@@ -123,7 +129,7 @@ input, while an @deftech{output port} is specifically for output.
 
 @doc(
   fun Port.Input.peek_byte(in :: Port.Input,
-                           skip :: NonnegInt = 0) :: Byte || Eof
+                           skip :: NonnegInt = 0) :: Byte || Port.Eof
 ){
  Like @rhombus(Port.Input.read_byte), but peeks instead of reading, and skips
  @rhombus(skip) bytes at the start of the port.
@@ -131,22 +137,22 @@ input, while an @deftech{output port} is specifically for output.
 
 @doc(
   fun Port.Input.peek_char(in :: Port.Input,
-                           skip :: NonnegInt = 0) :: Char || Eof
+                           skip :: NonnegInt = 0) :: Char || Port.Eof
 ){
  Like @rhombus(Port.Input.read_char), but peeks instead of reading, and skips
  @rhombus(skip) bytes (not characters) at the start of the port.
 }
 
 @doc(
-  fun Port.Input.read_byte(in :: Port.Input) :: Byte || Eof
+  fun Port.Input.read_byte(in :: Port.Input) :: Byte || Port.Eof
 ){
  Reads a single byte from @rhombus(in).  If no bytes are available before and
- end-of-file, then @rhombus(Eof.eof) is returned.
+ end-of-file, then @rhombus(Port.eof) is returned.
 }
 
 @doc(
   fun Port.Input.read_bytes(in :: Port.Input,
-                            amount :: NonnegInt) :: Bytes || Eof
+                            amount :: NonnegInt) :: Bytes || Port.Eof
 ){
  Reads a @tech{byte string} containing the next @rhombus(amount) bytes from
  @rhombus(in).  If @rhombus(amount) is 0, then an empty byte string is returned.
@@ -154,17 +160,62 @@ input, while an @deftech{output port} is specifically for output.
  end-of-file is encountered, then the returned byte string will contain only
  those bytes before the end-of-file; that is, the returned byte string's length
  will be less than @rhombus(amount).  If no bytes are available before an
- end-of-file, then @rhombus(Eof.eof) is returned.
+ end-of-file, then @rhombus(Port.eof) is returned.
 }
 
 @doc(
-  fun Port.Input.read_char(in :: Port.Input) :: Char || Eof
-){}
+  fun Port.Input.read_char(in :: Port.Input) :: Char || Port.Eof
+){
+ Reads a single character from @rhombus(in) - which may involve reading several
+ bytes to UTF-8-decode them into a character; a minimal number of bytes are
+ read/peeked to perform the decoding. If no bytes are available before an
+ end-of-file, then @rhombus(Port.eof) is returned.
+}
 
 @doc(
   fun Port.Input.read_line(in :: Port.Input,
-                           mode :: Symbol = #'linefeed) :: String || Eof
-){}
+                           mode :: Symbol
+                                     = #'linefeed
+                                     || #'return
+                                     || #'#{return-linefeed}
+                                     || #'any
+                                     || #'#{any-one}) :: String || Port.Eof
+){
+ Returns a string containing the next line of characters from @rhombus(in).
+
+ Characters are read from @rhombus(in) until a line separator or an
+ end-of-file is read. The line separator is not included in the result
+ string (but it is removed from the port's stream). If no characters
+ are read before an end-of-file is encountered, @rhombus(Port.eof) is
+ returned.
+
+ The @rhombus(mode) argument determines the line separator(s). It must be one of
+ the following symbols:
+
+ @itemlist(
+   @item{@rhombus(#'linefeed) breaks lines on linefeed characters.}
+
+   @item{@rhombus(#'return) breaks lines on return characters.}
+
+   @item{
+     @rhombus(#'#{return-linefeed}) breaks lines on return-linefeed combinations.
+     If a return character is not followed by a linefeed character, it is
+     included in the result string; similarly, a linefeed that is not preceded
+     by a return is included in the result string.
+   }
+
+   @item{
+     @rhombus(#'any) breaks lines on any of a return character, linefeed
+     character, or return-linefeed combination. If a return character is
+     followed by a linefeed character, the two are treated as a combination.
+   }
+
+   @item{
+     @rhombus(#'#{any-one}) breaks lines on either a return or linefeed
+     character, without recognizing return-linefeed combinations.
+   }
+ )
+}
 
 @doc(
   fun Port.Output.open_bytes(name :: Symbol) :: Port.Output

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -181,9 +181,9 @@ input, while an @deftech{output port} is specifically for output.
                            mode :: Symbol
                                      = #'linefeed
                                      || #'return
-                                     || #'#{return-linefeed}
+                                     || #'return_linefeed
                                      || #'any
-                                     || #'#{any-one}) :: String || Port.Eof
+                                     || #'any_one) :: String || Port.Eof
 ){
  Returns a string containing the next line of characters from @rhombus(in).
 
@@ -202,7 +202,7 @@ input, while an @deftech{output port} is specifically for output.
    @item{@rhombus(#'return) breaks lines on return characters.}
 
    @item{
-     @rhombus(#'#{return-linefeed}) breaks lines on return-linefeed combinations.
+     @rhombus(#'return_linefeed) breaks lines on return-linefeed combinations.
      If a return character is not followed by a linefeed character, it is
      included in the result string; similarly, a linefeed that is not preceded
      by a return is included in the result string.
@@ -215,7 +215,7 @@ input, while an @deftech{output port} is specifically for output.
    }
 
    @item{
-     @rhombus(#'#{any-one}) breaks lines on either a return or linefeed
+     @rhombus(#'any_one) breaks lines on either a return or linefeed
      character, without recognizing return-linefeed combinations.
    }
  )

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -31,7 +31,7 @@ input, while an @deftech{output port} is specifically for output.
   annot.macro 'Port'
   annot.macro 'Port.Input'
   annot.macro 'Port.Output'
-  annot.macro 'Port.Eof'
+  annot.macro 'Port.EOF'
 ){
 
  The @rhombus(Port, ~annot) annotation is satisified by a @tech{port}.
@@ -39,7 +39,7 @@ input, while an @deftech{output port} is specifically for output.
  recognizes input ports specifically, while @rhombus(Port.Output, ~annot)
  recognizes output ports, and it is possible for a port to be both.
 
- The @rhombus(Port.Eof, ~annot) annotation is satisfied by the @rhombus(Port.eof) value.
+ The @rhombus(Port.EOF, ~annot) annotation is satisfied by the @rhombus(Port.eof) value.
 }
 
 @doc(
@@ -99,7 +99,7 @@ input, while an @deftech{output port} is specifically for output.
 
 
 @doc(
- def Port.eof :: Eof
+ def Port.eof :: Port.EOF
 ){
  A value (distinct from all other values) that represents an end-of-file.
 }
@@ -133,7 +133,7 @@ input, while an @deftech{output port} is specifically for output.
 
 @doc(
   fun Port.Input.peek_byte(in :: Port.Input,
-                           skip :: NonnegInt = 0) :: Byte || Port.Eof
+                           skip :: NonnegInt = 0) :: Byte || Port.EOF
 ){
  Like @rhombus(Port.Input.read_byte), but peeks instead of reading, and skips
  @rhombus(skip) bytes at the start of the port.
@@ -141,14 +141,14 @@ input, while an @deftech{output port} is specifically for output.
 
 @doc(
   fun Port.Input.peek_char(in :: Port.Input,
-                           skip :: NonnegInt = 0) :: Char || Port.Eof
+                           skip :: NonnegInt = 0) :: Char || Port.EOF
 ){
  Like @rhombus(Port.Input.read_char), but peeks instead of reading, and skips
  @rhombus(skip) bytes (not characters) at the start of the port.
 }
 
 @doc(
-  fun Port.Input.read_byte(in :: Port.Input) :: Byte || Port.Eof
+  fun Port.Input.read_byte(in :: Port.Input) :: Byte || Port.EOF
 ){
  Reads a single byte from @rhombus(in).  If no bytes are available before and
  end-of-file, then @rhombus(Port.eof) is returned.
@@ -156,7 +156,7 @@ input, while an @deftech{output port} is specifically for output.
 
 @doc(
   fun Port.Input.read_bytes(in :: Port.Input,
-                            amount :: NonnegInt) :: Bytes || Port.Eof
+                            amount :: NonnegInt) :: Bytes || Port.EOF
 ){
  Reads a @tech{byte string} containing the next @rhombus(amount) bytes from
  @rhombus(in).  If @rhombus(amount) is 0, then an empty byte string is returned.
@@ -168,7 +168,7 @@ input, while an @deftech{output port} is specifically for output.
 }
 
 @doc(
-  fun Port.Input.read_char(in :: Port.Input) :: Char || Port.Eof
+  fun Port.Input.read_char(in :: Port.Input) :: Char || Port.EOF
 ){
  Reads a single character from @rhombus(in) - which may involve reading several
  bytes to UTF-8-decode them into a character; a minimal number of bytes are
@@ -183,7 +183,7 @@ input, while an @deftech{output port} is specifically for output.
                                      || #'return
                                      || #'return_linefeed
                                      || #'any
-                                     || #'any_one) :: String || Port.Eof
+                                     || #'any_one) :: String || Port.EOF
 ){
  Returns a string containing the next line of characters from @rhombus(in).
 

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -31,6 +31,7 @@ input, while an @deftech{output port} is specifically for output.
   annot.macro 'Port'
   annot.macro 'Port.Input'
   annot.macro 'Port.Output'
+  annot.macro 'Eof'
 ){
 
  The @rhombus(Port, ~annot) annotation is satisified by a @tech{port}.
@@ -38,6 +39,7 @@ input, while an @deftech{output port} is specifically for output.
  recognizes input ports specifically, while @rhombus(Port.Output, ~annot)
  recognizes output ports, and it is possible for a port to be both.
 
+ The @rhombus(Eof, ~annot) annotation is satisfied by the @rhombus(Eof.eof) value.
 }
 
 @doc(
@@ -107,16 +109,61 @@ input, while an @deftech{output port} is specifically for output.
 
 @doc(
   fun Port.Input.open_bytes(bstr :: Bytes) :: Port.Input
+){
+ Creates an @tech{input port} that reads bytes from @rhombus(bstr), a
+ @tech{byte string}.
+}
+
+@doc(
   fun Port.Input.open_string(str :: ReadableString) :: Port.Input
+){
+ Creates an @tech{input port} that reads @tech{characters} from @rhombus(str), a
+ @tech{string}.
+}
+
+@doc(
+  fun Port.Input.peek_byte(in :: Port.Input,
+                           skip :: NonnegInt = 0) :: Byte || Eof
+){
+ Like @rhombus(Port.Input.read_byte), but peeks instead of reading, and skips
+ @rhombus(skip) bytes at the start of the port.
+}
+
+@doc(
+  fun Port.Input.peek_char(in :: Port.Input,
+                           skip :: NonnegInt = 0) :: Char || Eof
+){
+ Like @rhombus(Port.Input.read_char), but peeks instead of reading, and skips
+ @rhombus(skip) bytes (not characters) at the start of the port.
+}
+
+@doc(
+  fun Port.Input.read_byte(in :: Port.Input) :: Byte || Eof
+){
+ Reads a single byte from @rhombus(in).  If no bytes are available before and
+ end-of-file, then @rhombus(Eof.eof) is returned.
+}
+
+@doc(
+  fun Port.Input.read_bytes(in :: Port.Input,
+                            amount :: NonnegInt) :: Bytes || Eof
+){
+ Reads a @tech{byte string} containing the next @rhombus(amount) bytes from
+ @rhombus(in).  If @rhombus(amount) is 0, then an empty byte string is returned.
+ Otherwise if fewer than @rhombus(amount) bytes are available before an
+ end-of-file is encountered, then the returned byte string will contain only
+ those bytes before the end-of-file; that is, the returned byte string's length
+ will be less than @rhombus(amount).  If no bytes are available before an
+ end-of-file, then @rhombus(Eof.eof) is returned.
+}
+
+@doc(
+  fun Port.Input.read_char(in :: Port.Input) :: Char || Eof
 ){}
 
 @doc(
-  fun Port.Input.peek_byte(in :: Port.Input, skip :: NonnegInt = 0) :: Byte || Eof
-  fun Port.Input.peek_char(in :: Port.Input, skip :: NonnegInt = 0) :: Char || Eof
-  fun Port.Input.read_byte(in :: Port.Input) :: Byte || Eof
-  fun Port.Input.read_bytes(in :: Port.Input, amount :: NonnegInt) :: Bytes || Eof
-  fun Port.Input.read_char(in :: Port.Input) :: Char || Eof
-  fun Port.Input.read_line(in :: Port.Input, mode :: Symbol = #'linefeed) :: String || Eof
+  fun Port.Input.read_line(in :: Port.Input,
+                           mode :: Symbol = #'linefeed) :: String || Eof
 ){}
 
 @doc(

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -170,10 +170,10 @@ input, while an @deftech{output port} is specifically for output.
 @doc(
   fun Port.Input.read_char(in :: Port.Input) :: Char || Port.EOF
 ){
- Reads a single character from @rhombus(in) - which may involve reading several
- bytes to UTF-8-decode them into a character; a minimal number of bytes are
- read/peeked to perform the decoding. If no bytes are available before an
- end-of-file, then @rhombus(Port.eof) is returned.
+ Reads a single character from @rhombus(in) --- which may involve reading
+ several bytes to UTF-8-decode them into a character; a minimal number of
+ bytes are read/peeked to perform the decoding. If no bytes are available
+ before an end-of-file, then @rhombus(Port.eof) is returned.
 }
 
 @doc(

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -39,7 +39,8 @@ input, while an @deftech{output port} is specifically for output.
  recognizes input ports specifically, while @rhombus(Port.Output, ~annot)
  recognizes output ports, and it is possible for a port to be both.
 
- The @rhombus(Port.EOF, ~annot) annotation is satisfied by the @rhombus(Port.eof) value.
+ The @rhombus(Port.EOF, ~annot) annotation is satisfied by the
+ @rhombus(Port.eof) value.
 }
 
 @doc(
@@ -126,8 +127,8 @@ input, while an @deftech{output port} is specifically for output.
   fun Port.Input.open_string(str :: ReadableString,
                              name :: Symbol = #'string) :: Port.Input
 ){
- Creates an @tech{input port} that reads @tech{characters} from @rhombus(str), a
- @tech{string}.  The optional @rhombus(name) is used as the name for the
+ Creates an @tech{input port} that reads @tech{characters} from @rhombus(str),
+ a @tech{string}.  The optional @rhombus(name) is used as the name for the
  returned port.
 }
 
@@ -189,8 +190,8 @@ input, while an @deftech{output port} is specifically for output.
  are read before an end-of-file is encountered, @rhombus(Port.eof) is
  returned.
 
- The @rhombus(mode) argument determines the line separator(s). It must be one of
- the following symbols:
+ The @rhombus(mode) argument determines the line separator(s). It must be one
+ of the following symbols:
 
  @itemlist(
    @item{

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -178,12 +178,8 @@ input, while an @deftech{output port} is specifically for output.
 
 @doc(
   fun Port.Input.read_line(in :: Port.Input,
-                           mode :: Symbol
-                                     = #'linefeed
-                                     || #'return
-                                     || #'return_linefeed
-                                     || #'any
-                                     || #'any_one) :: String || Port.EOF
+                           mode :: ReadLineMode = ReadLineMode.any)
+    :: String || Port.EOF
 ){
  Returns a string containing the next line of characters from @rhombus(in).
 
@@ -197,28 +193,43 @@ input, while an @deftech{output port} is specifically for output.
  the following symbols:
 
  @itemlist(
-   @item{@rhombus(#'linefeed) breaks lines on linefeed characters.}
-
-   @item{@rhombus(#'return) breaks lines on return characters.}
-
    @item{
-     @rhombus(#'return_linefeed) breaks lines on return-linefeed combinations.
-     If a return character is not followed by a linefeed character, it is
-     included in the result string; similarly, a linefeed that is not preceded
-     by a return is included in the result string.
+     @rhombus(Port.ReadLineMode.linefeed) breaks lines on linefeed characters.
    }
 
    @item{
-     @rhombus(#'any) breaks lines on any of a return character, linefeed
-     character, or return-linefeed combination. If a return character is
-     followed by a linefeed character, the two are treated as a combination.
+     @rhombus(Port.ReadLineMode.return) breaks lines on return characters.
    }
 
    @item{
-     @rhombus(#'any_one) breaks lines on either a return or linefeed
-     character, without recognizing return-linefeed combinations.
+     @rhombus(Port.ReadLineMode.return_linefeed) breaks lines on
+     return-linefeed combinations.  If a return character is not followed by a
+     linefeed character, it is included in the result string; similarly, a
+     linefeed that is not preceded by a return is included in the result string.
+   }
+
+   @item{
+     @rhombus(Port.ReadLineMode.any) breaks lines on any of a return character,
+     linefeed character, or return-linefeed combination. If a return character
+     is followed by a linefeed character, the two are treated as a combination.
+   }
+
+   @item{
+     @rhombus(Port.ReadLineMode.any_one) breaks lines on either a return or
+     linefeed character, without recognizing return-linefeed combinations.
    }
  )
+}
+
+@doc(
+  enum Port.ReadLineMode:
+    linefeed
+    return
+    return_linefeed
+    any
+    any_one
+){
+ Line reading modes.
 }
 
 @doc(

--- a/rhombus/rhombus/tests/char.rhm
+++ b/rhombus/rhombus/tests/char.rhm
@@ -49,6 +49,10 @@ check:
   Char.titlecase("a"[0]) ~is "A"[0]
   Char.grapheme_step("a"[0], 0) ~is values(#false, 1)
 
+block:
+  use_static
+  check Char.from_int(10).to_int() ~is 10
+
 check:
   ~eval
   "a"[0] :: CharCI

--- a/rhombus/rhombus/tests/port.rhm
+++ b/rhombus/rhombus/tests/port.rhm
@@ -1,4 +1,4 @@
-#lang rhombus
+#lang rhombus/static
 
 block:
   import "static_arity.rhm"
@@ -19,3 +19,45 @@ block:
     Port.Output.flush([out]) ~method
     Port.Output.current([out])
     Port.Output.current_error([out])
+
+block:
+  let p = Port.Input.open_string("abλcdefμ")
+  check p.peek_byte() ~is "a"[0].to_int()
+  check p.peek_byte(~skip_bytes: 1) ~is "b"[0].to_int()
+  check p.read_byte() ~is "a"[0].to_int()
+  check p.peek_byte(~skip_bytes: 3) ~is "c"[0].to_int()
+  check p.peek_char() ~is "b"[0]
+  check p.peek_char(~skip_bytes: 1) ~is "λ"[0]
+  check p.peek_char(~skip_bytes: 3) ~is "c"[0]
+  check p.read_char() ~is "b"[0]
+  check p.read_char() ~is "λ"[0]
+  check p.peek_char() ~is "c"[0]
+  check p.read_bytes(2) ~is_now #"cd".copy()
+  // check p.read_string(2) ~is "fμ"
+
+block:
+  def str = "a\nb\rc\r\nd\n\re"
+  fun read_many(mode):
+    let p = Port.Input.open_string(str)
+    fun read():
+      if mode
+      | p.read_line(mode)
+      | p.read_line()
+    [read(),
+     read(),
+     read(),
+     read(),
+     read(),
+     read(),
+     read()]     
+  check read_many(#'any) ~is ["a", "b", "c", "d", "", "e", Port.eof]  
+  check read_many(#false) ~is read_many(#'any)
+  check read_many(#'linefeed) ~is ["a", "b\rc\r", "d", "\re", Port.eof, Port.eof, Port.eof]
+  check read_many(#'backward) ~throws "Port.Input.ReadLineMode"
+
+block:
+  let p = Port.Output.open_bytes()
+  print("x", p)
+  check p.get_bytes() ~is_now #"x".copy()
+  check p.get_string() ~is "x"
+  check p.flush() ~is #void

--- a/rhombus/rhombus/tests/port.rhm
+++ b/rhombus/rhombus/tests/port.rhm
@@ -4,6 +4,14 @@ block:
   import "static_arity.rhm"
   static_arity.check:
     Port.Input.current([in])
+    Port.Input.open_bytes(bstr)
+    Port.Input.open_string(str)
+    Port.Input.peek_byte(in, [skip])
+    Port.Input.peek_char(in, [skip])
+    Port.Input.read_byte(in)
+    Port.Input.read_bytes(in, amount)
+    Port.Input.read_char(in)
+    Port.Input.read_line(in, [mode])
     Port.Output.open_bytes([name])
     Port.Output.open_string([name])
     Port.Output.get_bytes(out) ~method

--- a/rhombus/rhombus/tests/port.rhm
+++ b/rhombus/rhombus/tests/port.rhm
@@ -4,8 +4,8 @@ block:
   import "static_arity.rhm"
   static_arity.check:
     Port.Input.current([in])
-    Port.Input.open_bytes(bstr)
-    Port.Input.open_string(str)
+    Port.Input.open_bytes(bstr, [name])
+    Port.Input.open_string(str, [name])
     Port.Input.peek_byte(in, [skip])
     Port.Input.peek_char(in, [skip])
     Port.Input.read_byte(in)


### PR DESCRIPTION
A few initial methods for reading from `Port.Input`.  Documentation adjusted from the associated Racket functions.  The functions all have a required `Port.Input` argument, unlike the Racket equivalents which use a default parameter.