### PR TITLE
Print immutable arrays/boxes as `.snapshot`s

### DIFF
--- a/rhombus/rhombus/scribblings/reference/array.scrbl
+++ b/rhombus/rhombus/scribblings/reference/array.scrbl
@@ -265,9 +265,15 @@ contents, even if one is mutable and the other is immutable.
  @rhombus(end) (exclusive).
 
 @examples(
-  Array("a", "b", "c").copy()
-  Array("a", "b", "c").copy(1)
-  Array("a", "b", "c").copy(1, 2)
+  ~repl:
+    def a = Array("a", "b", "c")
+    a.copy()
+    a.copy(1)
+    a.copy(1, 2)
+  ~repl:
+    def a = Array("a", "b", "c").snapshot()
+    a.copy()
+    a.copy() is_now a
 )
 
 }
@@ -289,15 +295,21 @@ contents, even if one is mutable and the other is immutable.
 }
 
 @doc(
-  fun Array.snapshot(arr :: Array)
-    :: ImmutableArray
+  fun Array.snapshot(arr :: Array) :: ImmutableArray
 ){
 
  Returns an immutable array as-is or copies a mutable array's content to
  an immutable array.
 
 @examples(
-  Array("a", "b", "c").snapshot()
+  ~repl:
+    def a = Array("a", "b", "c")
+    a.snapshot()
+    a.snapshot() is_now a
+  ~repl:
+    def a = Array("a", "b", "c").snapshot()
+    a.snapshot()
+    a.snapshot() === a
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/box.scrbl
+++ b/rhombus/rhombus/scribblings/reference/box.scrbl
@@ -6,7 +6,7 @@
 @title{Boxes}
 
 A @deftech{box} is an object with a single value field, which can be
-accessed from a box @rhombus(bx) as
+accessed from a box @rhombus(bx, ~var) as
 @rhombus(#,(@rhombus(bx, ~var)).value) or set to the value of
 @nontermref(expr) using
 @rhombus(#,(@rhombus(bx, ~var)).value := #,(@nontermref(expr)))
@@ -14,10 +14,17 @@ or other @tech{assignment operators} like @rhombus(:=). The function
 @rhombus(Box.value) can also be directly used.
 
 A box is normally mutable, but immutable boxes can originate from
-Racket. Assignment is statically allowed by fails dynamically for an
+Racket or @rhombus(Box.snapshot). Assignment is statically allowed but fails dynamically for an
 immutable box. The @rhombus(Box, ~annot) annotation is satisfied by both
 mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
 @rhombus(ImmutableBox, ~annot) require one or the other.
+
+@dispatch_table(
+  "box"
+  Box
+  bx.copy()
+  bx.snapshot()
+)
 
 @doc(
   annot.macro 'Box'
@@ -25,7 +32,6 @@ mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
   annot.macro 'Box.later_of($annot)'
   annot.macro 'MutableBox'
   annot.macro 'ImmutableBox'
-
 ){
 
  The @rhombus(Box, ~annot) annotation (without @rhombus(now_of, ~datum) or
@@ -37,7 +43,7 @@ mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
  values installed into the box will satisfy @rhombus(annot). The
  given @rhombus(annot) must not be a converting annotation. Static
  information from @rhombus(annot) is not propagated to accesses of
- the box's values, since there's no gauarantee that the value will still
+ the box's values, since there's no guarantee that the value will still
  satisfy the annotation.
 
  The @rhombus(Box.later_of, ~annot) form constructs a @tech(~doc: guide_doc){converter
@@ -46,7 +52,7 @@ mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
  result of the annotation is a view on the original box, but one where
  @rhombus(annot) is checked against a value when it is accessed from
  the box or for a value to be installed into the box. (A different view
- of the box might changes its value to one that does not astisfy
+ of the box might changes its value to one that does not satisfy
  @rhombus(annot).) Static information from @rhombus(annot) is propagated
  to accesses of the box's value. Note that a converter @rhombus(annot)
  is applied for each access or update.
@@ -75,14 +81,14 @@ mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
   fun Box(v :: Any) :: Box
 ){
 
- Constructs a box containg @rhombus(v)).
+ Constructs a box containing @rhombus(v).
 
 @examples(
-  def bx = Box(1)
-  bx
-  bx.value
-  bx.value := 2
-  bx
+  def b = Box(1)
+  b
+  b.value
+  b.value := 2
+  b
 )
 
 }
@@ -104,17 +110,36 @@ mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
 
 
 @doc(
-  fun Box.value(box :: Box) :: Any
-  fun Box.value(box :: MutableBox, val :: Any) :: Void
+  fun Box.value(bx :: Box) :: Any
+  fun Box.value(bx :: MutableBox, val :: Any) :: Void
 ){
 
- Accesses or updates the value field of @rhombus(box).
+ Accesses or updates the value field of @rhombus(bx).
 
 @examples(
-  def bx = Box(1)
-  Box.value(bx)
-  Box.value(bx, 2)
-  Box.value(bx)
+  def b = Box(1)
+  Box.value(b)
+  Box.value(b, 2)
+  Box.value(b)
 )
+
+}
+
+
+@doc(
+  fun Box.copy(bx :: Box) :: MutableBox
+){
+
+ Creates a mutable box whose initial content matches @rhombus(bx).
+
+}
+
+
+@doc(
+  fun Box.snapshot(bx :: Box) :: ImmutableBox
+){
+
+ Returns an immutable box whose content matches @rhombus(bx). If
+ @rhombus(bx) is immutable, then it is the result.
 
 }

--- a/rhombus/rhombus/scribblings/reference/box.scrbl
+++ b/rhombus/rhombus/scribblings/reference/box.scrbl
@@ -132,6 +132,16 @@ mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
 
  Creates a mutable box whose initial content matches @rhombus(bx).
 
+@examples(
+  ~repl:
+    def b = Box(1)
+    b.copy()
+  ~repl:
+    def b = Box(1).snapshot()
+    b.copy()
+    b.copy() is_now b
+)
+
 }
 
 
@@ -141,5 +151,16 @@ mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
 
  Returns an immutable box whose content matches @rhombus(bx). If
  @rhombus(bx) is immutable, then it is the result.
+
+@examples(
+  ~repl:
+    def b = Box(1)
+    b.snapshot()
+    b.snapshot() is_now b
+  ~repl:
+    def b = Box(1).snapshot()
+    b.snapshot()
+    b.snapshot() === b
+)
 
 }

--- a/rhombus/rhombus/scribblings/reference/bytes.scrbl
+++ b/rhombus/rhombus/scribblings/reference/bytes.scrbl
@@ -155,8 +155,14 @@ like @rhombus(<) and @rhombus(>) work on byte strings.
   fun Bytes.copy(bstr :: Bytes) :: MutableBytes
 ){
 
- Returns a frash mutable byte string with the same initial content as
+ Returns a fresh mutable byte string with the same initial content as
  @rhombus(bstr).
+
+@examples(
+  def b = #"apple"
+  b.copy()
+  b.copy() is_now b
+)
 
 }
 
@@ -177,15 +183,21 @@ like @rhombus(<) and @rhombus(>) work on byte strings.
 }
 
 @doc(
-  fun Bytes.snapshot(str :: Bytes)
-    :: ImmutableBytes
+  fun Bytes.snapshot(str :: Bytes) :: ImmutableBytes
 ){
 
  Returns an immutable byte string as-is or copies a mutable byte
  string's content to an immutable byte string.
 
 @examples(
-  #"apple".copy().snapshot()
+  ~repl:
+    def b = #"apple"
+    b.snapshot()
+    b.snapshot() === b
+  ~repl:
+    def b = #"apple".copy()
+    b.snapshot()
+    b.snapshot() is_now b
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/map.scrbl
+++ b/rhombus/rhombus/scribblings/reference/map.scrbl
@@ -615,8 +615,16 @@ in an unspecified order.
 
  Creates a mutable map whose initial content matches @rhombus(mp).
 
-}
+@examples(
+  ~repl:
+    def m = {"a": 1, "b": 2}
+    m.copy()
+  ~repl:
+    def m = MutableMap{"a": 1, "b": 2}
+    m.copy()
+)
 
+}
 
 
 @doc(
@@ -625,6 +633,16 @@ in an unspecified order.
 
  Returns an immutable map whose content matches @rhombus(mp). If
  @rhombus(mp) is immutable, then it is the result.
+
+@examples(
+  ~repl:
+    def m = {"a": 1, "b": 2}
+    m.snapshot()
+    m.snapshot() === m
+  ~repl:
+    def m = MutableMap{"a": 1, "b": 2}
+    m.snapshot()
+)
 
 }
 

--- a/rhombus/rhombus/scribblings/reference/set.scrbl
+++ b/rhombus/rhombus/scribblings/reference/set.scrbl
@@ -461,6 +461,15 @@ it supplies its elements in an unspecified order.
 
  Creates a mutable set whose initial content matches @rhombus(st).
 
+@examples(
+  ~repl:
+    def s = {"a", "b"}
+    s.copy()
+  ~repl:
+    def s = MutableSet{"a", "b"}
+    s.copy()
+)
+
 }
 
 
