### PR TITLE
shrubbery: make `\` handling more normal

### DIFF
--- a/shrubbery-lib/shrubbery/navigation.rkt
+++ b/shrubbery-lib/shrubbery/navigation.rkt
@@ -67,10 +67,10 @@
 ;; if `pos` is at the first bar
 (define (start-of-alts t pos)
   (define at-start (line-start t pos))
-  (define col (col-of pos at-start (line-delta t at-start)))
+  (define col (col-of pos at-start))
   (define (outdented? s)
     (define start (line-start t s))
-    (define s-col (col-of s start (line-delta t s)))
+    (define s-col (col-of s start))
     (s-col . <= . col))
   (define (select last-bar last-block last-pos s)
     (or last-bar (and last-pos last-block) last-pos s))
@@ -113,7 +113,7 @@
                [(opener)
                 (select last-bar last-block last-pos s)]
                [(bar-operator)
-                (define s-col (col-of s s-start (line-delta t s-start)))
+                (define s-col (col-of s s-start))
                 (cond
                   [(eqv? bar-start s-start)
                    ;; same line, so earlier bar the in same block

--- a/shrubbery/shrubbery/scribblings/group-and-block.scrbl
+++ b/shrubbery/shrubbery/scribblings/group-and-block.scrbl
@@ -593,10 +593,17 @@ inside:« fruit » more
 
 As a last resort, @litchar{\} can be used at the end of a line (optionally
 followed by whitespace and coments on the line) to continue the next
-line as it if were one line continuing with the next line. The itself
-@litchar{\} does not appear in the parsed form. A @litchar{\} that is not at the end of a
-line (followed by whitespace and coments) is treated the same as
-whitespace.
+line as it if were one line continuing with the next line. The
+@litchar{\} itself does not appear in the parsed form. Within the same line,
+a @litchar{\} can be followed only by whitespace and comments in line-sensitive
+mode (i.e., outside @guillemets that form a line-insensitive group).
+
+A continuing @litchar{\} does not affect the assignment of columns to
+positions on a subsequent line; that is, column counting starts again
+at 0 following a newline after @litchar{\}. The beginning of the group
+still determines the group's indentation, even if the continuing line
+starts less indented. When no terms precede a @litchar{\} within a
+group, the @litchar{\} is effectively whitespace.
 
 Lines containing only whitespace and (non-term) comments do not count
 as ``the next line'' even for @litchar{\} continuations, so any number of
@@ -605,28 +612,24 @@ it continues.
 
 @rhombusblock(
   this is \
-    the first group
-  this \ is \ the \ second \ group
+  the first group
+  \
+  this is the second group
 
   this is a group \
-    with (a,
-                             nested,
-                             list)
+  with:
+    a
+    nested
+    block
 
   this is a group \
-   with (a,
-                  \
-         nested,
-                  \
-         list)
+  with (a,
+        nested,
+        list)
 
-  this is a group \
-   with (a,
-                  \
-         /* this a comment on `nested`: */
-         nested,
-                  \
-         list)
+  this is \
+  /* comment */
+  the last group
 )
 
 @section(~tag: "group-comment"){Group Comments with @litchar{#//}}

--- a/shrubbery/shrubbery/scribblings/rationale.scrbl
+++ b/shrubbery/shrubbery/scribblings/rationale.scrbl
@@ -66,19 +66,9 @@ they can be freely added without intefering with grouping. The
 @litchar{\} continuation operator is somewhat unusual in that it skips
 blank and comment lines to continue, as opposed to requiring @litchar{\}
 on every continuing line; that, too, allows extra blank and comment
-lines to be added, even amid continuing lines.
-
-The interaction of indentation and @litchar{\} differs slightly from
-Python, which does not count the space for @litchar{\} itself or any
-leading whitespace on a continuing line toward indentation. Counting the
-leading whitespace on a continuing line has the advantage that it can
-reach an arbitrary amount of identation within a constrained textual
-width. Counting the @litchar{\} itself is consistent with ignoring
-@litchar{\} when it appears within a line, so grouping stays the same
-whether there's a newline or the continue line immediately after
-@litchar{\}. The whitespace role of @litchar{\} also means that spaces
-can be turned into @litchar{\} to ``harden'' code for transfer via media
-(such as email) that might mangle consecutive spaces.
+lines to be added, even amid continuing lines, although at the risk that a
+@litchar{\}'s reach will extend further than intended past blank
+lines.
 
 Using @litchar{~} for keywords has a precedent in OCaml. Reserving
 @litchar{~} for keywords exclusively would use up a character that

--- a/shrubbery/shrubbery/tests/indent.rkt
+++ b/shrubbery/shrubbery/tests/indent.rkt
@@ -203,11 +203,11 @@
           ^green,}
 
  @e{this is a \
-      !ong linear group}
+    ^ong linear group}
 
  @e{this is a \
       very long linear group \
-      !hat spans multiple lines}
+    ^hat spans multiple lines}
 
  @e{this is | one: a \
                     long result
@@ -216,14 +216,14 @@
  @e{this is | one: a \
                     long result
             | two \
-                !lso long}
+    ^         ^lso long}
 
  @e{this is a group \  with (a,
                              ^nested}
 
  @e{this is a group \
       with (a,
-                             ^nested}
+            ^nested}
 
  @e{this is a group \
      with (a,
@@ -231,8 +231,8 @@
            ^nested}
 
  @e{hello | a | c\
-     :
-                     ^d}
+      :
+        ^d}
 
  @e{nonsense:
       hello | there 4.5

--- a/shrubbery/shrubbery/tests/input.rkt
+++ b/shrubbery/shrubbery/tests/input.rkt
@@ -1509,16 +1509,18 @@ this is | one: a \
 
 this is \
   the first group
-this \ is \ the \ second \ group
+\
+this is the second group
 
-this is a group \  with (a,
-                         nested,
-                         list)
+this is a group with (a, \
+                      nested \
+                      ,
+                      list)
 
 this is a group \
   with (a,
-                         nested,
-                         list)
+        nested,
+        list)
 
 this is a group \
  with (a,
@@ -1541,12 +1543,28 @@ hello | a | c\
 
 this: \
       is more
-             foo
+      foo
 
 foo
 | more \
 | again:
-             sub
+   sub
+
+hello:
+  one two \
+  three:
+    more
+  four
+
+hello:
+  one two \
+three:
+    more
+four
+
+a \ /* multi
+       line */
+ b
 
 a
 |
@@ -1673,6 +1691,10 @@ INPUT
     (group
      foo
      (alts (block (group more)) (block (group again (block (group sub))))))
+    (group hello (block (group one two three (block (group more))) (group four)))
+    (group hello (block (group one two three (block (group more)))))
+    (group four)
+    (group a b)
     (group a (alts (block (group b (alts (block (group x)))) (group d))))
     (group something (op +))
     (group more stuff)

--- a/shrubbery/shrubbery/tests/parse.rkt
+++ b/shrubbery/shrubbery/tests/parse.rkt
@@ -270,3 +270,7 @@
 (check-fail " 1\n \t2" #rx"wrong indentation")
 (check-fail "\ta\n\t| 1\n | 2" #rx"mixed tabs")
 (check-fail "\"x\ty\": 1\n       2" #rx"mixed tabs")
+
+(check-fail "1 \\ 2" #rx"line-continuing '\\\\' is followed by a another token")
+(check-fail "1 \\ /* ok */ 2" #rx"line-continuing '\\\\' is followed by a another token")
+(check-fail "1 \\ \n 2 \\ 3" #rx"line-continuing '\\\\' is followed by a another token")


### PR DESCRIPTION
The original `\` rules were trying too hard to enable something that hasn't turned out to matter: being able to reach any virtual column within a narrow physical column. The attempt made the interaction of `\` and indentation very difficult to parse visually.

Make `\` much simpler by not affecting the way that columns are assigned to tokens on the next line. If a continuing line has an opening parenthesis or `:` followed by another token, for example, that token's column (potentially needed by subsequent lines) is the visually obvious one, instead of a column that depends on the continued line's length. Editor indentation support encourages lining up a continuing line's start with the group's start; something more specialized would be possible, but that's the simplest and most obvious choice, and it looks reasonable.

Also, disallow `\` followed by more on the same line. Previously, a `\` with mroe on the same line that was treated as whitespace, but whitespace `\`s haven't turned out to be useful, either. It's less confusing to disallow them. Disalloweing them also potentially leaves a little more room for future uses of `\`; then again, `\` needs to be treated as whitespace after all in line-insensitive mode, so that may limit future meanings for `\`.