### PR TITLE
More Port.Input methods

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -51,11 +51,14 @@
   #:properties ()
   #:methods
   ([peek_byte Port.Input.peek_byte]
+   [peek_bytes Port.Input.peek_bytes]
    [peek_char Port.Input.peek_char]
+   [peek_string Port.Input.peek_string]
    [read_byte Port.Input.read_byte]
    [read_bytes Port.Input.read_bytes]
    [read_char Port.Input.read_char]
-   [read_line Port.Input.read_line]))
+   [read_line Port.Input.read_line]
+   [read_string Port.Input.read_string]))
 
 (define-primitive-class Output output-port
   #:lift-declaration
@@ -115,15 +118,31 @@
     [() (open-output-string)]
     [(name) (open-output-string name)]))
 
+(define (coerce-read-result v)
+  (cond
+    [(string? v) (string->immutable-string v)]
+    [else v]))
+
 (define/method (Port.Input.peek_byte port #:skip_bytes [skip 0])
   #:inline
   #:primitive (peek-byte)
   (peek-byte port skip))
 
+(define/method (Port.Input.peek_bytes port amt #:skip_bytes [skip 0])
+  #:inline
+  #:primitive (peek-bytes)
+  (peek-bytes amt skip port))
+
 (define/method (Port.Input.peek_char port #:skip_bytes [skip 0])
   #:inline
   #:primitive (peek-char)
   (peek-char port skip))
+
+(define/method (Port.Input.peek_string port amt #:skip_bytes [skip 0])
+  #:inline
+  #:primitive (peek-bytes)
+  (coerce-read-result
+   (peek-string amt skip port)))
 
 (define/method (Port.Input.read_byte port)
   #:inline
@@ -140,10 +159,6 @@
   #:primitive (read-char)
   (read-char port))
 
-(define (coerce-read-result v)
-  (cond
-    [(string? v) (string->immutable-string v)]
-    [else v]))
 
 (define/method Port.Input.read_line
   #:inline
@@ -161,6 +176,11 @@
                    [(return_linefeed) 'return-linefeed]
                    [(any_one) 'any-one]
                    [else mode])))]))
+
+(define/method (Port.Input.read_string port amt)
+  #:inline
+  #:primitive (read-string)
+  (coerce-read-result (read-string amt port)))
 
 (define/method (Port.Output.get_bytes port)
   #:inline

--- a/rhombus/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/rhombus/scribblings/ref-io.scrbl
@@ -12,11 +12,14 @@ input, while an @deftech{output port} is specifically for output.
   "input port"
   Port.Input
   in.peek_byte(arg, ...)
+  in.peek_bytes(arg, ...)
   in.peek_char(arg, ...)
+  in.peek_string(arg, ...)
   in.read_byte()
   in.read_bytes(arg, ...)
   in.read_char()
   in.read_line(arg, ...)
+  in.read_string(arg)
 )
 
 @dispatch_table(
@@ -142,12 +145,32 @@ input, while an @deftech{output port} is specifically for output.
 }
 
 @doc(
+  fun Port.Input.peek_bytes(in :: Port.Input,
+                            amount :: NonnegInt,
+                            ~skip_bytes: skip :: NonnegInt = 0)
+    :: Bytes || Port.EOF
+){
+ Like @rhombus(Port.Input.read_bytes), but peeks instead of reading, and skips
+ @rhombus(skip) bytes at the start of the port.
+}
+
+@doc(
   fun Port.Input.peek_char(in :: Port.Input,
                            ~skip_bytes: skip :: NonnegInt = 0)
     :: Char || Port.EOF
 ){
  Like @rhombus(Port.Input.read_char), but peeks instead of reading, and skips
  @rhombus(skip) bytes (not characters) at the start of the port.
+}
+
+@doc(
+  fun Port.Input.peek_string(in :: Port.Input,
+                             amount :: NonnegInt,
+                             ~skip_bytes: skip :: NonnegInt = 0)
+    :: String || Port.EOF
+){
+ Like @rhombus(Port.Input.read_string), but peeks instead of reading, and skips
+ @rhombus(skip) bytes at the start of the port.
 }
 
 @doc(
@@ -222,6 +245,24 @@ input, while an @deftech{output port} is specifically for output.
      linefeed character, without recognizing return-linefeed combinations.
    }
  )
+}
+
+@doc(
+  fun Port.Input.read_string(in :: Port.Input,
+                             amt :: NonnegInt) :: String || Port.EOF
+){
+ Returns a string containing the next @rhombus(amt) characters from
+ @rhombus(in).
+
+ If @rhombus(amt) is @rhombus(0), then the empty string is
+ returned. Otherwise, if fewer than @rhombus(amt) characters are
+ available before an end-of-file is encountered, then the returned
+ string will contain only those characters before the end-of-file; that
+ is, the returned string's length will be less than @rhombus(amt). (A
+ temporary string of size @rhombus(amt) is allocated while reading the
+ input, even if the size of the result is less than @rhombus(amt)
+ characters.) If no characters are available before an end-of-file,
+ then @rhombus(Port.eof) is returned.
 }
 
 @doc(

--- a/rhombus/rhombus/tests/port.rhm
+++ b/rhombus/rhombus/tests/port.rhm
@@ -7,7 +7,9 @@ block:
     Port.Input.open_bytes(bstr, [name])
     Port.Input.open_string(str, [name])
     Port.Input.peek_byte(in, [skip])
+    Port.Input.peek_bytes(in, amount, [skip])
     Port.Input.peek_char(in, [skip])
+    Port.Input.peek_string(in, amount, [skip])
     Port.Input.read_byte(in)
     Port.Input.read_bytes(in, amount)
     Port.Input.read_char(in)
@@ -33,7 +35,24 @@ block:
   check p.read_char() ~is "λ"[0]
   check p.peek_char() ~is "c"[0]
   check p.read_bytes(2) ~is_now #"cd".copy()
-  // check p.read_string(2) ~is "fμ"
+  check p.read_string(3) ~is "efμ"
+
+block:
+  let p = Port.Input.open_string("abcdefg")
+  check p.peek_bytes(4) ~is_now #"abcd"
+  check p.peek_bytes(4, ~skip_bytes: 4) ~is_now #"efg"
+  check p.peek_bytes(4, ~skip_bytes: 7) ~is Port.eof
+  check p.read_bytes(4) ~is_now #"abcd"
+  check p.peek_bytes(4) ~is_now #"efg"
+  check p.read_bytes(4) ~is_now #"efg"
+  check p.read_bytes(4) ~is Port.eof
+
+block:
+  let p = Port.Input.open_string("abλcdefμ")
+  check p.peek_string(2) ~is "ab"
+  check p.peek_string(~skip_bytes: 2, 1) ~is "λ"
+  check p.peek_string(3) ~is "abλ"
+  check p.peek_string(1, ~skip_bytes: 4) ~is "c"
 
 block:
   def str = "a\nb\rc\r\nd\n\re"


### PR DESCRIPTION
Implementations for `peek_bytes`, `peek_string`, and `read_string`.