@@ -470,6 +479,16 @@ it supplies its elements in an unspecified order.
 
  Returns an immutable set whose content matches @rhombus(st). If
  @rhombus(st) is immutable, then it is the result.
+
+@examples(
+  ~repl:
+    def s = {"a", "b"}
+    s.snapshot()
+    s.snapshot() === s
+  ~repl:
+    def s = MutableSet{"a", "b"}
+    s.snapshot()
+)
 
 }
 

--- a/rhombus/rhombus/scribblings/reference/string.scrbl
+++ b/rhombus/rhombus/scribblings/reference/string.scrbl
@@ -8,7 +8,7 @@ A @deftech{string} is a sequence of Unicode @tech{characters}. A string
 works with map-referencing @brackets to access a character via
 @rhombus(#%index). A string also works with the @rhombus(++) operator to
 append strings, but a @rhombus(+&) can be used to append strings with
-the static guaratee that the result is a string. A string can be used as
+the static guarantee that the result is a string. A string can be used as
 @tech{sequence}, in which case it supplies its characters in order.
 
 Although Racket supports mutable strings, the @rhombus(String, ~annot)
@@ -367,7 +367,9 @@ Strings are @tech{comparable}, which means that generic operations like
  Creates a mutable copy of @rhombus(str).
 
 @examples(
-  "apple".copy()
+  def s = "apple"
+  s.copy()
+  s.copy() is_now s
 )
 
 }
