### PR TITLE
`error` and `error.message`

### DIFF
--- a/rhombus-draw-lib/rhombus/draw/private/bitmap.rhm
+++ b/rhombus-draw-lib/rhombus/draw/private/bitmap.rhm
@@ -90,7 +90,9 @@ class Bitmap():
                ~as_unscaled: as_unscaled :: Any.to_boolean = #false):
     unless rkt.send handle.#{save-file}(#{#:unscaled?}: as_unscaled,
                                         dest, kind, quality)
-    | error("error writing bitmap")
+    | error(~who: "Bitmap.write",
+            "error writing bitmap",
+            error.text(~label: "destination", dest))
 
 annot.delayed_complete intf.BitmapForward: Bitmap
 

--- a/rhombus-draw-lib/rhombus/draw/private/color.rhm
+++ b/rhombus-draw-lib/rhombus/draw/private/color.rhm
@@ -69,7 +69,10 @@ class Color(private _handle):
 
 fun from_handle(handle) :~ Color:
   unless handle rkt.is_a rkt.#{color%}
-  | error("Color.from_handle", "not a color handle: " +& handle)
+  | error(~who: "Color.from_handle",
+          ~exn: Exn.Fail.Annot,
+          "not a color handle",
+          error.val(handle))
   _Color(handle)
 
 fun

--- a/rhombus-draw-lib/rhombus/draw/private/dc.rhm
+++ b/rhombus-draw-lib/rhombus/draw/private/dc.rhm
@@ -220,7 +220,10 @@ interface DC:
 
 fun from_handle(handle) :: DC:
   unless handle rkt.is_a rkt.#{dc<%>}
-  | error("DC.from_handle", "not a DC handle: " +& handle)
+  | error(~who: "DC.from_handle",
+          ~exn: Exn.Fail.Annot,
+          "not a DC handle",
+          error.val(handle))
   SomeDC(handle)
 
 class DCDump(pen, brush, font, clipping_region, transformation, dump)
@@ -240,7 +243,7 @@ class SomeDC(private _handle):
 
   override method restore():
     unless dump
-    | error("DC.restore", "no state saved")
+    | error(~who: "DC.restore", "no state saved")
     macro 'update $('. $field') ...':
       'block:
          def old_dump :~ DCDump = dump

--- a/rhombus-lib/info.rkt
+++ b/rhombus-lib/info.rkt
@@ -16,4 +16,4 @@
 
 (define license '(Apache-2.0 OR MIT))
 
-(define version "0.28")
+(define version "0.29")

--- a/rhombus-lib/rhombus/private/amalgam/charset.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/charset.rhm
@@ -2,6 +2,7 @@
 import:
   "when_unless.rhm" open
   "recur.rhm" open
+  "error.rhm" open
   lib("racket/base.rkt")
 
 export:
@@ -18,7 +19,10 @@ class Charset(private _ranges):
       let start = start_c.to_int()
       let end = end_c.to_int()
       unless start <= end
-      | error(#'Charset, "bad range")
+      | error(~who: #'Charset,
+              "range end is before start",
+              error.val(~label: "start to_int", start),
+              error.val(~label: "end to_int", end))
       cond
       | start < 0xD800 && end >= 0x10000:
           super([[start, 0xD7FF], [0x10000, end]])

--- a/rhombus-lib/rhombus/private/amalgam/control.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/control.rkt
@@ -22,11 +22,7 @@
                       rhombus/namespace)
                      Continuation)
          try
