### PR TITLE
Typo

### DIFF
--- a/rhombus/rhombus/scribblings/naming-convention.scrbl
+++ b/rhombus/rhombus/scribblings/naming-convention.scrbl
@@ -4,7 +4,7 @@
 
 The @rhombuslangname(rhombus) language's bindings follow certain naming
 conventions. While Rhombus does not impose a naming convention
-syntactically, authors are new libraries are encouraged to stick to
+syntactically, authors of new libraries are encouraged to stick to
 @rhombuslangname(rhombus) conventions where possible.
 
 Most names use ``snake case,'' where the leading character is lowercase


### PR DESCRIPTION
"authors are new libraries" -> "authors of new libraries"