@@ -380,7 +382,14 @@ Strings are @tech{comparable}, which means that generic operations like
  an immutable string.
 
 @examples(
-  "apple".copy().snapshot()
+  ~repl:
+    def s = "apple"
+    s.snapshot()
+    s.snapshot() === s
+  ~repl:
+    def s = "apple".copy()
+    s.snapshot()
+    s.snapshot() is_now s
 )
 
 }

--- a/rhombus/rhombus/tests/array.rhm
+++ b/rhombus/rhombus/tests/array.rhm
@@ -363,13 +363,12 @@ check:
     "given: \"oops\"",
   )
 
-// TODO print immutable arrays differently
 check:
   (Array(1, 2, 3).snapshot() :~ MutableArray)[0] := 0
   ~throws values(
     "Array.set: contract violation",
     "expected: MutableArray",
-    "given: Array(1, 2, 3)",
+    "given: Array.snapshot(Array(1, 2, 3))",
   )
 
 check:

--- a/rhombus/rhombus/tests/box.rhm
+++ b/rhombus/rhombus/tests/box.rhm
@@ -5,6 +5,8 @@ block:
   static_arity.check:
     Box(v)
     Box.value(bx, [val])
+    Box.copy(bx) ~method
+    Box.snapshot(bx) ~method
 
 check:
   Box(1) ~is_now Box(1)
@@ -15,6 +17,36 @@ check:
   Box(1) is_a ImmutableBox ~is #false
   10 is_a MutableBox ~is #false
   10 is_a ImmutableBox ~is #false
+
+block:
+  use_static
+  let bx = Box(10)
+  let bx_snapshot = bx.snapshot()
+  let bx_copy = bx.copy()
+  check:
+    bx ~is_a MutableBox
+    bx.value ~is 10
+    bx_snapshot ~is_a ImmutableBox
+    bx_snapshot.value ~is 10
+    bx_copy ~is_a MutableBox
+    bx_copy.value ~is 10
+    bx_copy === bx ~is #false
+    bx_snapshot === bx ~is #false
+
+block:
+  use_static
+  let bx = Box(10).snapshot()
+  let bx_snapshot = bx.snapshot()
+  let bx_copy = bx.copy()
+  check:
+    bx ~is_a ImmutableBox
+    bx.value ~is 10
+    bx_snapshot ~is_a ImmutableBox
+    bx_snapshot.value ~is 10
+    bx_copy ~is_a MutableBox
+    bx_copy.value ~is 10
+    bx_copy === bx ~is #false
+    bx_snapshot === bx ~is #true
 
 check:
   use_static
@@ -147,4 +179,13 @@ check:
     "Box.value: contract violation",
     "expected: MutableBox",
     "given: \"oops\"",
+  )
+
+// TODO print immutable boxes differently
+check:
+  (Box(1).snapshot() :~ MutableBox).value := 0
+  ~throws values(
+    "Box.value: contract violation",
+    "expected: MutableBox",
+    "given: Box(1)",
   )

--- a/rhombus/rhombus/tests/box.rhm
+++ b/rhombus/rhombus/tests/box.rhm
@@ -181,11 +181,10 @@ check:
     "given: \"oops\"",
   )
 
-// TODO print immutable boxes differently
 check:
   (Box(1).snapshot() :~ MutableBox).value := 0
   ~throws values(
     "Box.value: contract violation",
     "expected: MutableBox",
-    "given: Box(1)",
+    "given: Box.snapshot(Box(1))",
   )


### PR DESCRIPTION
This PR changes the printing of immutable arrays/boxes to the combination of mutable constructors plus `.snapshot` methods.  `Box.{copy,snapshot}` methods are added both to align with other primitive data types and to allow the printing.