-         throw
-         (for-spaces (#f
-                      rhombus/statinfo)
-                     (rename-out
-                      [rhombus-error error])))
+         throw)
 
 (define-name-root Continuation
   #:fields
@@ -61,40 +57,6 @@
 
 (define/arity (Continuation.Marks.current)
   (current-continuation-marks))
-
-(define/arity #:name error rhombus-error
-  (case-lambda
-    [(msg) (do-error who #f msg)]
-    [(who-in msg) (do-error who who-in msg)]))
-
-(define (do-error e-who who msg)
-  (define who-sym
-    (cond
-      [(not who) #f]
-      [(symbol? who) who]
-      [(string? who) (string->symbol who)]
-      [(identifier? who) (syntax-e who)]
-      [(and (syntax? who)
-            (syntax-parse who
-              #:datum-literals (op)
-              [(op id) (syntax-e #'id)]
-              [_ #f]))]
-      [else (raise-argument-error* e-who
-                                   rhombus-realm
-                                   "maybe(ReadableString || Symbol || Identifier || Operator)"
-                                   who)]))
-  (unless (string? msg)
-    (raise-argument-error* e-who rhombus-realm "ReadableString" msg))
-  (define adj (current-error-message-adjuster))
-  (define-values (adj-who who-realm)
-    (if who-sym
-        ((or (adj 'name) values) who-sym rhombus-realm)
-        (values #f rhombus-realm)))
-  (define-values (err-who error-who-realm adj-msg msg-realm)
-    ((or (adj 'message) values) adj-who who-realm msg rhombus-realm))
-  (if err-who
-      (error err-who "~a" adj-msg)
-      (error adj-msg)))
 
 (define-syntax try
   (expression-transformer

--- a/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 (require "../bounce.rkt")
 
-(bounce "recur.rhm"
+(bounce "error.rhm"
+        "recur.rhm"
         "check.rhm"
         "maybe.rhm"
         "string.rhm"

--- a/rhombus-lib/rhombus/private/amalgam/error.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/error.rhm
@@ -1,0 +1,169 @@
+#lang rhombus/private/amalgam/core
+import:
+  "core-meta.rkt" open
+  "maybe.rhm" open
+  lib("racket/base.rkt")
+
+use_static
+
+export:
+  error
+
+namespace error:
+  export:
+    Who
+
+    // constructs full message without raising it
+    message
+
+    // builders of main message test
+    annot_msg
+
+    Clause
+
+    // clause builders
+    text
+    val
+    vals
+    annot
+
+    // helper
+    reindent
+
+annot.macro 'Who':
+  'ReadableString || Symbol || Name'
+
+class Clause(msg :: String):
+  nonfinal
+
+// primary `error` function
+// (not backward-comptible with current `error` due to `~who` keyword argument)
+fun error(~srcloc: srcloc :: maybe(Srcloc) = #false,
+          ~who: who :: maybe(error.Who) = #false,
+          ~realm: realm :: Symbol = #'rhombus,
+          // make things like `~exn: Exn.Fail.User` easy; for more complex
+          // exception constructions, use `error.message`, instead, to build
+          // just the message text
+          ~exn: exn :: (Function.of_arity(2)
+                          // also gets srcloc list
+                          || Function.of_arity(3)
+                          // also gets clause list
+                          || Function.of_arity(4)) = Exn.Fail,
+          // intended to be a single short line
+          msg :: ReadableString,
+          // if non-empty, ";" is added to the end of `message`, and
+          // each `detail` is shown on its own line with a 1-space prefix
+          ~details: [detail :: ReadableString, ...] = [],
+          // intended to be constructed by `error.val`, `error.annot`,
+          // or `error.text`; each `clause` starts its own line with
+          // a 2-space prefix:
+          clause :: error.Clause,
+          ...):
+  let msg = message(~srcloc: srcloc,
+                    ~who: who,
+                    ~realm: realm,
+                    msg,
+                    ~detail: [detail, ...],
+                    clause, ...)
+  let marks = Continuation.Marks.current()
+  let e:
+    match exn
+    | exn :: Function.of_arity(4): exn(msg, marks, [srcloc], [clause, ...])
+    | exn :: Function.of_arity(3): exn(msg, marks, [srcloc])
+    | exn :: Function.of_arity(2): exn(msg, marks)
+  throw e
+
+// exported as `error.message`, same arguments as `error` except for `~exn`
+fun message(~srcloc: srcloc :: maybe(Srcloc) = #false,
+            ~who: who :: maybe(error.Who) = #false,
+            ~realm: realm :: Symbol = #'rhombus,
+            message :: ReadableString,
+            ~detail: [detail :: ReadableString, ...] = [],
+            clause :: error.Clause,
+            ...) :~ String:
+  (if srcloc | Srcloc.to_report_string(srcloc) ++ ": " | "")
+    ++ (base.#{error-message->adjusted-string}(
+          (who && who_to_sym(who)),
+          realm,
+          message
+            ++ (if [detail, ...].length() == 0 | "" | ";")
+            ++ String.append("\n " ++ detail, ...)
+            ++ String.append("\n  " ++ clause.msg, ...),
+          realm
+        ))
+
+fun
+| who_to_sym(s :: Symbol): s
+| who_to_sym(s :: ReadableString): Symbol.from_string(s)
+| who_to_sym(s :: Syntax): Symbol.from_string(s.to_source_string())
+
+fun annot_msg(what :: String = "value") :~ String:
+  what ++ " does not satisfy annotation"
+
+fun text(~label: label :: String,
+         v) :~ Clause:
+  Clause(
+    label ++ ": " ++ reindent(to_string(v), ~label: label)
+  )
+
+fun val(~label: label :: String = "value", v) :~ Clause:
+  Clause(
+    label ++ ":" ++ reindent(to_error_string(v),
+                             ~label: label)
+  )
+
+fun vals(~label: label :: String = "values", v, ...) :~ Clause:
+  match [v, ...]
+  | []:
+      Clause(
+        label ++ ": <none>"
+      )
+  | [v]:
+      Clause(
+        label ++ ":" ++ reindent(to_error_string(v),
+                                 ~label: label)
+      )
+  | [v, ...]:
+      Clause(
+        label ++ ":" ++ String.append(reindent(to_error_string(v), ~max_len: 0),
+                                      ...)
+      )
+
+fun annot(~label: label :: String = "annotation",
+          ~realm: realm :: Symbol = #'rhombus,
+          annotation) :~ Clause:
+  Clause(
+    label ++ ":" ++ reindent(base.#{error-contract->adjusted-string}(annotation, realm),
+                             ~label: label)
+  )
+
+fun to_error_string(v):
+  base.#{error-value->string-handler}()(v, base.#{error-print-width}())
+
+// exported as `error.reindent`, because it may be more generally useful
+fun reindent(s :~ String,
+             // added before `s` if it stays on 1 line
+             ~space: space :: String = " ",
+             // added before each line if multi-line
+             ~tab: tab :: String = "   ",
+             // used only for default `max_len`
+             ~label: label :: String = "",
+             // determines when a single-line `s` is moved
+             // to its own line to fit better
+             ~max_len: max_len :: NonnegInt
+                         = 72 - (2 + label.length() + 1 + space.length())) :~ String:
+  if (s.length() > max_len
+        || (for any (c: s):
+              c == "\n"[0]))
+  | "\n" ++ tab
+      ++ (block:
+            fun loop(i, start):
+              cond
+              | i == s.length():
+                  s.substring(start, i)
+              | s[i] == "\n"[0]:
+                  s.substring(start, i) ++ "\n" ++ tab ++ loop(i+1, i+1)
+              | ~else:
+                  loop(i+1, start)
+            loop(0, 0))
+  | space ++ s

--- a/rhombus-lib/rhombus/private/amalgam/exn-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/exn-object.rkt
@@ -3,11 +3,14 @@
                      syntax/parse/pre)
          "provide.rkt"
          "class-primitive.rkt"
+         "call-result-key.rkt"
          "function-arity-key.rkt"
          "index-result-key.rkt"
+         "define-arity.rkt"
          (submod "list.rkt" for-compound-repetition)
          (submod "syntax-object.rkt" for-quasiquote)
-         (submod "srcloc-object.rkt" for-static-info))
+         (submod "srcloc-object.rkt" for-static-info)
+         "realm.rkt")
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -62,7 +65,8 @@
               Network
               OutOfMemory
               Unsupported
-              User))
+              User
+              [Annot Exn.Fail.Annot]))
 
 (define-exn Contract exn:fail:contract
   #:parent Fail exn:fail
@@ -72,6 +76,12 @@
               NonFixnumResult
               Continuation
               Variable))
+
+(define/arity (Exn.Fail.Annot message marks)
+  #:static-infos ((#%call-result #,(get-exn:fail:contract-static-infos)))
+  (unless (string? message) (raise-argument-error* who rhombus-realm "ReadableString" message))
+  (unless (continuation-mark-set? marks) (raise-argument-error* who rhombus-realm "Continuation.Marks" marks))
+  (exn:fail:contract message marks))
 
 (define-exn Arity exn:fail:contract:arity
   #:parent Contract exn:fail:contract

--- a/rhombus-lib/rhombus/private/amalgam/recur.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/recur.rhm
@@ -1,6 +1,7 @@
 #lang rhombus/private/amalgam/core
 import:
   "core-meta.rkt" open
+  "error.rhm" open
   lib("racket/unsafe/undefined.rkt").#{unsafe-undefined}
 
 use_static
@@ -94,10 +95,11 @@ expr.macro 'recur $(name :: Identifier) ($(arg :: bind_meta.Argument),
   statinfo_meta.wrap(expr, r.static_info)
 
 fun no_match(who, ann_str, what):
-  error(who,
-        "value does not match annotation\n"
-          +& "  annotation: " +& ann_str +& "\n"
-          +& "  value: " +& what)
+  error(~who: who,
+        ~exn: Exn.Fail.Annot,
+        error.annot_msg(),
+        error.annot(ann_str),
+        error.val(what))
 
 meta:
   fun wrap_converter(expr, count, maybe_converter, annotation_string, name):
@@ -123,9 +125,10 @@ meta:
     | expr
 
 fun bad_result(who, ann_str):
-  error(who,
-        "result does not match annotation\n"
-          +& "  annotation: " +& ann_str)
+  error(~who: who,
+        ~exn: Exn.Fail.Annot,
+        error.annot_msg("result"),
+        error.annot(ann_str))
 
 annot.macro 'providing($unpacked_static_info)':
   annot_meta.pack_predicate('fun (x): #true',

--- a/rhombus-lib/rhombus/private/amalgam/rx.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx.rhm
@@ -116,7 +116,7 @@ export:
   unicode
 
 meta:
-  fun rx_macro(stx :~ Syntax, pat, is_full):
+  fun rx_macro(self, stx :~ Syntax, pat, is_full):
     match pat
     | #false:
         let stx_str = to_string(stx)
@@ -132,7 +132,7 @@ meta:
         if rkt_rx is_a Syntax
         | let [vars_seq, ...]: describe_splice_vars([var, ...], vars)
           // generate run-time construction of a regexp
-          'splice_regexp($rkt_rx, [$vars_seq, ...], $has_backref, $stx_str)'
+          'splice_regexp(#' $self, $rkt_rx, [$vars_seq, ...], $has_backref, $stx_str)'
         | let rkt_full_rx:
             if is_full
             | compile('sequence(bof, $ast, eof)', vars, num_captures, stx)
@@ -142,19 +142,23 @@ meta:
 
 expr.macro
 | '«rx ''»':
+    ~op_stx: self
     ~all_stx: stx
-    rx_macro(stx, #false, #true)
+    rx_macro(self, stx, #false, #true)
 | '«rx '$(pat :: rx_meta.Parsed)'»':
+    ~op_stx: self
     ~all_stx: stx
-    rx_macro(stx, pat, #true)
+    rx_macro(self, stx, pat, #true)
 
 expr.macro
 | '«rx_in ''»':
+    ~op_stx: self
     ~all_stx: stx
-    rx_macro(stx, #false, #false)
+    rx_macro(self, stx, #false, #false)
 | '«rx_in '$(pat :: rx_meta.Parsed)'»':
+    ~op_stx: self
     ~all_stx: stx
-    rx_macro(stx, pat, #false)
+    rx_macro(self, stx, pat, #false)
 
 rx.macro'$left #%index $(next :: rx_meta.AfterInfixParsed('#%juxtapose')) $()':
   ~weaker_than: #%parens #%juxtapose ++

--- a/rhombus-lib/rhombus/private/amalgam/rx_match.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx_match.rhm
@@ -1,6 +1,7 @@
 #lang rhombus/private/amalgam/core
 import:
   "when_unless.rhm" open
+  "error.rhm" open
 
 export:
   RXMatch
@@ -20,6 +21,11 @@ class RXMatch(whole, captures :: List, capture_names :: Map):
         let index = Map.get(capture_names, sym, #false)
         if index
         | captures[index - 1]
-        | error(#'#{RX.get}, "no capture group by that name")
+        | error(~who: #'#{RX.get},
+                "no capture group by given name",
+                error.val("name", index))
     | ~else:
-       error(#'#{RX.get}, "invalid match index")
+       error(~who: #'#{RX.get},
+             ~exn: Exn.Fail.Annot,
+             "invalid match index",
+             error.val("index", index))

--- a/rhombus-lib/rhombus/private/amalgam/rx_object.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx_object.rhm
@@ -4,6 +4,7 @@ import:
   "core-meta.rkt" open
   "maybe.rhm" open
   "recur.rhm" open
+  "error.rhm" open
   "rx_match.rhm" open
 
 export:
@@ -22,7 +23,7 @@ class RX(private _rkt_partial_rx,
          private _has_backref,
          private _str):
   internal _RX
-  constructor (): error("don't instantiate")
+  constructor (): error(~who: #'RX, "cannot instantiate directly")
 
   export:
     from_handles
@@ -119,13 +120,18 @@ class RX(private _rkt_partial_rx,
       freeze(elem)
 
   fun check_filter(who, in, out):
+    fun bad(kind):
+      error(~who: who,
+            ~exn: Exn.Fail.Annot,
+            "expected " ++ kind ++ "string result from replacing function",
+            error.val(~label: "result", out))
     cond
     | in is_a Bytes:
         unless out is_a Bytes
-        | error(who, "expected byte string result from replacing function")
+        | bad("byte ")
     | ~else:
         unless out is_a String
-        | error(who, "expected string result from replacing function")
+        | bad("")
     out
 
   method replace(input :: String || Bytes,
@@ -154,10 +160,15 @@ fun from_handles(rx,
                  vars :: Map.of(Symbol, NonnegInt),
                  ~has_backref: has_backref :: Any.to_boolean = #false,
                  ~source: source :: String = "rx'....'") :~ RX:
+  fun bad(rx, mode):
+    error(~who: #'#{RX.from_handles},
+          ~exn: Exn.Fail.Annot,
+          "not a primitive regular expression for " ++ mode ++ " mode",
+          error.val(rx))
   unless base.#{regexp?}(rx)
-  | error(#'#{RX.from_handles}, "not a primitive regular expression for whole-match mode")
+  | bad("whole-match")
   unless base.#{regexp?}(partial_rx)
-  | error(#'#{RX.from_handles}, "not a primitive regular expression for partial-match mode")
+  | bad("partial-match")
   _RX(partial_rx, rx, num_captures, vars, has_backref, source)
 
 fun freeze(elem):
@@ -166,18 +177,28 @@ fun freeze(elem):
   | bstr :: Bytes: bstr
   | ~else: #false
 
-fun splice_regexp(PairList(a, ...) && as, var_seq, has_backref, src) :~ RX:
+fun splice_regexp(who, PairList(a, ...) && as, var_seq, has_backref, src) :~ RX:
   fun extract(a):
     match a
     | _ :: String: a
     | Pair(_, regexp :: _RX):
         when has_backref && (regexp._num_captures != 0)
-        | error("cannot splice RX that has capture groups into a pattern with backreferences")
+        | error(~who: who,
+                ~exn: Exn.Fail.Annot,
+                "cannot splice regexp that has capture groups into a pattern with backreferences",
+                error.val(~label: "rexgexp", regexp))
         when regexp._has_backref
-        | error("cannot splice RX backreferences into a larger pattern")
+        | error(~who: who,
+                ~exn: Exn.Fail.Annot,
+                "cannot splice regexp with backreferences into a larger pattern",
+                error.val(~label: "rexgexp", regexp))
         "(?:" ++ base.#{object-name}(regexp.in_handle) ++ ")"
     | Pair(src_str, val):
-        error("spliced value for " +& src_str +& " does not satisfy `RX`")
+        error(~who: who,
+              ~exn: Exn.Fail.Annot,
+              error.annot_msg("spliced value for " +& src_str),
+              error.annot("RX"),
+              error.val(~label: "spliced value", a))
   let str = String.append(extract(a), ...)
   let (num_captures, vars):
     recur loop(vars :~ Map = Map.by(===){}, as = as, var_seq = var_seq, di = 0):

--- a/rhombus-lib/rhombus/private/amalgam/str.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/str.rhm
@@ -3,6 +3,7 @@ import:
   "core-meta.rkt" open
   lib("racket/base.rkt")
   "str_help.rhm" open
+  "error.rhm" open
   "maybe.rhm" open
   "enum.rhm" open
 
@@ -42,7 +43,11 @@ namespace str:
                    ~zero_sign: zero_sign,
                    ~sign_align: sign_align):
     when min_width && max_width && max_width .< min_width
-    | error(who, "maximum width is less than minimum width")
+    | error(~who: who,
+            ~exn: Exn.Fail.Annot,
+            "maximum width is less than minimum width",
+            error.val(~label: "minimum", min_width),
+            error.val(~label: "maximum", max_width))
     let sign :~ String:
       cond
       | max_width == 0: ""

--- a/rhombus-lib/rhombus/random.rhm
+++ b/rhombus-lib/rhombus/random.rhm
@@ -30,7 +30,11 @@ class Random(private _handle):
           math.random(n)
   | random(start :: Int, end :: Int) :~ Number:
       unless start < end
-      | error(#'random, "start index is not less than end index")
+      | error(~who: #'random,
+              ~exn: Exn.Fail.Annot,
+              "start index is not less than end index",
+              error.val(~label: "start index", start),
+              error.val(~label: "end index", end))
       random(end - start) + start
 
   property

--- a/rhombus-pict-lib/rhombus/pict/balloon.rhm
+++ b/rhombus-pict-lib/rhombus/pict/balloon.rhm
@@ -70,7 +70,9 @@ fun pin(content :: Pict,
         cond
         | !at_x:
             if find_mode == #'always
-            | error(#'#{balloon.pin}, "cannot find pict")
+            | error(~who: #'#{balloon.pin}, "cannot find pict",
+                    error.val(~label: "finder", at),
+                    error.val(~label: "within pict", p))
             | p
         | ~else:
             let fill_color = (color && as_color(color)) || Color(0, 0, 0, 0.0).handle

--- a/rhombus-pict-lib/rhombus/pict/private/anim.rhm
+++ b/rhombus-pict-lib/rhombus/pict/private/anim.rhm
@@ -63,7 +63,12 @@ fun animate(~children: children :: List.of(Pict) = [],
     fun (n, child_or_config, ...):
       let p = proc(bend(n), child_or_config, ...)
       unless p is_a StaticPict
-      | error(#'animate, "procedure result does not satisfy StaticPict")
+      | error(~who: #'animate,
+              ~exn: Exn.Fail.Annot,
+              error.annot_msg("procedure result"),
+              error.annot("StaticPict"),
+              error.val(~label: "procedure", proc),
+              error.val(~label: "result", p))
       p
   AnimPict(~children: children,
            proc,
@@ -75,7 +80,12 @@ fun rebuildable(~children: children :: List.of(Pict) = [],
                 proc :: Function.of_arity(children.length() + (if config | 1 | 0))) :~ Pict:
   let p = proc(& children ++ (if config | [config] | []))
   unless p is_a Pict
-  | error(#'rebuildable, "procedure result does not satisfy Pict")
+  | error(~who: #'rebuildable,
+          ~exn: Exn.Fail.Annot,
+          error.annot_msg("procedure result"),
+          error.annot("Pict"),
+          error.val(~label: "procedure", proc),
+          error.val(~label: "result", p))
   let rebuild:
     if config
     | fun ([child, ..., config]):

--- a/rhombus-pict-lib/rhombus/pict/private/static.rhm
+++ b/rhombus-pict-lib/rhombus/pict/private/static.rhm
@@ -262,7 +262,12 @@ class Pict():
         cond
         | new != this:
             unless new is_a Pict
-            | error(#'rebuild, "pre-adjust function's result does not satisfy Pict")
+            | error(~who: #'rebuild,
+                    ~exn: Exn.Fail.Annot,
+                    error.annot_msg("pre-adjust function's result"),
+                    error.annot("Pict"),
+                    error.val(~label: "function", pre_adjuster),
+                    error.val(~label: "result", new))
             values(new, subst ++ { this: new })
         | ~else:
             let (new, subst :~ Map):
@@ -279,10 +284,14 @@ class Pict():
                       values(new_deps.add(new_dep), new_subst)
                   let new_config:
                     _config && (block:
-                                  let c = adjuster(_config)
+                                  let c = config_adjuster(_config)
                                   unless c is_a Map
-                                  | error(#'rebuild, "config-adjust function's result does not satisfy Map")
-                                  c)
+                                  | error(~who: #'rebuild,
+                                          ~exn: Exn.Fail.Annot,
+                                          error.annot_msg("config-adjust function's result"),
+                                          error.annot("Pict"),
+                                          error.val(~label: "function", config_adjuster),
+                                          error.val(~label: "result", c)))
                   let new:
                     if (all(new_dep === dep, ...)
                           && new_config == _config)
@@ -300,7 +309,12 @@ class Pict():
                     values (new, subst)
             let new = adjuster(new)
             unless new is_a Pict
-            | error(#'rebuild, "post-adjust function's result does not satisfy Pict")
+            | error(~who: #'rebuild,
+                    ~exn: Exn.Fail.Annot,
+                    error.annot_msg("post-adjust function's result"),
+                    error.annot("Pict"),
+                    error.val(~label: "function", adjuster),
+                    error.val(~label: "result", new))
             values(new, subst ++ { this: new })
 
 class StaticPict(private _handle,
@@ -370,7 +384,10 @@ class StaticPict(private _handle,
         if to_handle
         | static_pict(rkt.refocus(handle, to_handle), this, _instances,
                       ~dependencies: [this, to_p], retry)
-        | error(#'refocus, "pict for refocus not found")
+        | error(~who: #'refocus,
+                "pict not found",
+                error.val(~label: "pict", to_p),
+                error.val(~label: "within pict", this))
 
   override method
   | _pad(amt :: Real):
@@ -512,7 +529,7 @@ class NothingPict():
   override method launder(): this
   override method ghost(do_ghost = #true): this
   override method refocus(to_p :: Pict):
-    error(#'refocus, "cannot refocus nothing")
+    error(~who: #'refocus, "cannot refocus nothing")
 
   override method
   | _pad(amt :: Real): this
@@ -1226,7 +1243,10 @@ class Find(private q, private find, private t_find_or_dt, private is_animated):
       let (x, y) = find(p, q, epoch, n)
       if x
       | values(x, y)
-      | error(#'#{Find.in}, "cannot find pict")
+      | error(~who: #'#{Find.in},
+              "cannot find pict",
+              error.val(~label: "pict", q),
+              error.val(~label: "in pict", p))
 
   method
   | maybe_in(p :: Pict):
@@ -1243,11 +1263,17 @@ class Find(private q, private find, private t_find_or_dt, private is_animated):
           loop(c, start + delta)
     match t_find_or_dt
     | dt :: Int:
-        loop(p, dt) || error(#'#{Find.start_in}, "cannot find pict")
+        loop(p, dt) || error(~who: #'#{Find.start_in},
+                             "cannot find pict",
+                             error.val(~label: "pict", q),
+                             error.val(~label: "in pict", p))
     | ~else:
         let dt = t_find_or_dt(p)
         unless dt is_a Int
-        | error(#'#{Find.start_in}, "function did not produce an integer time box difference")
+        | error(#'#{Find.start_in},
+                ~exn: Exn.Fail.Annot,
+                "function did not produce an integer time box difference",
+                error.val(~label: "result", dt))
         dt
 
   method delay(dt :: Int) :~ Find:
@@ -1350,7 +1376,11 @@ fun animate(xy_proc :: Function.of_arity(2) || Function.of_arity(3),
             | (_ :: False, _ :: False):
                 values(#false, #false)
             | (arg, ...):
-                error(#'#{Find.animate}, "invalid result from animation procedure")
+                error(#'#{Find.animate},
+                      ~exn: Exn.Fail.Annot,
+                      "invalid result from animation function",
+                      error.val(~label: "function", xy_proc),
+                      error.val(~label: "result", arg, ...))
           ),
         t_proc,
         #true)
@@ -1508,7 +1538,10 @@ fun connect(~on: p :: Pict,
         | ~else:
             if find_mode == #'maybe
             | p
-            | error(#'connect, if from_x | "cannot find `~to` pict" | "cannot find `~from p ict")
+            | error(#'connect,
+                    if from_x | "cannot find `~to` pict" | "cannot find `~from pict",
+                    error.val(~label: "finder", if from_x | from | to),
+                    error.val(~label: "in pict", p))
     | ~else:
         convert(children, #'center, #'sustain,
                 fun (ps :~ List, dt, n): retry(ps[0], label && ps[1], from, to, 0, 0),
@@ -1577,7 +1610,10 @@ fun pin(q :: Pict,
           | [p :: _StaticPict, q :: _StaticPict]:
               let (at_x, at_y): at.maybe_in(p, dt, n)
               when !at_x && find_mode == #'always
-              | error(#'pin, "cannot find pict")
+              | error(#'pin,
+                      "cannot find pict",
+                      error.val(~label: "finder", at),
+                      error.val(~label: "in pict", p))
               let (dx, dy) = using.in(q, dt, n)
               if at_x
               | let new_handle:

--- a/rhombus-pict-lib/rhombus/pict/rhombus.rhm
+++ b/rhombus-pict-lib/rhombus/pict/rhombus.rhm
@@ -34,7 +34,10 @@ Parameter.def current_rhombus_tt :: Function.of_arity(1):
 fun rtt(str_s) :~ Pict:
   let p = current_rhombus_tt()(str_s)
   unless p is_a Pict
-  | error("Rhombus code function returned a non-Pict: " +& p)
+  | error(error.annot_msg("Rhombus `tt` function result"),
+          ~exn: Exn.Fail.Annot,
+          error.annot("Pict"),
+          error.val(~label: "result", p))
   p
 
 def (render_line,
@@ -85,10 +88,13 @@ def (render_line,
                  fun (v):
                    v is_a Pict)
 
-fun to_pict(v):
+fun to_pict(who, v):
   if v is_a Pict
   | v
-  | error("escape produced a non-Pict: " +& v)
+  | error(~who: who,
+          ~exn: Exn.Fail.Annot,
+          error.annot_msg("escape result"),
+          error.val(~label: "result", v))
 
 define.macros (rhombus,
                rhombusblock,

--- a/rhombus-pict-lib/rhombus/pict/text.rhm
+++ b/rhombus-pict-lib/rhombus/pict/text.rhm
@@ -75,7 +75,8 @@ fun flatten_string(who, c, font) :~ Pict:
   | p :: Pict: p
   | [c, ...]: pict.beside(~vert: #'topline, flatten_string(who, c, font), ...)
   | ~else:
-      error(who, "bad text content: " +& to_string(c, ~mode: #'expr))
+      // shouldn't get here
+      error(~who: who, "bad text content", error.val(c))
 
 fun t(~font: font :: draw.Font = current_font(),
       s :: TextContent, ...) :~ Pict:
@@ -195,7 +196,8 @@ fun flatten_para_content(who, decode, c) :~ List:
     | [c1, & c]:
         flatten(c1) ++ flatten(c)
     | ~else:
-        error(who, "bad paragraph content: " +& to_string(c, ~mode: #'expr))
+        // shouldn't get here
+        error(~who: who, "bad paragraph content", error.val(c))
 
 fun join_nonbreaking(l :: List):
   match l

--- a/rhombus-scribble-lib/rhombus/scribble/private/index.rhm
+++ b/rhombus-scribble-lib/rhombus/scribble/private/index.rhm
@@ -18,7 +18,11 @@ fun index(words :: (String ||  List.of(String)),
     let norm_words = (if words is_a String | [words] | words)
     let norm_content = (if content is_a String | [content] | content)
     unless List.length(content) == List.length(words)
-    | error(#'index, "words and content mismatch")
+    | error(~who: #'index,
+            ~exn: Exn.Fail.Annot,
+            "word count and content count do no match",
+            error.val(~label: "word list", words),
+            error.val(~label: "content list", content))
     base.#{index*}(convert_list(words), convert_list(content), pre_content)
 
 fun as_index(pre_content :: PreContent) :: Element:

--- a/rhombus-scribble-lib/rhombus/scribble/private/rhombus-doc.rkt
+++ b/rhombus-scribble-lib/rhombus/scribble/private/rhombus-doc.rkt
@@ -612,7 +612,7 @@
   (syntax-parse stx
     #:datum-literals (group block)
     [(group _ ... (parens field ...) . _)
-     (cons "enumeration"
+     (cons "class"
            (for/list ([field (in-list (syntax->list #'(field ...)))])
              "function"))]))
 

--- a/rhombus-scribble-lib/rhombus/scribble/private/rhombus.rhm
+++ b/rhombus-scribble-lib/rhombus/scribble/private/rhombus.rhm
@@ -9,10 +9,13 @@ export:
   rhombusblock
   rhombusblock_etc  
 
+fun escape(who, v):
+  elem(v)
+
 define.macros (rhombus,
                rhombusblock,
                rhombusblock_etc):
   ~render_line: #{typeset-rhombus}
   ~render_block: #{typeset-rhombusblock}
-  ~escape: elem
+  ~escape: escape
   ~result: Any

--- a/rhombus-slideshow-lib/slideshow/content.rhm
+++ b/rhombus-slideshow-lib/slideshow/content.rhm
@@ -106,7 +106,10 @@ fun flatten_slide_content(who, c) :~ List:
   | p :: Horiz: [p]
   | p :: Align: [p]
   | ~else:
-      error(who, "bad slide content: " +& to_string(c, ~mode: #'expr))
+      error(~who: who,
+            ~exn: Exn.Fail.Annot,
+            "bad slide content",
+            error.val(c))
 
 // generated in `align_content` for consumption by `next_to_anim`:
 class SetSep(pre_sep, post_sep)

--- a/rhombus/rhombus/scribblings/ref-error.scrbl
+++ b/rhombus/rhombus/scribblings/ref-error.scrbl
@@ -1,0 +1,211 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@title{Errors}
+
+@doc(
+  fun error(
+    ~exn: exn :: (Function.of_arity(2)
+                    || Function.of_arity(3)
+                    || Function.of_arity(4))
+            = Exn.Fail,
+    ~srcloc: srcloc :: maybe(Srcloc) = #false,
+    ~who: who :: maybe(error.Who) = #false,
+    msg :: ReadableString,
+    ~details: details :: [List.of(ReadableString)] = [],
+    clause :: error.Clause,
+    ...
+  ) :: None
+){
+
+ Throws the result of @rhombus(exn) as an exception, constructing the
+ error message from @rhombus(srcloc), @rhombus(who), @rhombus(msg),
+ @rhombus(details), and the @rhombus(clause)s in order.
+
+ If @rhombus(who) is not @rhombus(#false), it is added to the beginning
+ of the message, and a @litchar{: } separator is added in between.
+
+ The @rhombus(msg) part of the error message is meant to fit on a single
+ line. If @rhombus(details) is non-empty, then @litchar{;} is added to
+ the end of @rhombus(msg), and each element of @rhombus(details) is
+ written on its own line with a 1-space prefix.
+
+ The @rhombus(clause)s are added to the end of the error message.
+ Construct a clause with functions like @rhombus(error.val),
+ @rhombus(error.vals), @rhombus(error.annot), or @rhombus(error.text).
+ Each @rhombus(clause) will start on its own line with a 2-space prefix.
+
+ When @rhombus(exn) is called by @rhombus(error), the first argument is
+ a string message, and the second argument is
+ @rhombus(Continuation.Marks.current()). If @rhombus(exn) accepts at
+ least three arguments, then @rhombus(srcloc) is provided as the third
+ argument. If @rhombus(exn) accepts four arguments, then the list of
+ @rhombus(clause)s is provided as the fourth argument.
+
+ Conventions for using @rhombus(error):
+
+ @itemlist(
+
+  @item{Start @rhombus(msg) in lowercase, and keep it short. Use
+  @rhombus(details) to elaborate on the initial message, but report any
+  values or other specifics in @rhombus(clause)s. When @rhombus(details)
+  has multiple sentences, separate then with @litchar{;} and stay in
+  lowercase mode.}
+
+  @item{Normally, @rhombus(Exn.Fail.Annot) should be used for
+  @rhombus(exn) (in place of @rhombus(Exn.Fail, ~annot)) if the exception
+  represents an error that could have been prevented (without a race
+  condition) by a preceding check.}
+
+  @item{To throw an error that complains about a single
+  argument--annotation mismatch (in the same way as @rhombus(::)), use
+  @rhombus(~exn: Exn.Fail.Annot), use @rhombus(error.annot_msg) to
+  construct @rhombus(message), and use @rhombus(error.annot) to and
+  @rhombus(error.val) to constructs @rhombus(clause)s. Provide the same
+  label string to @rhombus(error.annot_msg) and @rhombus(error.val) if it
+  is useful to be more specific than @rhombus("value").}
+
+ )
+
+@examples(
+  ~repl:
+    ~error:
+      error("oops")
+    ~error:
+      error(~who: #'me, "oops")
+    ~error:
+      error(~who: #'me,
+            "oops",
+            ~details: ["something has gone wrong;",
+                       "see the manual for more information"])
+    ~error:
+      error(~who: #'me,
+            ~exn: Exn.Fail.Annot,
+            error.annot_msg("fruit"),
+            error.annot("Tropical"),
+            error.val(~label: "fruit", #'Apple))
+    ~error:
+      error(~who: #'me,
+            "mismatch between fruit and vegetable",
+            error.val(~label: "fruit", [#'Apple, 0]),
+            error.val(~label: "vegetable", [#'Lettuce, -1]))
+)
+
+}
+
+
+@doc(
+  fun error.message(
+    ~srcloc: srcloc :: maybe(Srcloc) = #false,
+    ~who: who :: maybe(error.Who) = #false,
+    msg :: ReadableString,
+    ~details: details :: [List.of(ReadableString)] = [],
+    clause :: Error.Clause,
+    ...
+  ) :: String
+){
+
+ Like @rhombus(error), but without the @rhombus(~exn) argument, and the
+ result is a message string instead of throwing an exception.
+
+@examples(
+  ~repl:
+    error.message(~who: #'me, "oops")
+)
+
+}
+
+
+@doc(
+  annot.macro 'error.Who'
+){
+
+ Satisfied by a @rhombus(ReadableString, ~annot),
+ @rhombus(Symbol, ~annot), or @rhombus(Name, ~annot).
+
+}
+
+
+@doc(
+  class error.Clause(msg :: String):
+    nonfinal
+  fun error.text(~label: label :: String,
+                 v :: Any)
+    :: error.Clause
+  fun error.val(~label: label :: String = "value",
+                v :: Any)
+    :: error.Clause
+  fun error.vals(~label: label :: String = "value",
+                 v :: Any, ...)
+    :: error.Clause
+  fun error.annot(~label: label :: String = "annotation",
+                  annot_str :: String)
+    :: error.Clause
+){
+
+ An @rhombus(error.Clause, ~annot) represents a piece of an error
+ message that has a label followed by a value or text. The
+ @rhombus(error.text) constructor is the most generic one, where the
+ argument @rhombus(v) is converted with @rhombus(to_string) to include in
+ the message. If the string form of @rhombus(v) spans multiple lines,
+ each line will get a 3-space prefix to incorporate it into the message
+ string; see also @rhombus(error.reindent).
+
+ The @rhombus(error.val) and @rhombus(error.vals) function convert each
+ @rhombus(v) to a string using @rhombus(repr).
+
+ Use @rhombus(error.annot) to report an annotation in an error message,
+ where @rhombus(Syntax.to_source_string) may be useful (especially in in
+ a macro's implementation) to construct a suitable string form of an
+ annotation.
+
+ The @rhombus(msg) field of a @rhombus(error.Clause, ~annot) omits a
+ 2-space prefix that will be added to the clause by @rhombus(error) or
+ @rhombus(error.message), but if it spans multiple lines, then
+ @rhombus(msg) will include a 3-space prefix on each line after the first
+ one.
+
+@examples(
+  error.text(~label: "name", "Alice")
+  error.val([1, 2, 3])
+  error.val(~label: "list", [1, 2, 3])
+  error.vals(1, 2, 3)
+  error.annot("List.of(Int)")
+)
+
+}
+
+
+@doc(
+  fun error.annot_msg(what :: String = "value")
+){
+
+ Constructs the text of a ``does not satify annotation'' error, using
+ @rhombus(what) as the noun in the message.
+
+}
+
+
+@doc(
+  fun error.reindent(
+    s :~ String,
+    ~space: space :: String = " ",
+    ~tab: tab :: String = "   ",
+    ~label: label :: String = "",
+    ~max_len: max_len :: NonnegInt
+                = 72 - (2 + label.length() + 1 + space.length())
+  ) :: String
+){
+
+ The indentation function used by @rhombus(error.text) and related
+ functions. If @rhombus(s) has multiple lines or if it is longer than
+ @rhombus(max_len) characters, then @rhombus(s) is prefixed with a
+ newline, and each line of @rhombus(s) is prefixed with @rhombus(tab).
+ Otherwise, @rhombus(s) is prefixed with just @rhombus(space).
+
+ The @rhombus(label) argument is used only to determine the default
+ value of @rhombus(max_len).
+
+}

--- a/rhombus/rhombus/scribblings/ref-exn.scrbl
+++ b/rhombus/rhombus/scribblings/ref-exn.scrbl
@@ -101,22 +101,6 @@
 
 }
 
-@doc(
-  fun error(message :: ReadableString)
-    :: None
-  fun error(
-    who :: maybe(ReadableString || Symbol || Identifier || Operator),
-    message :: ReadableString
-  ) :: None
-){
-
- Throws the @rhombus(Exn.Fail, ~class) exception with @rhombus(message) as the
- message and @rhombus(Continuation.Marks.current()) as the continuation
- marks. If @rhombus(who) is not @rhombus(#false), it is added to the
- beginning of the message, and a @litchar{: } separator is added in
- between.
-
-}
 
 @doc(
   class Exn(message :: ReadableString, marks :: Continuation.Marks)
@@ -178,5 +162,18 @@
 ){
 
  Primitive exceptions.
+
+}
+
+
+@doc(
+  fun Exn.Fail.Annot(message :: ReadableString,
+                     marks :: Continuation.Marks)
+    :: Exn.Fail.Contract
+){
+
+ A constructor alias for @rhombus(Exn.Fail.Contract, ~annot), since
+ annotation-satisfaction failures exceptions do not have additional
+ information beyond @rhombus(Exn.Fail.Contract, ~annot).
 
 }

--- a/rhombus/rhombus/scribblings/ref-stxobj-meta.scrbl
+++ b/rhombus/rhombus/scribblings/ref-stxobj-meta.scrbl
@@ -9,18 +9,22 @@
 
 @doc(
   ~meta
-  fun syntax_meta.error(in_stx :: Syntax)
-    :: None
-  fun syntax_meta.error(message :: ReadableString,
+  fun syntax_meta.error(~who: who :: maybe(error.Who) = #false,
                         in_stx :: Syntax)
     :: None
-  fun syntax_meta.error(message :: ReadableString,
+  fun syntax_meta.error(~who: who :: maybe(error.Who) = #false,
+                        message :: ReadableString,
+                        in_stx :: Syntax)
+    :: None
+  fun syntax_meta.error(~who: who :: maybe(error.Who) = #false,
+                        message :: ReadableString,
                         in_stx :: Syntax,
                         at_stx :: Syntax || List.of(Syntax))
     :: None
 ){
 
  Throws a syntax-error message concerning @rhombus(in_stx). If
+ @rhombus(who) is @rhombus(#false), it is inferred from @rhombus(in_stx). If
  @rhombus(message) is not provided, the message is @rhombus("bad syntax").
  If @rhombus(at_stx) is provided, it should be something like an enclosed
  form of @rhombus(in_stx) to provide extra context. Alternatively,

--- a/rhombus/rhombus/scribblings/ref-stxobj.scrbl
+++ b/rhombus/rhombus/scribblings/ref-stxobj.scrbl
@@ -238,11 +238,11 @@ Metadata for a syntax object can include a source location and the raw
 
  @item{@rhombus(Name, ~annot) matches a syntax object that is an
   identifier, operator, or dotted multi-term group that fits the shape of
-  an @rhombus(op_or_id_name).}
+  an @nontermref(op_or_id_name).}
 
  @item{@rhombus(IdentifierName, ~annot) matches a syntax object that is an
   identifier or dotted multi-term group that fits the shape of
-  an @rhombus(id_name).}
+  an @nontermref(id_name).}
 
 
 )

--- a/rhombus/rhombus/scribblings/reference.scrbl
+++ b/rhombus/rhombus/scribblings/reference.scrbl
@@ -30,6 +30,7 @@
 @include_section("ref-for.scrbl")
 @include_section("ref-recur.scrbl")
 @include_section("ref-parameter.scrbl")
+@include_section("ref-error.scrbl")
 @include_section("ref-exn.scrbl")
 @include_section("ref-control.scrbl")
 

--- a/rhombus/rhombus/tests/example-interp-ast.rhm
+++ b/rhombus/rhombus/tests/example-interp-ast.rhm
@@ -62,7 +62,9 @@ fun parse(s):
   | '($e)':
       parse(e)
   | ~else:
-      error(#'parse, "invalid input: " +& s)
+      error(~who: #'parse,
+            "invalid input",
+            error.val(~label: "given", s))
 
 module test:
   check: parse('2')
@@ -105,7 +107,7 @@ fun interp(a, env):
           interp(body,
                  extend_env(bind(n, interp(arg, env)),
                             c_env))
-      | ~else: error(#'interp, "not a function")
+      | ~else: error(~who: #'interp, "not a function")
   | if0E(tst, thn, els):
       interp(if num_is_zero(interp(tst, env))
              | thn
@@ -168,13 +170,13 @@ fun num_op(op, l, r):
   | l is_a intV && r is_a intV:
       intV(op(intV.n(l), intV.n(r)))
   | ~else:
-      error(#'interp, "not a number")
+      error(~who: #'interp, "not a number")
 fun num_plus(l :: Value, r :: Value) :: Value:
   num_op(fun (a, b): a+b, l, r)
 fun num_is_zero(v :: Value) :: Boolean:
   match v
   | intV(n): n == 0
-  | ~else: error(#'interp, "not a number")
+  | ~else: error(~who: #'interp, "not a number")
 
 module test:
   check: num_plus(intV(1), intV(2))
@@ -189,7 +191,7 @@ fun lookup(n, env):
   // traditional recursion
   match env
   | []:
-      error(#'lookup, "free variable: " +& n)
+      error(~who: #'lookup, "free variable: " +& n)
   | List.cons(b, rst_env):
       cond
       | n == bind.name(b):

--- a/rhombus/rhombus/tests/exn.rhm
+++ b/rhombus/rhombus/tests/exn.rhm
@@ -3,7 +3,7 @@
 block:
   import "static_arity.rhm"
   static_arity.check:
-    error([who], msg)
+    error(msg, clause, ...)
 
 block:
   use_static
@@ -52,19 +52,87 @@ block:
     v is_a Exn ~is #true
 
 check:
-  error(#'example, "~a oops")
+  error(~who: #'example, "~a oops")
   ~throws "~a oops"
 
 block:
   check:
-    error("who-str", "message")
+    error(~who: "who-str", "message")
     ~throws values("who-str: ", "message")
   check:
-    error(#'who_sym, "message")
+    error(~who: #'who_sym, "message")
     ~throws values("who_sym: ", "message")
   check:
-    error(Syntax.make(#'who_id), "message")
+    error(~who: Syntax.make(#'who_id), "message")
     ~throws values("who_id: ", "message")
   check:
-    error(Syntax.make_op(#'who_op), "message")
+    error(~who: Syntax.make_op(#'who_op), "message")
     ~throws values("who_op: ", "message")
+  check:
+    error(~who: Syntax.make_op(#'who_op).source_properties("PREFIX", "the who", "!", "SUFFIX"), "message")
+    ~throws values("the who!: ", "message")
+  check:
+    error(~who: 'some.namespace.function', "message")
+    ~throws values("some.namespace.function: ", "message")
+  check:
+    error(~who: 'some .  namespace .function', "message")
+    ~throws values("some .  namespace .function: ", "message")
+  check:
+    error(~who: '+++', "message")
+    ~throws values("+++: ", "message")
+  check:
+    error(~who: 'some.namespace.(+++)', "message")
+    ~throws values("some.namespace.(+++): ", "message")
+
+block:
+  check:
+    error(~srcloc: Srcloc("file", 1, 2, 3, 4), "message")
+    ~throws values("file:1:2", "message")
+  check:
+    error(~srcloc: Srcloc("file", 1, #false, 3, 4), "message")
+    ~throws values("file::3", "message")
+
+block:
+  import:
+    meta -1: rhombus/meta open
+    lib("racket/base.rkt")
+  parameterize { base.#{error-print-source-location}: #true }:
+    check:
+      syntax_meta.error("wrong form")
+      ~throws "wrong form"
+    check:
+      syntax_meta.error('garbage + 2')
+      ~throws values("garbage: ",  "bad syntax", "garbage + 2")
+    check:
+      syntax_meta.error("all wrong", 'garbage + 2')
+      ~throws values("garbage: ", "all wrong", "garbage + 2")
+    check:
+      syntax_meta.error("all wrong", 'garbage + 2', 'extra1')
+      ~throws values("garbage: ", "all wrong", "garbage + 2", "extra1")
+    check:
+      syntax_meta.error(~who: "my_form", 'garbage + 2')
+      ~throws values("my_form: ", "bad syntax", "garbage + 2")
+    check:
+      syntax_meta.error(~who: "my_form", "all wrong", 'garbage + 2')
+      ~throws values("my_form: ", "all wrong", "garbage + 2")
+    check:
+      syntax_meta.error(~who: "my_form", "all wrong", 'garbage + 2', 'extra1')
+      ~throws values("my_form: ", "all wrong", "garbage + 2", "extra1")
+    check:
+      syntax_meta.error(~who: "my_form", "all wrong", 'garbage + 2', ['extra1', 'extra2'])
+      ~throws values("my_form: ", "all wrong", "garbage + 2", "extra1")
+    check:
+      syntax_meta.error(~who: #'my_form, 'garbage + 2')
+      ~throws values("my_form: ", "bad syntax", "garbage + 2")
+    check:
+      syntax_meta.error(~who: 'my_form', 'garbage + 2')
+      ~throws values("my_form: ", "bad syntax", "garbage + 2")
+    check:
+      syntax_meta.error(~who: '+++', 'garbage + 2')
+      ~throws values("+++: ", "bad syntax", "garbage + 2")
+    check:
+      syntax_meta.error(~who: 'my_ns.my_form', 'garbage + 2')
+      ~throws values("my_ns.my_form: ", "bad syntax", "garbage + 2")
+    check:
+      syntax_meta.error(~who: 'my_ns.(++)', 'garbage + 2')
+      ~throws values("my_ns.(++): ", "bad syntax", "garbage + 2")

--- a/rhombus/rhombus/tests/recur.rhm
+++ b/rhombus/rhombus/tests/recur.rhm
@@ -71,7 +71,7 @@ check:
 check:
   recur loop(x :: String = 10):
     x.length()
-  ~throws "value does not match annotation"
+  ~throws "value does not satisfy annotation"
 
 check:
   (recur loop(x :: String = "abs") :: String:
@@ -88,12 +88,12 @@ check:
 check:
   recur loop(x :: String = "abs") :: String:
     0
-  ~throws "result does not match annotation"
+  ~throws "result does not satisfy annotation"
 
 check:
   recur loop(x :: String = "abs") :: (String, Int):
     0
-  ~throws "result does not match annotation"
+  ~throws "result does not satisfy annotation"
 
 check:
   def mutable count = 0

--- a/rhombus/rhombus/tests/rx.rhm
+++ b/rhombus/rhombus/tests/rx.rhm
@@ -419,8 +419,8 @@ block:
   check ((rx'($d: any) $rx1'.match("dabc")) :~ RXMatch)[#'c] ~is "c"
   check ((rx'($d: any) $rx1'.match("dabc")) :~ RXMatch)[#'d] ~is "d"
   check M rx'$rxor $rxor' "ab" ~is ["ab"]
-  check rx'($x: $rx1) $x' ~throws "cannot splice RX that has capture groups"
-  check rx'$rxc' ~throws "cannot splice RX backreferences"
+  check rx'($x: $rx1) $x' ~throws "cannot splice regexp that has capture groups"
+  check rx'$rxc' ~throws "cannot splice regexp with backreferences"
 
 expr.macro 'check_throws $t ... $(msg :: String)':
   'check:

--- a/rhombus/rhombus/tests/static_arity.rhm
+++ b/rhombus/rhombus/tests/static_arity.rhm
@@ -28,7 +28,7 @@ expr.macro 'static_arity_check $(pattern:
                 )
               ...':
   fun make_error(_):
-    'error("static_arity.check", "should not get here")'
+    'error(~who: "static_arity.check", "should not get here")'
   fun extract_args(args):
     fun
     | make_less('($arg, ..., $_)'): '($(make_error(arg)), ...)'

--- a/shrubbery-render-lib/shrubbery/render/define.rhm
+++ b/shrubbery-render-lib/shrubbery/render/define.rhm
@@ -70,8 +70,8 @@ meta:
   fun escape_tail(stxs):
     match stxs
     | '#,($expr ...) $tail ...':
-        let escaped_id = current_escape_id()
-        'sequence_cons_syntax($escaped_id($expr ...), $(escape_tail('$tail ...')),
+        let Pair(escaped_id, self) = current_escape_id()
+        'sequence_cons_syntax($escaped_id(#' $self, $expr ...), $(escape_tail('$tail ...')),
                               Syntax.literal($(head_escape_context(stxs))))'
     | '$head $tail ...':
         let new_head = escape_term(head)
@@ -152,11 +152,11 @@ meta:
     | ~else:
         syntax_meta.error("invalid space", kw_stx)
 
-  fun escape_top(g, escape_id):
-    parameterize { current_escape_id: escape_id }:
+  fun escape_top(self, g, escape_id):
+    parameterize { current_escape_id: Pair(escape_id, self) }:
       escape_group(g)
-  fun escape_top_term(t, escape_id):
-    parameterize { current_escape_id: escape_id }:
+  fun escape_top_term(self, t, escape_id):
+    parameterize { current_escape_id: Pair(escape_id, self) }:
       escape_term(t)
 
 defn.macro 'macros ($rhombus,
@@ -169,41 +169,46 @@ defn.macro 'macros ($rhombus,
   '«
      expr.macro
      | '$rhombus ($('$')(forms :: Group))':
-         '$typeset_rhombus($('$')(escape_top(spacer.adjust_group(forms, #false, '#,'), '$escape'))) :~ $Result'
+         ~op_stx: self
+         '$typeset_rhombus($('$')(escape_top(self, spacer.adjust_group(forms, #false, '#,'), '$escape'))) :~ $Result'
      | '$rhombus ($('$')forms, ~at $('$')(name0 :: Name) $('$')(name :: Name) $('...'))':
+         ~op_stx: self
          let sp = [Symbol.from_string(String.append(to_string(name0),
                                                     to_string(name), $('...')))]
          '$typeset_rhombus(~space: #'$('$')sp,
-                           $('$')(escape_top(spacer.adjust_group(forms, sp, '#,'), '$escape'))) :~ $Result'
+                           $('$')(escape_top(self, spacer.adjust_group(forms, sp, '#,'), '$escape'))) :~ $Result'
      | '$rhombus ($('$')forms, $('$')(kw_stx :: Keyword))':
+         ~op_stx: self
          let kw = kw_stx.unwrap()
          match keyword_mode(kw_stx)
          | #'plain:
              '$typeset_rhombus(~space: #'$('$')kw_stx, $('$')(literal_group(forms))) :~ $Result'
          | #'spaced:
              let sp = #{full-space-names}(kw)
-             '$typeset_rhombus(~space: #'$('$')kw_stx, $('$')(escape_top(spacer.adjust_group(forms, sp, '#,'), '$escape'))) :~ $Result'
+             '$typeset_rhombus(~space: #'$('$')kw_stx, $('$')(escape_top(self, spacer.adjust_group(forms, sp, '#,'), '$escape'))) :~ $Result'
 
      expr.macro '$rhombusblock_etc $('$')tail $('...')':
+       ~op_stx: self
        ~all_stx stx
-       '$('$')(rhombusblock_etc(stx, '$('$')tail $('...')', '$typeset_rhombusblock', '$escape')) :~ $Result'
+       '$('$')(rhombusblock_etc(self, stx, '$('$')tail $('...')', '$typeset_rhombusblock', '$escape')) :~ $Result'
 
      expr.macro '$rhombusblock ($('$')args)':
+       ~op_stx: self
        '$typeset_rhombusblock(
           ~indent_from_block: #false,
-          $('$')(escape_top_term(spacer.adjust_term(': $('$')args', #false, '#,'), '$escape'))
+          $('$')(escape_top_term(self, spacer.adjust_term(': $('$')args', #false, '#,'), '$escape'))
         ) :~ $Result'
   »'
 
 meta:
-  fun rhombusblock_etc(stx, '$tail ...', typeset_rhombusblock_stx, escape_id):
+  fun rhombusblock_etc(self, stx, '$tail ...', typeset_rhombusblock_stx, escape_id):
     fun finish([opt, ...], fin_tail):
       match fin_tail
       | ': $_': #void
       | ~else: syntax_meta.error("expected a block", stx)
       '$typeset_rhombusblock_stx(
          $opt, ...,
-         $(escape_top_term(spacer.adjust_term(fin_tail, #false, '#,'), escape_id))
+         $(escape_top_term(self, spacer.adjust_term(fin_tail, #false, '#,'), escape_id))
        )'
     fun check_options(options :~ List):
       for (opt: options):

--- a/shrubbery-render-lib/shrubbery/render/private/spacer.rhm
+++ b/shrubbery-render-lib/shrubbery/render/private/spacer.rhm
@@ -97,7 +97,8 @@ meta:
   fun adjust_group(g :: Group, context, esc :: Name) :~ Syntax:
      match adjust_sequence(g, context, esc)
      | '$(new_g :: Group)': new_g.relocate_group(g)
-     | '': error("group turned into empty sequence: " +& to_string(g, ~mode: #'expr))
+     | '': error("group turned into empty sequence",
+                 error.val(~label: "group", g))
 
   fun adjust_sequence(seq :: TermSequence, context :: Context, esc :: Name) :~ Syntax:
     fun loop(head, tail):
@@ -131,12 +132,15 @@ meta:
             try:
               proc(!implicit && set_space(id, relevant_context), tail, context, esc)
               ~catch x :: Exn.Fail:
-                error("error from " +& to_string(id, ~mode: #'expr) +& " spacer\n"
-                        +& "  message: " +& Exn.message(x))
+                error("error from spacer",
+                      error.val(~label: "spacer form", id),
+                      error.text(~label: "message", Exn.message(x)))
           match res
           | '$_ ...': res
           | ~else:
-              error(#false, "spacer " +& proc +& " returned wrong value " +& to_string(res, ~mode: #'expr))
+              error("spacer returned wrong value",
+                    error.val(~label: "spacer function", proc),
+                    error.val(~label: "result", res))
         | fail()
     | ~else:
         fail()


### PR DESCRIPTION
This change is backward-incompatible, because it makes the `who` argument to `error` a keyword argument with `~who`, and it renames `Exn.Fail.Contract` to `Exn.Fail.Annot`.

The main change is to add support for message details and clauses. Clause constructors like `error.val` and `error.annot` build the label–value pairs that go at the end of an error message. The `error.message` function can be used to just construct the message text that `error` puts into an exception.

This commit does not change the non-message content of exceptions, but the clause protocol is meant to accommodate and adapt to future changes.

Examples from the docs:

```
> error("oops")
oops
> error(~who: #'me, "oops")
me: oops
> error(~who: #'me,
        "oops",
        ~details: ["something has gone wrong;",
                   "see the manual for more information"])
me: oops;
 something has gone wrong;
 see the manual for more information
> error(~who: #'me,
        ~exn: Exn.Fail.Annot,
        error.annot_msg("fruit"),
        error.annot("Tropical"),
        error.val(~label: "fruit", #'Apple))
me: fruit does not satisfy annotation
  annotation: Tropical
  fruit: #’Apple
> error(~who: #'me,
        "mismatch between fruit and vegetable",
        error.val(~label: "fruit", [#'Apple, 0]),
        error.val(~label: "vegetable", [#'Lettuce, -1]))
me: mismatch between fruit and vegetable
  fruit: [#’Apple, 0]
  vegetable: [#’Lettuce, -1]
```

I expected to have various helper functions like `annot_error` to raise a standard "does not satisfy annotation" error, for example. But in changing existing error messages, I concluded that it's better to have functions for constructing arguments to `error`, such as the `error.annot_msg()` for constructing the main "does not satisfy annotation" message text. A drawback of this approach is that `error.annot_msg()` as an argument to `error` needs to be paired with `~exn: Exn.Fail.Annot` as well as (usually) `error.annot` and `error.val` clause constructions. But this approach still ended up being more comfortable than an `annot_error` function, because explicitly raised annotation errors often include small variations on the normal message (otherwise `::` would be used in the first place), and it seemed easiest to just remember and use the `error` protocol.
