### PR TITLE
`rhombus/draw`: adding a `draw.` prefix

### DIFF
--- a/rhombus-draw/rhombus/draw/scribblings/bitmap.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/bitmap.scrbl
@@ -20,7 +20,7 @@
 @doc(
   property (bm :: draw.Bitmap).width :: PosInt
   property (bm :: draw.Bitmap).height :: PosInt
-  property (bm :: draw.Bitmap).size :: draw.Size
+  property (bm :: draw.Bitmap).size :: Size
   property (bm :: draw.Bitmap).backing_scale :: Real.above(0.0)
   property (bm :: draw.Bitmap).depth :: NonnegInt
   property (bm :: draw.Bitmap).has_color :: Boolean
@@ -28,14 +28,14 @@
   property (bm :: draw.Bitmap).is_ok :: Boolean
 ){
 
- Properties to access bitmap components. The @rhombus(draw.Bitmap.size)
- property combines the @rhombus(draw.Bitmap.width) and @rhombus(draw.Bitmap.height)
+ Properties to access bitmap components. The @rhombus(Bitmap.size)
+ property combines the @rhombus(Bitmap.width) and @rhombus(Bitmap.height)
  properties.
 
 }
 
 @doc(
-  method (bm :: draw.Bitmap).make_dc() :: draw.DC
+  method (bm :: draw.Bitmap).make_dc() :: DC
 ){
 
  Creates a drawing context that writes to the bitmap.
@@ -84,7 +84,7 @@
 }
 
 @doc(
-  fun draw.Bitmap.from_file(path :: String || Path) :: draw.Bitmap
+  fun draw.Bitmap.from_file(path :: String || Path) :: Bitmap
 ){
 
   Reads a bitmap from @rhombus(path).

--- a/rhombus-draw/rhombus/draw/scribblings/bitmap.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/bitmap.scrbl
@@ -5,7 +5,7 @@
 @title{Bitmap}
 
 @doc(
-  class Bitmap():
+  class draw.Bitmap():
     constructor (
       width :: PosInt,
       height :: PosInt,
@@ -18,24 +18,24 @@
 }
 
 @doc(
-  property (bm :: Bitmap).width :: PosInt
-  property (bm :: Bitmap).height :: PosInt
-  property (bm :: Bitmap).size :: Size
-  property (bm :: Bitmap).backing_scale :: Real.above(0.0)
-  property (bm :: Bitmap).depth :: NonnegInt
-  property (bm :: Bitmap).has_color :: Boolean
-  property (bm :: Bitmap).has_alpha :: Boolean
-  property (bm :: Bitmap).is_ok :: Boolean
+  property (bm :: draw.Bitmap).width :: PosInt
+  property (bm :: draw.Bitmap).height :: PosInt
+  property (bm :: draw.Bitmap).size :: draw.Size
+  property (bm :: draw.Bitmap).backing_scale :: Real.above(0.0)
+  property (bm :: draw.Bitmap).depth :: NonnegInt
+  property (bm :: draw.Bitmap).has_color :: Boolean
+  property (bm :: draw.Bitmap).has_alpha :: Boolean
+  property (bm :: draw.Bitmap).is_ok :: Boolean
 ){
 
- Properties to access bitmap components. The @rhombus(Bitmap.size)
- property combines the @rhombus(Bitmap.width) and @rhombus(Bitmap.height)
+ Properties to access bitmap components. The @rhombus(draw.Bitmap.size)
+ property combines the @rhombus(draw.Bitmap.width) and @rhombus(draw.Bitmap.height)
  properties.
 
 }
 
 @doc(
-  method (bm :: Bitmap).make_dc() :: DC
+  method (bm :: draw.Bitmap).make_dc() :: draw.DC
 ){
 
  Creates a drawing context that writes to the bitmap.
@@ -43,7 +43,7 @@
 }
 
 @doc(
-  method (bm :: Bitmap).argb_pixels(
+  method (bm :: draw.Bitmap).argb_pixels(
     ~x: x :: NonnegInt = 0,
     ~y: y :: NonnegInt = 0,
     ~width: width :: NonnegInt = width,
@@ -57,7 +57,7 @@
 }
 
 @doc(
-  method (bm :: Bitmap).set_argb_pixels(
+  method (bm :: draw.Bitmap).set_argb_pixels(
     src :: Bytes,
     ~x: x :: NonnegInt = 0,
     ~y: y :: NonnegInt = 0,
@@ -71,7 +71,7 @@
 }
 
 @doc(
-  method (bm :: Bitmap).write(
+  method (bm :: draw.Bitmap).write(
     dest :: Path,
     ~kind: kind :: Any.of(#'png, #'jpeg, #'xbm, #'xpm, #'bmp),
     ~quality: quality :: Int.in(0, 100) = 75,
@@ -84,7 +84,7 @@
 }
 
 @doc(
-  fun Bitmap.from_file(path :: String || Path) :: Bitmap
+  fun draw.Bitmap.from_file(path :: String || Path) :: draw.Bitmap
 ){
 
   Reads a bitmap from @rhombus(path).

--- a/rhombus-draw/rhombus/draw/scribblings/brush.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/brush.scrbl
@@ -5,12 +5,14 @@
 @title{Brush}
 
 @doc(
-  class Brush():
+  class draw.Brush():
     constructor (
-      ~color: color :: (String || Color) = "Black",
-      ~style: style :: Brush.Style = #'solid,
-      ~stipple: stipple :: maybe(Bitmap) = #false,
-      ~gradient: gradient :: maybe(LinearGradient || RadialGradient) = #false,
+      ~color: color :: (String || draw.Color) = "Black",
+      ~style: style :: draw.Brush.Style = #'solid,
+      ~stipple: stipple :: maybe(draw.Bitmap) = #false,
+      ~gradient:
+        gradient :: maybe(draw.LinearGradient || draw.RadialGradient):
+          #false,
     )
 ){
 
@@ -23,11 +25,11 @@
 }
 
 @doc(
-  property (brush :: Brush).color :: Color
-  property (brush :: Brush).style :: Brush.Style
-  property (brush :: Brush).stipple :: maybe(Bitmap)
-  property (brush :: Brush).gradient
-    :: maybe(LinearGradient || RadialGradient)
+  property (brush :: draw.Brush).color :: draw.Color
+  property (brush :: draw.Brush).style :: draw.Brush.Style
+  property (brush :: draw.Brush).stipple :: maybe(draw.Bitmap)
+  property (brush :: draw.Brush).gradient
+    :: maybe(draw.LinearGradient || draw.RadialGradient)
 ){
 
  Properties to access brush components.
@@ -35,7 +37,7 @@
 }
 
 @doc(
-  enum Brush.Style:
+  enum draw.Brush.Style:
     transparent
     solid
     opaque
@@ -56,7 +58,7 @@
 
 
 @doc(
-  def Brush.none :: Brush
+  def draw.Brush.none :: draw.Brush
 ){
 
  A brush with style @rhombus(#'transparent).
@@ -64,32 +66,32 @@
 }
 
 @doc(
-  class LinearGradient():
-    constructor (pt1 :: PointLike,
-                 pt2 :: PointLike,
-                 [[stop :: Real.in(0.0, 1.0), color :: Color], ...])
-  property (grad :: LinearGradient).line
-    :: matching([_ :: Point, _ :: Point])
-  property (grad :: LinearGradient).stops
-    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: Color]))
+  class draw.LinearGradient():
+    constructor (pt1 :: draw.PointLike,
+                 pt2 :: draw.PointLike,
+                 [[stop :: Real.in(0.0, 1.0), color :: draw.Color], ...])
+  property (grad :: draw.LinearGradient).line
+    :: matching([_ :: draw.Point, _ :: draw.Point])
+  property (grad :: draw.LinearGradient).stops
+    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: draw.Color]))
 ){
 
- A linear gradient for a @rhombus(Brush, ~class).
+ A linear gradient for a @rhombus(draw.Brush, ~class).
 
 }
 
 @doc(
-  class RadialGradient():
-    constructor ([[pt1 :: PointLike], r1 :: Real],
-                 [[pt2 :: PointLike], r2 :: Real],
-                 [[stop :: Real.in(0.0, 1.0), color :: Color], ...])
-  property (grad :: RadialGradient).circles
-    :: matching([[_ :: PointLike, _ :: Real],
-                 [_ :: PointLike, _ :: Real]])
-  property (grad :: RadialGradient).stops
-    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: Color]))
+  class draw.RadialGradient():
+    constructor ([[pt1 :: draw.PointLike], r1 :: Real],
+                 [[pt2 :: draw.PointLike], r2 :: Real],
+                 [[stop :: Real.in(0.0, 1.0), color :: draw.Color], ...])
+  property (grad :: draw.RadialGradient).circles
+    :: matching([[_ :: draw.PointLike, _ :: Real],
+                 [_ :: draw.PointLike, _ :: Real]])
+  property (grad :: draw.RadialGradient).stops
+    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: draw.Color]))
 ){
 
- A radial gradient for a @rhombus(Brush, ~class).
+ A radial gradient for a @rhombus(draw.Brush, ~class).
 
 }

--- a/rhombus-draw/rhombus/draw/scribblings/brush.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/brush.scrbl
@@ -7,12 +7,10 @@
 @doc(
   class draw.Brush():
     constructor (
-      ~color: color :: (String || draw.Color) = "Black",
-      ~style: style :: draw.Brush.Style = #'solid,
-      ~stipple: stipple :: maybe(draw.Bitmap) = #false,
-      ~gradient:
-        gradient :: maybe(draw.LinearGradient || draw.RadialGradient):
-          #false,
+      ~color: color :: (String || Color) = "Black",
+      ~style: style :: Brush.Style = #'solid,
+      ~stipple: stipple :: maybe(Bitmap) = #false,
+      ~gradient: gradient :: maybe(LinearGradient || RadialGradient) = #false
     )
 ){
 
@@ -25,11 +23,11 @@
 }
 
 @doc(
-  property (brush :: draw.Brush).color :: draw.Color
-  property (brush :: draw.Brush).style :: draw.Brush.Style
-  property (brush :: draw.Brush).stipple :: maybe(draw.Bitmap)
+  property (brush :: draw.Brush).color :: Color
+  property (brush :: draw.Brush).style :: Brush.Style
+  property (brush :: draw.Brush).stipple :: maybe(Bitmap)
   property (brush :: draw.Brush).gradient
-    :: maybe(draw.LinearGradient || draw.RadialGradient)
+    :: maybe(LinearGradient || RadialGradient)
 ){
 
  Properties to access brush components.
@@ -58,7 +56,7 @@
 
 
 @doc(
-  def draw.Brush.none :: draw.Brush
+  def draw.Brush.none :: Brush
 ){
 
  A brush with style @rhombus(#'transparent).
@@ -67,31 +65,31 @@
 
 @doc(
   class draw.LinearGradient():
-    constructor (pt1 :: draw.PointLike,
-                 pt2 :: draw.PointLike,
-                 [[stop :: Real.in(0.0, 1.0), color :: draw.Color], ...])
-  property (grad :: draw.LinearGradient).line
-    :: matching([_ :: draw.Point, _ :: draw.Point])
-  property (grad :: draw.LinearGradient).stops
-    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: draw.Color]))
+    constructor (pt1 :: PointLike,
+                 pt2 :: PointLike,
+                 [[stop :: Real.in(0.0, 1.0), color :: Color], ...])
+  property (grad :: LinearGradient).line
+    :: matching([_ :: Point, _ :: Point])
+  property (grad :: LinearGradient).stops
+    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: Color]))
 ){
 
- A linear gradient for a @rhombus(draw.Brush, ~class).
+ A linear gradient for a @rhombus(Brush, ~class).
 
 }
 
 @doc(
   class draw.RadialGradient():
-    constructor ([[pt1 :: draw.PointLike], r1 :: Real],
-                 [[pt2 :: draw.PointLike], r2 :: Real],
-                 [[stop :: Real.in(0.0, 1.0), color :: draw.Color], ...])
-  property (grad :: draw.RadialGradient).circles
-    :: matching([[_ :: draw.PointLike, _ :: Real],
-                 [_ :: draw.PointLike, _ :: Real]])
-  property (grad :: draw.RadialGradient).stops
-    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: draw.Color]))
+    constructor ([[pt1 :: PointLike], r1 :: Real],
+                 [[pt2 :: PointLike], r2 :: Real],
+                 [[stop :: Real.in(0.0, 1.0), color :: Color], ...])
+  property (grad :: RadialGradient).circles
+    :: matching([[_ :: PointLike, _ :: Real],
+                 [_ :: PointLike, _ :: Real]])
+  property (grad :: RadialGradient).stops
+    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: Color]))
 ){
 
- A radial gradient for a @rhombus(draw.Brush, ~class).
+ A radial gradient for a @rhombus(Brush, ~class).
 
 }

--- a/rhombus-draw/rhombus/draw/scribblings/color.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/color.scrbl
@@ -2,19 +2,18 @@
 @(import:
     "common.rhm" open
     meta_label:
-      lib("racket/draw.rkt"):
-        expose:
+      lib("racket/draw.rkt") open:
+        only:
           #{color-database<%>})
 
 @title{Color}
 
 @doc(
-  class Color():
+  class draw.Color():
     constructor
     | (name :: String)
     | (red :: Byte, green :: Byte, blue :: Byte)
-    | (red :: Byte, green :: Byte, blue :: Byte,
-       alpha :: Real.in(0.0, 1.0))
+    | (red :: Byte, green :: Byte, blue :: Byte, alpha :: Real.in(0.0, 1.0))
 ){
 
  When @rhombus(name) is given, it must be one of the predefined names
@@ -29,10 +28,10 @@
 }
 
 @doc(
-  property (col :: Color).red :: Byte
-  property (col :: Color).green :: Byte
-  property (col :: Color).blue :: Byte
-  property (col :: Color).alpha :: Real.in(0, 1)
+  property (col :: draw.Color).red :: Byte
+  property (col :: draw.Color).green :: Byte
+  property (col :: draw.Color).blue :: Byte
+  property (col :: draw.Color).alpha :: Real.in(0, 1)
 ){
 
  Properties to access color components.
@@ -40,7 +39,7 @@
 }
 
 @doc(
-  method (col :: Color).scale(factor :: NonnegReal) :: Color
+  method (col :: draw.Color).scale(factor :: NonnegReal) :: draw.Color
 ){
 
  Scales a color, making it brighter or darker. If @rhombus(factor) is
@@ -53,7 +52,7 @@
 }
 
 @doc(
-  method (col :: Color).blend(other :: Color) :: Color
+  method (col :: draw.Color).blend(other :: draw.Color) :: draw.Color
 ){
 
  Blends two colors to produce a new one. Each red, green, and blue
@@ -64,14 +63,14 @@
 }
 
 @doc(
-  property (col :: Color).handle :: Any
-  fun Color.from_handle(hand :: Any) :: Color
+  property (col :: draw.Color).handle :: Any
+  fun draw.Color.from_handle(hand :: Any) :: draw.Color
 ){
 
- The @rhombus(Color.handle) property returns a Racket object that
+ The @rhombus(draw.Color.handle) property returns a Racket object that
  corresponds to the drawing context for use directly with
- @racketmodname(racket/draw). The @rhombus(Color.from_handle) function
- creates a @rhombus(Color, ~class) from such a Racket object.
+ @racketmodname(racket/draw). The @rhombus(draw.Color.from_handle) function
+ creates a @rhombus(draw.Color, ~class) from such a Racket object.
 
 }
 

--- a/rhombus-draw/rhombus/draw/scribblings/color.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/color.scrbl
@@ -39,7 +39,7 @@
 }
 
 @doc(
-  method (col :: draw.Color).scale(factor :: NonnegReal) :: draw.Color
+  method (col :: draw.Color).scale(factor :: NonnegReal) :: Color
 ){
 
  Scales a color, making it brighter or darker. If @rhombus(factor) is
@@ -52,7 +52,7 @@
 }
 
 @doc(
-  method (col :: draw.Color).blend(other :: draw.Color) :: draw.Color
+  method (col :: draw.Color).blend(other :: Color) :: Color
 ){
 
  Blends two colors to produce a new one. Each red, green, and blue
@@ -64,13 +64,13 @@
 
 @doc(
   property (col :: draw.Color).handle :: Any
-  fun draw.Color.from_handle(hand :: Any) :: draw.Color
+  fun draw.Color.from_handle(hand :: Any) :: Color
 ){
 
- The @rhombus(draw.Color.handle) property returns a Racket object that
+ The @rhombus(Color.handle) property returns a Racket object that
  corresponds to the drawing context for use directly with
- @racketmodname(racket/draw). The @rhombus(draw.Color.from_handle) function
- creates a @rhombus(draw.Color, ~class) from such a Racket object.
+ @racketmodname(racket/draw). The @rhombus(Color.from_handle) function
+ creates a @rhombus(Color, ~class) from such a Racket object.
 
 }
 

--- a/rhombus-draw/rhombus/draw/scribblings/common.rhm
+++ b/rhombus-draw/rhombus/draw/scribblings/common.rhm
@@ -3,9 +3,13 @@
 import:
   meta_label:
     rhombus open
+    rhombus/draw open:
+      except:
+        Path
     rhombus/draw
 
 export:
   meta_label:
     all_from(rhombus)
+    all_from(rhombus/draw)
     draw

--- a/rhombus-draw/rhombus/draw/scribblings/common.rhm
+++ b/rhombus-draw/rhombus/draw/scribblings/common.rhm
@@ -3,10 +3,9 @@
 import:
   meta_label:
     rhombus open
-    rhombus/draw open:
-      except: Path
+    rhombus/draw
 
 export:
   meta_label:
     all_from(rhombus)
-    all_from(rhombus/draw)
+    draw

--- a/rhombus-draw/rhombus/draw/scribblings/dc.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/dc.scrbl
@@ -1,15 +1,12 @@
 #lang rhombus/scribble/manual
 @(import:
     "common.rhm" open:
-      except: Path
-    meta_label:
-      rhombus/draw:
-        expose: Path)
+      except: Path)
 
 @title{Drawing Context}
 
 @doc(
-  interface DC
+  interface draw.DC
 ){
 
  Represents a @deftech{drawing context} that renders to some destination,
@@ -20,8 +17,8 @@
 }
 
 @doc(
-  property (dc :: DC).handle :: Any
-  fun DC.from_handle(hand :: Any) :: DC
+  property (dc :: draw.DC).handle :: Any
+  fun draw.DC.from_handle(hand :: Any) :: draw.DC
 ){
 
  The @rhombus(DC.handle) property returns a Racket object that
@@ -32,9 +29,9 @@
 }
 
 @doc(
-  property (dc :: DC).width :: NonnegReal
-  property (dc :: DC).height :: NonnegReal
-  property (dc :: DC).size :: Size
+  property (dc :: draw.DC).width :: NonnegReal
+  property (dc :: draw.DC).height :: NonnegReal
+  property (dc :: draw.DC).size :: draw.Size
 ){
 
  The size of the drawing area: width, height, or both.
@@ -42,7 +39,7 @@
 }
 
 @doc(
-  method (dc :: DC).clear() :: Void
+  method (dc :: draw.DC).clear() :: Void
 ){
 
  Resets the output to an empty state.
@@ -51,20 +48,20 @@
 
 @doc(
   property
-  | (dc :: DC).pen :: Pen
-  | (dc :: DC).pen := (p :: Pen)
+  | (dc :: draw.DC).pen :: draw.Pen
+  | (dc :: draw.DC).pen := (p :: draw.Pen)
   property
-  | (dc :: DC).brush :: Brush
-  | (dc :: DC).brush := (b :: Brush)
+  | (dc :: draw.DC).brush :: draw.Brush
+  | (dc :: draw.DC).brush := (b :: draw.Brush)
   property
-  | (dc :: DC).font :: Font
-  | (dc :: DC).font := (f :: Font)
+  | (dc :: draw.DC).font :: draw.Font
+  | (dc :: draw.DC).font := (f :: draw.Font)
   property
-  | (dc :: DC).clipping_region :: maybe(Region)
-  | (dc :: DC).clipping_region := (rgn :: maybe(Region))
+  | (dc :: draw.DC).clipping_region :: maybe(draw.Region)
+  | (dc :: draw.DC).clipping_region := (rgn :: maybe(draw.Region))
   property
-  | (dc :: DC).transformation :: DC.Transformation
-  | (dc :: DC).transformation := (rgn :: DC.Transformation)
+  | (dc :: draw.DC).transformation :: draw.DC.Transformation
+  | (dc :: draw.DC).transformation := (rgn :: draw.DC.Transformation)
 ){
 
  Properties to get or set the drawing context's configuration.
@@ -72,35 +69,35 @@
 }
 
 @doc(
-  method (dc :: DC).scale(s :: Real) :: Void
-  method (dc :: DC).scale(sx :: Real, sy :: Real) :: Void
-  method (dc :: DC).translate(dpt :: PointLike) :: Void
-  method (dc :: DC).translate(dx :: Real, dy :: Real) :: Void
-  method (dc :: DC).rotate(radians :: Real) :: Void
-  method (dc :: DC).transform(t :: DC.Transformation) :: Void
+  method (dc :: draw.DC).scale(s :: Real) :: Void
+  method (dc :: draw.DC).scale(sx :: Real, sy :: Real) :: Void
+  method (dc :: draw.DC).translate(dpt :: draw.PointLike) :: Void
+  method (dc :: draw.DC).translate(dx :: Real, dy :: Real) :: Void
+  method (dc :: draw.DC).rotate(radians :: Real) :: Void
+  method (dc :: draw.DC).transform(t :: draw.DC.Transformation) :: Void
 ){
 
  Applies a (further) transformation to the drawing context's conversion
  from drawing coordinates to deivice coordinates. In other words, these
  methods change the result that is returned by the
- @rhombus(DC.transformation) property, and they affect drawing accodingly.
+ @rhombus(draw.DC.transformation) property, and they affect drawing accodingly.
 
 }
 
 @doc(
-  method (dc :: DC).save() :: Void
-  method (dc :: DC).restore() :: Void
-  dot (dc :: DC).save_and_restore:
+  method (dc :: draw.DC).save() :: Void
+  method (dc :: draw.DC).restore() :: Void
+  dot (dc :: draw.DC).save_and_restore:
     $body
     ...
 ){
 
  Saves and restores the draw context's configuration.
 
- The @rhombus(DC.save) method pushes the current drawing state (pen,
+ The @rhombus(draw.DC.save) method pushes the current drawing state (pen,
  brush, clipping region, and transformation) onto an internal stack, and
- @rhombus(DC.restore) pops the stack and restores the popped drawing
- state. The @rhombus(DC.save_and_restore) form wraps a @rhombus(body)
+ @rhombus(draw.DC.restore) pops the stack and restores the popped drawing
+ state. The @rhombus(draw.DC.save_and_restore) form wraps a @rhombus(body)
  sequence to save the drawing state on entry to the sequence and restore
  it on exit, returning the value(s) produced by the @rhombus(body)
  sequence; entry and exit cover continuation jumps, like @rhombus(try).
@@ -108,36 +105,39 @@
 }
 
 @doc(
-  method (dc :: DC).point(pt :: PointLike)
+  method (dc :: draw.DC).point(pt :: draw.PointLike)
     :: Void
-  method (dc :: DC).line(pt1 :: PointLike, pt2 :: PointLike)
+  method (dc :: draw.DC).line(pt1 :: draw.PointLike,
+                              pt2 :: draw.PointLike)
     :: Void
-  method (dc :: DC).lines([pt :: PointLike, ...],
-                          ~dpt: dpt :: PointLike = Point.zero,
-                          ~dx: dx :: Real = 0,
-                          ~dy: dy :: Real = 0)
+  method (dc :: draw.DC).lines(
+    [pt :: draw.PointLike, ...],
+    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    ~dx: dx :: Real = 0,
+    ~dy: dy :: Real = 0
+  ) :: Void
+  method (dc :: draw.DC).polygon(
+    [pt :: PointLike, ...],
+    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    ~dx: dx :: Real = 0,
+    ~dy: dy :: Real = 0,
+    ~fill: fill :: draw.DC.Fill = #'even_odd
+  ) :: Void
+  method (dc :: draw.DC).rectangle(r :: draw.RectLike)
     :: Void
-  method (dc :: DC).polygon([pt :: PointLike, ...],
-                            ~dpt: dpt :: PointLike = Point.zero,
-                            ~dx: dx :: Real = 0,
-                            ~dy: dy :: Real = 0,
-                            ~fill: fill :: DC.Fill = #'even_odd)
+  method (dc :: draw.DC).rounded_rectangle(r :: draw.RectLike,
+                                           radius :: Real = -0.25)
     :: Void
-  method (dc :: DC).rectangle(r :: RectLike)
+  method (dc :: draw.DC).ellipse(r :: draw.RectLike)
     :: Void
-  method (dc :: DC).rounded_rectangle(r :: RectLike,
-                                      radius :: Real = -0.25)
+  method (dc :: draw.DC).arc(r :: draw.RectLike,
+                             start :: Real, end :: Real)
     :: Void
-  method (dc :: DC).ellipse(r :: RectLike)
-    :: Void
-  method (dc :: DC).arc(r :: RectLike,
-                        start :: Real, end :: Real)
-    :: Void
-  method (dc :: DC).path(p :: Path,
-                         ~dpt: dpt :: PointLike = Point.zero,
-                         ~dx: dx :: Real = 0,
-                         ~dy: dy :: Real = 0,
-                         ~fill: fill :: DC.Fill = #'odd_even)
+  method (dc :: draw.DC).path(p :: draw.Path,
+                              ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+                              ~dx: dx :: Real = 0,
+                              ~dy: dy :: Real = 0,
+                              ~fill: fill :: draw.DC.Fill = #'odd_even)
     :: Void
 ){
 
@@ -151,13 +151,14 @@
 }
 
 @doc(
-  method (dc:: DC).text(str :: String,
-                        ~dpt: dpt :: PointLike = Point.zero,
-                        ~dx: dx :: Real = 0,
-                        ~dy: dy :: Real = 0,
-                        ~combine: combine :: DC.TextCombine = #'kern,
-                        ~angle: angle :: Real = 0.0)
-    :: Void
+  method (dc:: draw.DC).text(
+    str :: String,
+    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    ~dx: dx :: Real = 0,
+    ~dy: dy :: Real = 0,
+    ~combine: combine :: draw.DC.TextCombine = #'kern,
+    ~angle: angle :: Real = 0.0
+  ) :: Void
 ){
 
  Draws text into a drawing context using the current font.
@@ -165,15 +166,16 @@
 }
 
 @doc(
-  method (dc :: DC).bitmap(
-    bm :: Bitmap,
-    ~dpt: dpt :: PointLike = Point.zero,
+  method (dc :: draw.DC).bitmap(
+    bm :: draw.Bitmap,
+    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
     ~dx: dx :: Real = 0,
     ~dy: dy :: Real = 0,
-    ~source: source :: RectLike = Rect(Point.zero, Bitmap.size(bm)),
-    ~style: style :: DC.BitmapOverlay = #'solid,
-    ~color: color :: Color = Color("black"),
-    ~mask: mask :: maybe(Bitmap) = #false,
+    ~source: source :: draw.RectLike:
+               draw.Rect(draw.Point.zero, draw.Bitmap.size(bm)),
+    ~style: style :: draw.DC.BitmapOverlay = #'solid,
+    ~color: color :: draw.Color = draw.Color("black"),
+    ~mask: mask :: maybe(draw.Bitmap) = #false,
   ) :: Void
 ){
 
@@ -183,8 +185,8 @@
 }
 
 @doc(
-  method (dc :: DC).copy(source :: RectLike,
-                         dest :: PointLike)
+  method (dc :: draw.DC).copy(source :: draw.RectLike,
+                              dest :: draw.PointLike)
     :: Void
 ){
 
@@ -194,7 +196,7 @@
 }
 
 @doc(
-  method (dc :: DC).font_metrics_key() :: Any
+  method (dc :: draw.DC).font_metrics_key() :: Any
 ){
 
  Returns a value that changes when the selected font is changed to one
@@ -203,7 +205,7 @@
 }
 
 @doc(
-  enum DC.BitmapOverlay:
+  enum draw.DC.BitmapOverlay:
     solid
     opaque
     xor
@@ -214,7 +216,7 @@
 }
 
 @doc(
-  enum DC.TextCombine:
+  enum draw.DC.TextCombine:
     kern
     grapheme
     char
@@ -226,7 +228,7 @@
 
 
 @doc(
-  enum DC.Fill:
+  enum draw.DC.Fill:
     even_odd
     winding
 ){
@@ -237,7 +239,7 @@
 
 
 @doc(
-  annot.macro 'DC.Transformation'
+  annot.macro 'draw.DC.Transformation'
 ){
 
  Satisfied by an array of six @rhombus(Real, ~annot)s:

--- a/rhombus-draw/rhombus/draw/scribblings/dc.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/dc.scrbl
@@ -18,7 +18,7 @@
 
 @doc(
   property (dc :: draw.DC).handle :: Any
-  fun draw.DC.from_handle(hand :: Any) :: draw.DC
+  fun draw.DC.from_handle(hand :: Any) :: DC
 ){
 
  The @rhombus(DC.handle) property returns a Racket object that
@@ -31,7 +31,7 @@
 @doc(
   property (dc :: draw.DC).width :: NonnegReal
   property (dc :: draw.DC).height :: NonnegReal
-  property (dc :: draw.DC).size :: draw.Size
+  property (dc :: draw.DC).size :: Size
 ){
 
  The size of the drawing area: width, height, or both.
@@ -48,20 +48,20 @@
 
 @doc(
   property
-  | (dc :: draw.DC).pen :: draw.Pen
-  | (dc :: draw.DC).pen := (p :: draw.Pen)
+  | (dc :: draw.DC).pen :: Pen
+  | (dc :: draw.DC).pen := (p :: Pen)
   property
-  | (dc :: draw.DC).brush :: draw.Brush
-  | (dc :: draw.DC).brush := (b :: draw.Brush)
+  | (dc :: draw.DC).brush :: Brush
+  | (dc :: draw.DC).brush := (b :: Brush)
   property
-  | (dc :: draw.DC).font :: draw.Font
-  | (dc :: draw.DC).font := (f :: draw.Font)
+  | (dc :: draw.DC).font :: Font
+  | (dc :: draw.DC).font := (f :: Font)
   property
-  | (dc :: draw.DC).clipping_region :: maybe(draw.Region)
-  | (dc :: draw.DC).clipping_region := (rgn :: maybe(draw.Region))
+  | (dc :: draw.DC).clipping_region :: maybe(Region)
+  | (dc :: draw.DC).clipping_region := (rgn :: maybe(Region))
   property
-  | (dc :: draw.DC).transformation :: draw.DC.Transformation
-  | (dc :: draw.DC).transformation := (rgn :: draw.DC.Transformation)
+  | (dc :: draw.DC).transformation :: DC.Transformation
+  | (dc :: draw.DC).transformation := (rgn :: DC.Transformation)
 ){
 
  Properties to get or set the drawing context's configuration.
@@ -71,16 +71,16 @@
 @doc(
   method (dc :: draw.DC).scale(s :: Real) :: Void
   method (dc :: draw.DC).scale(sx :: Real, sy :: Real) :: Void
-  method (dc :: draw.DC).translate(dpt :: draw.PointLike) :: Void
+  method (dc :: draw.DC).translate(dpt :: PointLike) :: Void
   method (dc :: draw.DC).translate(dx :: Real, dy :: Real) :: Void
   method (dc :: draw.DC).rotate(radians :: Real) :: Void
-  method (dc :: draw.DC).transform(t :: draw.DC.Transformation) :: Void
+  method (dc :: draw.DC).transform(t :: DC.Transformation) :: Void
 ){
 
  Applies a (further) transformation to the drawing context's conversion
  from drawing coordinates to deivice coordinates. In other words, these
  methods change the result that is returned by the
- @rhombus(draw.DC.transformation) property, and they affect drawing accodingly.
+ @rhombus(DC.transformation) property, and they affect drawing accodingly.
 
 }
 
@@ -94,10 +94,10 @@
 
  Saves and restores the draw context's configuration.
 
- The @rhombus(draw.DC.save) method pushes the current drawing state (pen,
+ The @rhombus(DC.save) method pushes the current drawing state (pen,
  brush, clipping region, and transformation) onto an internal stack, and
- @rhombus(draw.DC.restore) pops the stack and restores the popped drawing
- state. The @rhombus(draw.DC.save_and_restore) form wraps a @rhombus(body)
+ @rhombus(DC.restore) pops the stack and restores the popped drawing
+ state. The @rhombus(DC.save_and_restore) form wraps a @rhombus(body)
  sequence to save the drawing state on entry to the sequence and restore
  it on exit, returning the value(s) produced by the @rhombus(body)
  sequence; entry and exit cover continuation jumps, like @rhombus(try).
@@ -105,39 +105,39 @@
 }
 
 @doc(
-  method (dc :: draw.DC).point(pt :: draw.PointLike)
+  method (dc :: draw.DC).point(pt :: PointLike)
     :: Void
-  method (dc :: draw.DC).line(pt1 :: draw.PointLike,
-                              pt2 :: draw.PointLike)
+  method (dc :: draw.DC).line(pt1 :: PointLike,
+                              pt2 :: PointLike)
     :: Void
   method (dc :: draw.DC).lines(
-    [pt :: draw.PointLike, ...],
-    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    [pt :: PointLike, ...],
+    ~dpt: dpt :: PointLike = Point.zero,
     ~dx: dx :: Real = 0,
     ~dy: dy :: Real = 0
   ) :: Void
   method (dc :: draw.DC).polygon(
     [pt :: PointLike, ...],
-    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    ~dpt: dpt :: PointLike = Point.zero,
     ~dx: dx :: Real = 0,
     ~dy: dy :: Real = 0,
-    ~fill: fill :: draw.DC.Fill = #'even_odd
+    ~fill: fill :: DC.Fill = #'even_odd
   ) :: Void
-  method (dc :: draw.DC).rectangle(r :: draw.RectLike)
+  method (dc :: draw.DC).rectangle(r :: RectLike)
     :: Void
-  method (dc :: draw.DC).rounded_rectangle(r :: draw.RectLike,
+  method (dc :: draw.DC).rounded_rectangle(r :: RectLike,
                                            radius :: Real = -0.25)
     :: Void
-  method (dc :: draw.DC).ellipse(r :: draw.RectLike)
+  method (dc :: draw.DC).ellipse(r :: RectLike)
     :: Void
-  method (dc :: draw.DC).arc(r :: draw.RectLike,
+  method (dc :: draw.DC).arc(r :: RectLike,
                              start :: Real, end :: Real)
     :: Void
   method (dc :: draw.DC).path(p :: draw.Path,
-                              ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+                              ~dpt: dpt :: PointLike = Point.zero,
                               ~dx: dx :: Real = 0,
                               ~dy: dy :: Real = 0,
-                              ~fill: fill :: draw.DC.Fill = #'odd_even)
+                              ~fill: fill :: DC.Fill = #'odd_even)
     :: Void
 ){
 
@@ -153,10 +153,10 @@
 @doc(
   method (dc:: draw.DC).text(
     str :: String,
-    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    ~dpt: dpt :: PointLike = Point.zero,
     ~dx: dx :: Real = 0,
     ~dy: dy :: Real = 0,
-    ~combine: combine :: draw.DC.TextCombine = #'kern,
+    ~combine: combine :: DC.TextCombine = #'kern,
     ~angle: angle :: Real = 0.0
   ) :: Void
 ){
@@ -167,15 +167,15 @@
 
 @doc(
   method (dc :: draw.DC).bitmap(
-    bm :: draw.Bitmap,
-    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    bm :: Bitmap,
+    ~dpt: dpt :: PointLike = Point.zero,
     ~dx: dx :: Real = 0,
     ~dy: dy :: Real = 0,
-    ~source: source :: draw.RectLike:
-               draw.Rect(draw.Point.zero, draw.Bitmap.size(bm)),
-    ~style: style :: draw.DC.BitmapOverlay = #'solid,
-    ~color: color :: draw.Color = draw.Color("black"),
-    ~mask: mask :: maybe(draw.Bitmap) = #false,
+    ~source: source :: RectLike:
+               Rect(Point.zero, Bitmap.size(bm)),
+    ~style: style :: DC.BitmapOverlay = #'solid,
+    ~color: color :: Color = Color("black"),
+    ~mask: mask :: maybe(Bitmap) = #false,
   ) :: Void
 ){
 
@@ -185,8 +185,8 @@
 }
 
 @doc(
-  method (dc :: draw.DC).copy(source :: draw.RectLike,
-                              dest :: draw.PointLike)
+  method (dc :: draw.DC).copy(source :: RectLike,
+                              dest :: PointLike)
     :: Void
 ){
 

--- a/rhombus-draw/rhombus/draw/scribblings/font.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/font.scrbl
@@ -7,17 +7,17 @@
 @doc(
   class draw.Font():
     constructor (
-      ~kind: kind :: draw.Font.Kind = #'default,
+      ~kind: kind :: Font.Kind = #'default,
       ~name: name :: maybe(String) = #false,
       ~size: size :: Real.in(0.0, 1024.0) = 12.0,
       ~in_pixels: in_pixels :: Any = #false,
-      ~style: style :: draw.Font.Style = #'normal,
-      ~weight: weight :: draw.Font.Weight = #'normal,
+      ~style: style :: Font.Style = #'normal,
+      ~weight: weight :: Font.Weight = #'normal,
       ~has_underline: has_underline :: Any = #false,
-      ~smoothing: smoothing :: draw.Font.Smoothing = #'default,
-      ~hinting: hinting :: draw.Font.Hinting = #'aligned,
+      ~smoothing: smoothing :: Font.Smoothing = #'default,
+      ~hinting: hinting :: Font.Hinting = #'aligned,
       ~features:
-        features :: Map.of(draw.Font.FeatureString, NonnegInt) = {},
+        features :: Map.of(Font.FeatureString, NonnegInt) = {},
     )
 ){
 
@@ -32,17 +32,17 @@
 }
 
 @doc(
-  property (font :: draw.Font).kind :: draw.Font.Kind
+  property (font :: draw.Font).kind :: Font.Kind
   property (font :: draw.Font).name :: maybe(String)
   property (font :: draw.Font).size :: Real.in(0.0, 1024.0)
   property (font :: draw.Font).in_pixels :: Boolean
-  property (font :: draw.Font).style :: draw.Font.Style
-  property (font :: draw.Font).weight :: draw.Font.Weight
+  property (font :: draw.Font).style :: Font.Style
+  property (font :: draw.Font).weight :: Font.Weight
   property (font :: draw.Font).has_underline :: Boolean
-  property (font :: draw.Font).smoothing :: draw.Font.Smoothing
-  property (font :: draw.Font).hinting :: draw.Font.Hinting
+  property (font :: draw.Font).smoothing :: Font.Smoothing
+  property (font :: draw.Font).hinting :: Font.Hinting
   property (font :: draw.Font).features
-    :: Map.of(draw.Font.FeatureString, NonnegInt)
+    :: Map.of(Font.FeatureString, NonnegInt)
 ){
 
  Propeties to access font components.

--- a/rhombus-draw/rhombus/draw/scribblings/font.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/font.scrbl
@@ -5,19 +5,19 @@
 @title{Font}
 
 @doc(
-  class Font():
+  class draw.Font():
     constructor (
-      ~kind: kind :: Font.Kind = #'default,
+      ~kind: kind :: draw.Font.Kind = #'default,
       ~name: name :: maybe(String) = #false,
       ~size: size :: Real.in(0.0, 1024.0) = 12.0,
       ~in_pixels: in_pixels :: Any = #false,
-      ~style: style :: Font.Style = #'normal,
-      ~weight: weight :: Font.Weight = #'normal,
+      ~style: style :: draw.Font.Style = #'normal,
+      ~weight: weight :: draw.Font.Weight = #'normal,
       ~has_underline: has_underline :: Any = #false,
-      ~smoothing: smoothing :: Font.Smoothing = #'default,
-      ~hinting: hinting :: Font.Hinting = #'aligned,
+      ~smoothing: smoothing :: draw.Font.Smoothing = #'default,
+      ~hinting: hinting :: draw.Font.Hinting = #'aligned,
       ~features:
-        features :: Map.of(Font.FeatureString, NonnegInt) = {},
+        features :: Map.of(draw.Font.FeatureString, NonnegInt) = {},
     )
 ){
 
@@ -32,17 +32,17 @@
 }
 
 @doc(
-  property (font :: Font).kind :: Font.Kind
-  property (font :: Font).name :: maybe(String)
-  property (font :: Font).size :: Real.in(0.0, 1024.0)
-  property (font :: Font).in_pixels :: Boolean
-  property (font :: Font).style :: Font.Style
-  property (font :: Font).weight :: Font.Weight
-  property (font :: Font).has_underline :: Boolean
-  property (font :: Font).smoothing :: Font.Smoothing
-  property (font :: Font).hinting :: Font.Hinting
-  property (font :: Font).features
-    :: Map.of(Font.FeatureString, NonnegInt)
+  property (font :: draw.Font).kind :: draw.Font.Kind
+  property (font :: draw.Font).name :: maybe(String)
+  property (font :: draw.Font).size :: Real.in(0.0, 1024.0)
+  property (font :: draw.Font).in_pixels :: Boolean
+  property (font :: draw.Font).style :: draw.Font.Style
+  property (font :: draw.Font).weight :: draw.Font.Weight
+  property (font :: draw.Font).has_underline :: Boolean
+  property (font :: draw.Font).smoothing :: draw.Font.Smoothing
+  property (font :: draw.Font).hinting :: draw.Font.Hinting
+  property (font :: draw.Font).features
+    :: Map.of(draw.Font.FeatureString, NonnegInt)
 ){
 
  Propeties to access font components.
@@ -50,7 +50,18 @@
 }
 
 @doc(
-  enum Font.Kind:
+  annot.macro 'draw.Font.FeatureString'
+){
+
+ Satisfied by a 4-character string containing only @litchar{ } (i.e., a
+ space), @litchar{!}, or characters with @rhombus(Char.to_int) values
+ between that of @litchar{#} and @litchar{~}, inclusive.
+
+}
+  
+
+@doc(
+  enum draw.Font.Kind:
     default
     decorative
     roman
@@ -66,7 +77,7 @@
 }
 
 @doc(
-  enum Font.Style:
+  enum draw.Font.Style:
     normal
     slant
     italic
@@ -77,7 +88,7 @@
 }
 
 @doc(
-  enum Font.Weight:
+  enum draw.Font.Weight:
     ~is_a Int.in(100, 1000 ~inclusive)
     thin
     ultralight
@@ -114,7 +125,7 @@
 }
 
 @doc(
-  enum Font.Smoothing:
+  enum draw.Font.Smoothing:
     default
     partly_smoothed
     smoothed
@@ -126,7 +137,7 @@
 }
 
 @doc(
-  enum Font.Hinting:
+  enum draw.Font.Hinting:
     aligned
     unaligned
 ){

--- a/rhombus-draw/rhombus/draw/scribblings/path.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/path.scrbl
@@ -1,15 +1,11 @@
 #lang rhombus/scribble/manual
 @(import:
-    "common.rhm" open:
-      except: Path
-    meta_label:
-      rhombus/draw:
-        expose: Path)
+    "common.rhm" open)
 
 @title{Path}
 
 @doc(
-  class Path()
+  class draw.Path()
 ){
 
  Creates a drawing path.
@@ -17,9 +13,9 @@
 }
 
 @doc(
-  method (path :: Path).close() :: Void
-  method (path :: Path).is_open() :: Boolean
-  method (path :: Path).reset() :: Void
+  method (path :: draw.Path).close() :: Void
+  method (path :: draw.Path).is_open() :: Boolean
+  method (path :: draw.Path).reset() :: Void
 ){
 
  Closes an open path, if any, check whether the path is currently open,
@@ -28,13 +24,13 @@
 }
 
 @doc(
-  method (path :: Path).move_to(pt :: PointLike)
+  method (path :: draw.Path).move_to(pt :: draw.PointLike)
     :: Void
-  method (path :: Path).line_to(pt :: PointLike)
+  method (path :: draw.Path).line_to(pt :: draw.PointLike)
     :: Void
-  method (path :: Path).curve_to(pt1 :: PointLike,
-                                 pt2 :: PointLike,
-                                 pt3 :: PointLike)
+  method (path :: draw.Path).curve_to(pt1 :: draw.PointLike,
+                                      pt2 :: draw.PointLike,
+                                      pt3 :: draw.PointLike)
     :: Void
 ){
 
@@ -45,34 +41,35 @@
 
 
 @doc(
-  method (path :: Path).polygon([pt :: PointLike, ...],
-                                ~dpt: dpt :: PointLike = Point.zero,
-                                ~dx: dx :: Real = 0,
-                                ~dy: dy :: Real = 0)
+  method (path :: draw.Path).polygon(
+    [pt :: draw.PointLike, ...],
+    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    ~dx: dx :: Real = 0,
+    ~dy: dy :: Real = 0
+  ) :: Void
+  method (path :: draw.Path).rectangle(r :: draw.RectLike)
     :: Void
-  method (path :: Path).rectangle(r :: RectLike)
+  method (path :: draw.Path).rounded_rectangle(r :: draw.RectLike,
+                                               radius :: Real = -0.25)
     :: Void
-  method (path :: Path).rounded_rectangle(r :: RectLike,
-                                          radius :: Real = -0.25)
+  method (path :: draw.Path).ellipse(r :: draw.RectLike)
     :: Void
-  method (path :: Path).ellipse(r :: RectLike)
-    :: Void
-  method (path :: Path).arc(r :: RectLike,
-                            start :: Real, end :: Real,
-                            ~clockwise: clockwise :: Any = #false)
+  method (path :: draw.Path).arc(r :: draw.RectLike,
+                                 start :: Real, end :: Real,
+                                 ~clockwise: clockwise :: Any = #false)
     :: Void
 ){
 
  Adds to the path. If the path is currently open, it is first closed,
- except in the case of @rhombus(Path.arc).
+ except in the case of @rhombus(draw.Path.arc).
 
 }
 
 @doc(
-  method (path :: Path).scale(s :: Real) :: Void
-  method (path :: Path).scale(sx :: Real, sy :: Real) :: Void
-  method (path :: Path).rotate(radians :: Real) :: Void
-  method (path :: Path).translate(dx :: Real, dy :: Real) :: Void
+  method (path :: draw.Path).scale(s :: Real) :: Void
+  method (path :: draw.Path).scale(sx :: Real, sy :: Real) :: Void
+  method (path :: draw.Path).rotate(radians :: Real) :: Void
+  method (path :: draw.Path).translate(dx :: Real, dy :: Real) :: Void
 ){
 
  Adjusts a path to scale, rotate, or translate every point defining the
@@ -81,7 +78,7 @@
 }
 
 @doc(
-  method (path :: Path).append(other_path :: Path) :: Void
+  method (path :: draw.Path).append(other_path :: draw.Path) :: Void
 ){
 
  Adds @rhombus(other_path) to the end of @rhombus(path).
@@ -89,7 +86,7 @@
 }
 
 @doc(
-  method (path :: Path).bounding_box() :: Rect
+  method (path :: draw.Path).bounding_box() :: Rect
 ){
 
  Returns a rectangle that bounds all of the points describing

--- a/rhombus-draw/rhombus/draw/scribblings/path.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/path.scrbl
@@ -24,13 +24,13 @@
 }
 
 @doc(
-  method (path :: draw.Path).move_to(pt :: draw.PointLike)
+  method (path :: draw.Path).move_to(pt :: PointLike)
     :: Void
-  method (path :: draw.Path).line_to(pt :: draw.PointLike)
+  method (path :: draw.Path).line_to(pt :: PointLike)
     :: Void
-  method (path :: draw.Path).curve_to(pt1 :: draw.PointLike,
-                                      pt2 :: draw.PointLike,
-                                      pt3 :: draw.PointLike)
+  method (path :: draw.Path).curve_to(pt1 :: PointLike,
+                                      pt2 :: PointLike,
+                                      pt3 :: PointLike)
     :: Void
 ){
 
@@ -42,19 +42,19 @@
 
 @doc(
   method (path :: draw.Path).polygon(
-    [pt :: draw.PointLike, ...],
-    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    [pt :: PointLike, ...],
+    ~dpt: dpt :: PointLike = Point.zero,
     ~dx: dx :: Real = 0,
     ~dy: dy :: Real = 0
   ) :: Void
-  method (path :: draw.Path).rectangle(r :: draw.RectLike)
+  method (path :: draw.Path).rectangle(r :: RectLike)
     :: Void
-  method (path :: draw.Path).rounded_rectangle(r :: draw.RectLike,
+  method (path :: draw.Path).rounded_rectangle(r :: RectLike,
                                                radius :: Real = -0.25)
     :: Void
-  method (path :: draw.Path).ellipse(r :: draw.RectLike)
+  method (path :: draw.Path).ellipse(r :: RectLike)
     :: Void
-  method (path :: draw.Path).arc(r :: draw.RectLike,
+  method (path :: draw.Path).arc(r :: RectLike,
                                  start :: Real, end :: Real,
                                  ~clockwise: clockwise :: Any = #false)
     :: Void

--- a/rhombus-draw/rhombus/draw/scribblings/pen.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/pen.scrbl
@@ -5,14 +5,14 @@
 @title{Pen}
 
 @doc(
-  class Pen():
+  class draw.Pen():
     constructor (
-      ~color: color :: (String || Color) = "Black",
+      ~color: color :: (String || draw.Color) = "Black",
       ~width: width :: Real.in(0, 255) = 1,
-      ~style: style :: Pen.Style = #'solid,
-      ~cap: cap :: Pen.Cap = #'round,
-      ~join: join :: Pen.Join = #'round,
-      ~stipple: stipple :: maybe(Bitmap) = #false,
+      ~style: style :: draw.Pen.Style = #'solid,
+      ~cap: cap :: draw.Pen.Cap = #'round,
+      ~join: join :: draw.Pen.Join = #'round,
+      ~stipple: stipple :: maybe(draw.Bitmap) = #false,
     )
 ){
 
@@ -25,12 +25,12 @@
 }
 
 @doc(
-  property (pen :: Pen).color :: Color
-  property (pen :: Pen).width :: Real.in(0, 255)
-  property (pen :: Pen).style :: Pen.Style
-  property (pen :: Pen).cap :: Pen.Cap
-  property (pen :: Pen).join :: Pen.Join
-  property (pen :: Pen).stipple :: maybe(Bitmap)
+  property (pen :: draw.Pen).color :: draw.Color
+  property (pen :: draw.Pen).width :: Real.in(0, 255)
+  property (pen :: draw.Pen).style :: draw.Pen.Style
+  property (pen :: draw.Pen).cap :: draw.Pen.Cap
+  property (pen :: draw.Pen).join :: draw.Pen.Join
+  property (pen :: draw.Pen).stipple :: maybe(draw.Bitmap)
 ){
 
  Properties to access pen components.
@@ -38,7 +38,7 @@
 }
 
 @doc(
-  enum Pen.Style:
+  enum draw.Pen.Style:
     transparent
     solid
     xor
@@ -58,7 +58,7 @@
 }
 
 @doc(
-  enum Pen.Cap:
+  enum draw.Pen.Cap:
     round
     projecting
     butt
@@ -69,7 +69,7 @@
 }
 
 @doc(
-  enum Pen.Join:
+  enum draw.Pen.Join:
     round
     bevel
     miter
@@ -81,7 +81,7 @@
 
 
 @doc(
-  def Pen.none :: Pen
+  def draw.Pen.none :: draw.Pen
 ){
 
  A pen with style @rhombus(#'transparent).

--- a/rhombus-draw/rhombus/draw/scribblings/pen.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/pen.scrbl
@@ -7,12 +7,12 @@
 @doc(
   class draw.Pen():
     constructor (
-      ~color: color :: (String || draw.Color) = "Black",
+      ~color: color :: (String || Color) = "Black",
       ~width: width :: Real.in(0, 255) = 1,
-      ~style: style :: draw.Pen.Style = #'solid,
-      ~cap: cap :: draw.Pen.Cap = #'round,
-      ~join: join :: draw.Pen.Join = #'round,
-      ~stipple: stipple :: maybe(draw.Bitmap) = #false,
+      ~style: style :: Pen.Style = #'solid,
+      ~cap: cap :: Pen.Cap = #'round,
+      ~join: join :: Pen.Join = #'round,
+      ~stipple: stipple :: maybe(Bitmap) = #false,
     )
 ){
 
@@ -25,12 +25,12 @@
 }
 
 @doc(
-  property (pen :: draw.Pen).color :: draw.Color
+  property (pen :: draw.Pen).color :: Color
   property (pen :: draw.Pen).width :: Real.in(0, 255)
-  property (pen :: draw.Pen).style :: draw.Pen.Style
-  property (pen :: draw.Pen).cap :: draw.Pen.Cap
-  property (pen :: draw.Pen).join :: draw.Pen.Join
-  property (pen :: draw.Pen).stipple :: maybe(draw.Bitmap)
+  property (pen :: draw.Pen).style :: Pen.Style
+  property (pen :: draw.Pen).cap :: Pen.Cap
+  property (pen :: draw.Pen).join :: Pen.Join
+  property (pen :: draw.Pen).stipple :: maybe(Bitmap)
 ){
 
  Properties to access pen components.
@@ -81,7 +81,7 @@
 
 
 @doc(
-  def draw.Pen.none :: draw.Pen
+  def draw.Pen.none :: Pen
 ){
 
  A pen with style @rhombus(#'transparent).

--- a/rhombus-draw/rhombus/draw/scribblings/point-et-al.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/point-et-al.scrbl
@@ -3,8 +3,8 @@
   import:
     "common.rhm" open
     meta_label:
-      lib("racket/draw.rkt"):
-        expose:
+      lib("racket/draw.rkt") open:
+        only:
           #{color-database<%>}
 )
 
@@ -18,21 +18,21 @@
 @title(~tag: "point-et-al"){Point, Size, and Rectangle}
 
 @doc(
-  class Point(x :: Real, y :: Real)
-  annot.macro 'PointLike'
-  annot.macro 'PointLike.to_point'
-  fun PointLike.to_point(pt :: PointLike) :: Point
-  def Point.zero :: Point = Point(0, 0)
+  class draw.Point(x :: Real, y :: Real)
+  annot.macro 'draw.PointLike'
+  annot.macro 'draw.PointLike.to_point'
+  fun draw.PointLike.to_point(pt :: draw.PointLike) :: draw.Point
+  def draw.Point.zero :: draw.Point = draw.Point(0, 0)
 ){
 
- The @rhombus(Point, ~class) class represents a point in two dimensions.
+ The @rhombus(draw.Point, ~class) class represents a point in two dimensions.
 
  Methods that expect a point typically accept a value satisfying
- @rhombus(PointLike, ~annot), which is any of the following:
+ @rhombus(draw.PointLike, ~annot), which is any of the following:
 
 @itemlist(
 
- @item{@rhombus(Point, ~annot): a @rhombus(Point, ~class) instance;}
+ @item{@rhombus(draw.Point, ~annot): a @rhombus(draw.Point, ~class) instance;}
 
  @item{@rhombus(matching([_ :: Real, _ :: Real]), ~annot): a
   @rhombus(List) containing two @rhombus(Real, ~annot) values; or}
@@ -43,39 +43,39 @@
 
 )
 
- The @rhombus(PointLike.to_point, ~annot) annotation is satified by any
- value that satisfis @rhombus(PointLike, ~annot), and the value is
- converted to an equivalent @rhombus(Point, ~class) object if it is not one
+ The @rhombus(draw.PointLike.to_point, ~annot) annotation is satified by any
+ value that satisfis @rhombus(draw.PointLike, ~annot), and the value is
+ converted to an equivalent @rhombus(draw.Point, ~class) object if it is not one
  already.
 
- The @rhombus(PointLike.to_point) function converts a
- @rhombus(PointLike, ~annot) value to a @rhombus(Point, ~class), like the
- @rhombus(PointLike.to_point, ~annot) annotation. An expression
- @rhombus(pt) with static information from @rhombus(PointLike, ~annot)
- can call @rhombus(PointLike.to_point(pt)) using @rhombus(pt.to_point()).
+ The @rhombus(draw.PointLike.to_point) function converts a
+ @rhombus(draw.PointLike, ~annot) value to a @rhombus(draw.Point, ~class), like the
+ @rhombus(draw.PointLike.to_point, ~annot) annotation. An expression
+ @rhombus(pt) with static information from @rhombus(draw.PointLike, ~annot)
+ can call @rhombus(draw.PointLike.to_point(pt)) using @rhombus(pt.to_point()).
 
- @rhombus(Point.zero) is a @rhombus(Point, ~class) object with @rhombus(0)
+ @rhombus(draw.Point.zero) is a @rhombus(draw.Point, ~class) object with @rhombus(0)
  values.
 
 }
 
 
 @doc(
-  class Size(width :: NonnegReal, height :: NonnegReal)
-  annot.macro 'SizeLike'
-  annot.macro 'SizeLike.to_size'
-  fun SizeLike.to_size(sz :: SizeLike) :: Size
-  def Size.zero :: Size = Size(0, 0)
+  class draw.Size(width :: NonnegReal, height :: NonnegReal)
+  annot.macro 'draw.SizeLike'
+  annot.macro 'draw.SizeLike.to_size'
+  fun draw.SizeLike.to_size(sz :: draw.SizeLike) :: draw.Size
+  def draw.Size.zero :: draw.Size = draw.Size(0, 0)
 ){
 
- The @rhombus(Size, ~class) class represents a size in two dimensions.
+ The @rhombus(draw.Size, ~class) class represents a size in two dimensions.
 
  Methods that expect a size typically accept a value satisfying
- @rhombus(SizeLike, ~annot), which is any of the following:
+ @rhombus(draw.SizeLike, ~annot), which is any of the following:
 
 @itemlist(
 
- @item{@rhombus(Size, ~annot); a @rhombus(Size, ~class) instance;}
+ @item{@rhombus(draw.Size, ~annot); a @rhombus(draw.Size, ~class) instance;}
 
  @item{@rhombus(matching([_ :: NonnegReal, _ :: NonnegReal]), ~annot):
   a @rhombus(List) containing two @rhombus(NonnegReal, ~annot)
@@ -87,49 +87,49 @@
 
 )
 
- The @rhombus(SizeLike.to_size, ~annot) annotation,
- @rhombus(SizeLike.to_size) function, and @rhombus(Size.zero) value are
- anaologous to @rhombus(PointLike.to_point, ~annot),
- @rhombus(PointLike.to_point), and @rhombus(Point.zero).
+ The @rhombus(draw.SizeLike.to_size, ~annot) annotation,
+ @rhombus(draw.SizeLike.to_size) function, and @rhombus(draw.Size.zero) value are
+ anaologous to @rhombus(draw.PointLike.to_point, ~annot),
+ @rhombus(draw.PointLike.to_point), and @rhombus(draw.Point.zero).
 
 }
 
 
 @doc(
-  class Rect(x :: Real, y :: Real,
-             width :: NonnegReal, height :: NonnegReal):
+  class draw.Rect(x :: Real, y :: Real,
+                  width :: NonnegReal, height :: NonnegReal):
     constructor
     | (x :: Real, y :: Real,
        width :: NonnegReal, height :: NonnegReal)
-    | (point :: PointLike, size :: SizeLike)
-  property (r :: Rect).point :: Point
-  property (r :: Rect).size :: Size
-  annot.macro 'RectLike'
-  annot.macro 'RectLike.to_rect'
-  fun RectLike.to_rect(sz :: RectLike) :: Rect
-  def Rect.zero :: Rect = Rect(0, 0, 0, 0)
+    | (point :: draw.PointLike, size :: draw.SizeLike)
+  property (r :: draw.Rect).point :: draw.Point
+  property (r :: draw.Rect).size :: draw.Size
+  annot.macro 'draw.RectLike'
+  annot.macro 'draw.RectLike.to_rect'
+  fun draw.RectLike.to_rect(sz :: draw.RectLike) :: draw.Rect
+  def draw.Rect.zero :: draw.Rect = draw.Rect(0, 0, 0, 0)
 ){
 
- The @rhombus(Rect) class represents a rectagular region, where
+ The @rhombus(draw.Rect, ~class) class represents a rectagular region, where
  @rhombus(x) and @rhombus(y) correspond to the top-left of the rectangle.
- The @rhombus(Rect.point) property produces @rhombus(x) and @rhombus(y)
- in a @rhombus(Point), while @rhombus(Rect.size) property produces
- @rhombus(width) and @rhombus(height) in a @rhombus(Size).
+ The @rhombus(draw.Rect.point) property produces @rhombus(x) and @rhombus(y)
+ in a @rhombus(draw.Point, ~class), while @rhombus(draw.Rect.size) property produces
+ @rhombus(width) and @rhombus(height) in a @rhombus(draw.Size, ~class).
 
  Methods that expect a rectangle typically accept a value satisfying
- @rhombus(RectLike, ~annot), which is any of the following:
+ @rhombus(draw.RectLike, ~annot), which is any of the following:
 
 @itemlist(
 
- @item{a @rhombus(Rect, ~class) instance;}
+ @item{a @rhombus(draw.Rect, ~class) instance;}
 
  @item{@rhombus(matching([_ :: Real, _ :: Real, _ :: NonnegReal, _ :: NonnegReal]), ~annot):
   a @rhombus(List) containing two @rhombus(Real, ~annot) values for the top-left point
   followed by two @rhombus(NonnegReal, ~annot) values for the size;}
 
- @item{@rhombus(matching([_ :: PointLike, _ :: SizeLike]), ~annot):
-  a @rhombus(List) containing a @rhombus(PointLike, ~annot) value
-  followed by a @rhombus(SizeLike, ~annot) value;}
+ @item{@rhombus(matching([_ :: draw.PointLike, _ :: draw.SizeLike]), ~annot):
+  a @rhombus(List) containing a @rhombus(draw.PointLike, ~annot) value
+  followed by a @rhombus(draw.SizeLike, ~annot) value;}
 
  @item{@rhombus(matching({#'x: _ :: Real, #'y: _ :: Real, #'width: _ :: NonnegReal, #'height: _ :: NonnegReal}), ~annot):
   a @rhombus(Map) containing at least the keys @x_sym,
@@ -137,17 +137,17 @@
   the first two are mapped to a @rhombus(Real, ~annot) value, and each of
   the last two are mapped to a @rhombus(NonnegReal, ~annot) value; or}
 
- @item{@rhombus(matching({#'point: _ :: PointLike, #'size: _ :: SizeLike}), ~annot):
+ @item{@rhombus(matching({#'point: _ :: draw.PointLike, #'size: _ :: draw.SizeLike}), ~annot):
   a @rhombus(Map) containing at least the keys @point_sym
   and @size_sym, where the first is mapped to a
-  @rhombus(PointLike, ~annot) value and the second is mapped to a
-  @rhombus(SizeLike, ~annot) value.}
+  @rhombus(draw.PointLike, ~annot) value and the second is mapped to a
+  @rhombus(draw.SizeLike, ~annot) value.}
 
 )
 
- The @rhombus(RectLike.to_rect, ~annot) annotation,
- @rhombus(RectLike.to_rect) function, and @rhombus(Rect.zero) value are
- anaologous to @rhombus(PointLike.to_point, ~annot),
- @rhombus(PointLike.to_point), and @rhombus(Point.zero).
+ The @rhombus(draw.RectLike.to_rect, ~annot) annotation,
+ @rhombus(draw.RectLike.to_rect) function, and @rhombus(draw.Rect.zero) value are
+ anaologous to @rhombus(draw.PointLike.to_point, ~annot),
+ @rhombus(draw.PointLike.to_point), and @rhombus(draw.Point.zero).
 
 }

--- a/rhombus-draw/rhombus/draw/scribblings/point-et-al.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/point-et-al.scrbl
@@ -21,18 +21,18 @@
   class draw.Point(x :: Real, y :: Real)
   annot.macro 'draw.PointLike'
   annot.macro 'draw.PointLike.to_point'
-  fun draw.PointLike.to_point(pt :: draw.PointLike) :: draw.Point
-  def draw.Point.zero :: draw.Point = draw.Point(0, 0)
+  fun draw.PointLike.to_point(pt :: PointLike) :: Point
+  def draw.Point.zero :: Point = Point(0, 0)
 ){
 
- The @rhombus(draw.Point, ~class) class represents a point in two dimensions.
+ The @rhombus(Point, ~class) class represents a point in two dimensions.
 
  Methods that expect a point typically accept a value satisfying
- @rhombus(draw.PointLike, ~annot), which is any of the following:
+ @rhombus(PointLike, ~annot), which is any of the following:
 
 @itemlist(
 
- @item{@rhombus(draw.Point, ~annot): a @rhombus(draw.Point, ~class) instance;}
+ @item{@rhombus(Point, ~annot): a @rhombus(Point, ~class) instance;}
 
  @item{@rhombus(matching([_ :: Real, _ :: Real]), ~annot): a
   @rhombus(List) containing two @rhombus(Real, ~annot) values; or}
@@ -43,18 +43,18 @@
 
 )
 
- The @rhombus(draw.PointLike.to_point, ~annot) annotation is satified by any
- value that satisfis @rhombus(draw.PointLike, ~annot), and the value is
- converted to an equivalent @rhombus(draw.Point, ~class) object if it is not one
+ The @rhombus(PointLike.to_point, ~annot) annotation is satified by any
+ value that satisfis @rhombus(PointLike, ~annot), and the value is
+ converted to an equivalent @rhombus(Point, ~class) object if it is not one
  already.
 
- The @rhombus(draw.PointLike.to_point) function converts a
- @rhombus(draw.PointLike, ~annot) value to a @rhombus(draw.Point, ~class), like the
- @rhombus(draw.PointLike.to_point, ~annot) annotation. An expression
- @rhombus(pt) with static information from @rhombus(draw.PointLike, ~annot)
- can call @rhombus(draw.PointLike.to_point(pt)) using @rhombus(pt.to_point()).
+ The @rhombus(PointLike.to_point) function converts a
+ @rhombus(PointLike, ~annot) value to a @rhombus(Point, ~class), like the
+ @rhombus(PointLike.to_point, ~annot) annotation. An expression
+ @rhombus(pt) with static information from @rhombus(PointLike, ~annot)
+ can call @rhombus(PointLike.to_point(pt)) using @rhombus(pt.to_point()).
 
- @rhombus(draw.Point.zero) is a @rhombus(draw.Point, ~class) object with @rhombus(0)
+ @rhombus(Point.zero) is a @rhombus(Point, ~class) object with @rhombus(0)
  values.
 
 }
@@ -64,18 +64,18 @@
   class draw.Size(width :: NonnegReal, height :: NonnegReal)
   annot.macro 'draw.SizeLike'
   annot.macro 'draw.SizeLike.to_size'
-  fun draw.SizeLike.to_size(sz :: draw.SizeLike) :: draw.Size
-  def draw.Size.zero :: draw.Size = draw.Size(0, 0)
+  fun draw.SizeLike.to_size(sz :: SizeLike) :: Size
+  def draw.Size.zero :: Size = Size(0, 0)
 ){
 
- The @rhombus(draw.Size, ~class) class represents a size in two dimensions.
+ The @rhombus(Size, ~class) class represents a size in two dimensions.
 
  Methods that expect a size typically accept a value satisfying
- @rhombus(draw.SizeLike, ~annot), which is any of the following:
+ @rhombus(SizeLike, ~annot), which is any of the following:
 
 @itemlist(
 
- @item{@rhombus(draw.Size, ~annot); a @rhombus(draw.Size, ~class) instance;}
+ @item{@rhombus(Size, ~annot); a @rhombus(Size, ~class) instance;}
 
  @item{@rhombus(matching([_ :: NonnegReal, _ :: NonnegReal]), ~annot):
   a @rhombus(List) containing two @rhombus(NonnegReal, ~annot)
@@ -87,10 +87,10 @@
 
 )
 
- The @rhombus(draw.SizeLike.to_size, ~annot) annotation,
- @rhombus(draw.SizeLike.to_size) function, and @rhombus(draw.Size.zero) value are
- anaologous to @rhombus(draw.PointLike.to_point, ~annot),
- @rhombus(draw.PointLike.to_point), and @rhombus(draw.Point.zero).
+ The @rhombus(SizeLike.to_size, ~annot) annotation,
+ @rhombus(SizeLike.to_size) function, and @rhombus(Size.zero) value are
+ anaologous to @rhombus(PointLike.to_point, ~annot),
+ @rhombus(PointLike.to_point), and @rhombus(Point.zero).
 
 }
 
@@ -101,35 +101,35 @@
     constructor
     | (x :: Real, y :: Real,
        width :: NonnegReal, height :: NonnegReal)
-    | (point :: draw.PointLike, size :: draw.SizeLike)
-  property (r :: draw.Rect).point :: draw.Point
-  property (r :: draw.Rect).size :: draw.Size
+    | (point :: PointLike, size :: SizeLike)
+  property (r :: draw.Rect).point :: Point
+  property (r :: draw.Rect).size :: Size
   annot.macro 'draw.RectLike'
   annot.macro 'draw.RectLike.to_rect'
-  fun draw.RectLike.to_rect(sz :: draw.RectLike) :: draw.Rect
-  def draw.Rect.zero :: draw.Rect = draw.Rect(0, 0, 0, 0)
+  fun draw.RectLike.to_rect(sz :: RectLike) :: Rect
+  def draw.Rect.zero :: Rect = Rect(0, 0, 0, 0)
 ){
 
- The @rhombus(draw.Rect, ~class) class represents a rectagular region, where
+ The @rhombus(Rect, ~class) class represents a rectagular region, where
  @rhombus(x) and @rhombus(y) correspond to the top-left of the rectangle.
- The @rhombus(draw.Rect.point) property produces @rhombus(x) and @rhombus(y)
- in a @rhombus(draw.Point, ~class), while @rhombus(draw.Rect.size) property produces
- @rhombus(width) and @rhombus(height) in a @rhombus(draw.Size, ~class).
+ The @rhombus(Rect.point) property produces @rhombus(x) and @rhombus(y)
+ in a @rhombus(Point, ~class), while @rhombus(Rect.size) property produces
+ @rhombus(width) and @rhombus(height) in a @rhombus(Size, ~class).
 
  Methods that expect a rectangle typically accept a value satisfying
- @rhombus(draw.RectLike, ~annot), which is any of the following:
+ @rhombus(RectLike, ~annot), which is any of the following:
 
 @itemlist(
 
- @item{a @rhombus(draw.Rect, ~class) instance;}
+ @item{a @rhombus(Rect, ~class) instance;}
 
  @item{@rhombus(matching([_ :: Real, _ :: Real, _ :: NonnegReal, _ :: NonnegReal]), ~annot):
   a @rhombus(List) containing two @rhombus(Real, ~annot) values for the top-left point
   followed by two @rhombus(NonnegReal, ~annot) values for the size;}
 
- @item{@rhombus(matching([_ :: draw.PointLike, _ :: draw.SizeLike]), ~annot):
-  a @rhombus(List) containing a @rhombus(draw.PointLike, ~annot) value
-  followed by a @rhombus(draw.SizeLike, ~annot) value;}
+ @item{@rhombus(matching([_ :: PointLike, _ :: SizeLike]), ~annot):
+  a @rhombus(List) containing a @rhombus(PointLike, ~annot) value
+  followed by a @rhombus(SizeLike, ~annot) value;}
 
  @item{@rhombus(matching({#'x: _ :: Real, #'y: _ :: Real, #'width: _ :: NonnegReal, #'height: _ :: NonnegReal}), ~annot):
   a @rhombus(Map) containing at least the keys @x_sym,
@@ -137,17 +137,17 @@
   the first two are mapped to a @rhombus(Real, ~annot) value, and each of
   the last two are mapped to a @rhombus(NonnegReal, ~annot) value; or}
 
- @item{@rhombus(matching({#'point: _ :: draw.PointLike, #'size: _ :: draw.SizeLike}), ~annot):
+ @item{@rhombus(matching({#'point: _ :: PointLike, #'size: _ :: SizeLike}), ~annot):
   a @rhombus(Map) containing at least the keys @point_sym
   and @size_sym, where the first is mapped to a
-  @rhombus(draw.PointLike, ~annot) value and the second is mapped to a
-  @rhombus(draw.SizeLike, ~annot) value.}
+  @rhombus(PointLike, ~annot) value and the second is mapped to a
+  @rhombus(SizeLike, ~annot) value.}
 
 )
 
- The @rhombus(draw.RectLike.to_rect, ~annot) annotation,
- @rhombus(draw.RectLike.to_rect) function, and @rhombus(draw.Rect.zero) value are
- anaologous to @rhombus(draw.PointLike.to_point, ~annot),
- @rhombus(draw.PointLike.to_point), and @rhombus(draw.Point.zero).
+ The @rhombus(RectLike.to_rect, ~annot) annotation,
+ @rhombus(RectLike.to_rect) function, and @rhombus(Rect.zero) value are
+ anaologous to @rhombus(PointLike.to_point, ~annot),
+ @rhombus(PointLike.to_point), and @rhombus(Point.zero).
 
 }

--- a/rhombus-draw/rhombus/draw/scribblings/region.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/region.scrbl
@@ -10,7 +10,7 @@
 
 @doc(
   class draw.Region():
-    constructor (dc :: maybe(draw.DC) = #false)
+    constructor (dc :: maybe(DC) = #false)
 ){
 
  Creates a region, optionally specific to @rhombus(dc).
@@ -18,7 +18,7 @@
 }
 
 @doc(
-  property (rgn :: draw.Region).dc :: maybe(draw.DC)
+  property (rgn :: draw.Region).dc :: maybe(DC)
 ){
 
  Reports the drawing context that the region is specific to, if any.
@@ -27,7 +27,7 @@
 
 @doc(
   method (rgn :: draw.Region).is_empty() :: Boolean
-  method (rgn :: draw.Region).contains(pt :: draw.PointLike) :: Boolean
+  method (rgn :: draw.Region).contains(pt :: PointLike) :: Boolean
 ){
 
   Queries the content represented by the region.
@@ -36,28 +36,28 @@
 
 @doc(
   method (rgn :: draw.Region).polygon(
-    [pt :: draw.PointLike, ...],
-    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    [pt :: PointLike, ...],
+    ~dpt: dpt :: PointLike = Point.zero,
     ~dx: dx :: Real = 0,
     ~dy: dy :: Real = 0,
-    ~fill: fill :: draw.Region.Fill = #'even_odd
+    ~fill: fill :: Region.Fill = #'even_odd
   ) :: Void
-  method (rgn :: draw.Region).rectangle(r :: draw.RectLike)
+  method (rgn :: draw.Region).rectangle(r :: RectLike)
     :: Void
-  method (rgn :: draw.Region).rounded_rectangle(r :: draw.RectLike,
+  method (rgn :: draw.Region).rounded_rectangle(r :: RectLike,
                                                 radius :: Real = -0.25)
     :: Void
-  method (rgn :: draw.Region).ellipse(r :: draw.RectLike)
+  method (rgn :: draw.Region).ellipse(r :: RectLike)
     :: Void
-  method (rgn :: draw.Region).arc(r :: draw.RectLike,
+  method (rgn :: draw.Region).arc(r :: RectLike,
                                   start :: Real, end :: Real)
     :: Void
   method (rgn :: draw.Region).path(
-    p :: Path,
-    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    p :: draw.Path,
+    ~dpt: dpt :: PointLike = Point.zero,
     ~dx: dx :: Real = 0,
     ~dy: dy :: Real = 0,
-    ~fill: fill :: draw.Region.Fill = #'odd_even
+    ~fill: fill :: Region.Fill = #'odd_even
   ) :: Void
 ){
 
@@ -66,10 +66,10 @@
 }
 
 @doc(
-  method (rgn :: draw.Region).union(rgn2 :: draw.Region) :: Void
-  method (rgn :: draw.Region).intersect(rgn2 :: draw.Region) :: Void
-  method (rgn :: draw.Region).subtract(rgn2 :: draw.Region) :: Void
-  method (rgn :: draw.Region).xor(rgn2 :: draw.Region) :: Void
+  method (rgn :: draw.Region).union(rgn2 :: Region) :: Void
+  method (rgn :: draw.Region).intersect(rgn2 :: Region) :: Void
+  method (rgn :: draw.Region).subtract(rgn2 :: Region) :: Void
+  method (rgn :: draw.Region).xor(rgn2 :: Region) :: Void
 ){
 
  Changes the region by applying a combination with another region. The

--- a/rhombus-draw/rhombus/draw/scribblings/region.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/region.scrbl
@@ -9,8 +9,8 @@
 @title{Region}
 
 @doc(
-  class Region():
-    constructor (dc :: maybe(DC) = #false)
+  class draw.Region():
+    constructor (dc :: maybe(draw.DC) = #false)
 ){
 
  Creates a region, optionally specific to @rhombus(dc).
@@ -18,7 +18,7 @@
 }
 
 @doc(
-  property (rgn :: Region).dc :: maybe(DC)
+  property (rgn :: draw.Region).dc :: maybe(draw.DC)
 ){
 
  Reports the drawing context that the region is specific to, if any.
@@ -26,8 +26,8 @@
 }
 
 @doc(
-  method (rgn :: Region).is_empty() :: Boolean
-  method (rgn :: Region).contains(pt :: PointLike) :: Boolean
+  method (rgn :: draw.Region).is_empty() :: Boolean
+  method (rgn :: draw.Region).contains(pt :: draw.PointLike) :: Boolean
 ){
 
   Queries the content represented by the region.
@@ -35,28 +35,30 @@
 }
 
 @doc(
-  method (rgn :: Region).polygon([pt :: PointLike, ...],
-                                 ~dpt: dpt :: PointLike = Point.zero,
-                                 ~dx: dx :: Real = 0,
-                                 ~dy: dy :: Real = 0,
-                                 ~fill: fill :: Region.Fill = #'even_odd)
+  method (rgn :: draw.Region).polygon(
+    [pt :: draw.PointLike, ...],
+    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    ~dx: dx :: Real = 0,
+    ~dy: dy :: Real = 0,
+    ~fill: fill :: draw.Region.Fill = #'even_odd
+  ) :: Void
+  method (rgn :: draw.Region).rectangle(r :: draw.RectLike)
     :: Void
-  method (rgn :: Region).rectangle(r :: RectLike)
+  method (rgn :: draw.Region).rounded_rectangle(r :: draw.RectLike,
+                                                radius :: Real = -0.25)
     :: Void
-  method (rgn :: Region).rounded_rectangle(r :: RectLike,
-                                           radius :: Real = -0.25)
+  method (rgn :: draw.Region).ellipse(r :: draw.RectLike)
     :: Void
-  method (rgn :: Region).ellipse(r :: RectLike)
+  method (rgn :: draw.Region).arc(r :: draw.RectLike,
+                                  start :: Real, end :: Real)
     :: Void
-  method (rgn :: Region).arc(r :: RectLike,
-                             start :: Real, end :: Real)
-    :: Void
-  method (rgn :: Region).path(p :: Path,
-                              ~dpt: dpt :: PointLike = Point.zero,
-                              ~dx: dx :: Real = 0,
-                              ~dy: dy :: Real = 0,
-                              ~fill: fill :: Region.Fill = #'odd_even)
-    :: Void
+  method (rgn :: draw.Region).path(
+    p :: Path,
+    ~dpt: dpt :: draw.PointLike = draw.Point.zero,
+    ~dx: dx :: Real = 0,
+    ~dy: dy :: Real = 0,
+    ~fill: fill :: draw.Region.Fill = #'odd_even
+  ) :: Void
 ){
 
  Adds to the region. A path or polygon is implicitly closed.
@@ -64,10 +66,10 @@
 }
 
 @doc(
-  method (rgn :: Region).union(rgn2 :: Region) :: Void
-  method (rgn :: Region).intersect(rgn2 :: Region) :: Void
-  method (rgn :: Region).subtract(rgn2 :: Region) :: Void
-  method (rgn :: Region).xor(rgn2 :: Region) :: Void
+  method (rgn :: draw.Region).union(rgn2 :: draw.Region) :: Void
+  method (rgn :: draw.Region).intersect(rgn2 :: draw.Region) :: Void
+  method (rgn :: draw.Region).subtract(rgn2 :: draw.Region) :: Void
+  method (rgn :: draw.Region).xor(rgn2 :: draw.Region) :: Void
 ){
 
  Changes the region by applying a combination with another region. The
@@ -76,8 +78,8 @@
 }
 
 @doc(
-  enum Region.Fill:
-    even_odd
+  enum draw.Region.Fill:
+    odd_even
     winding
 ){
 

--- a/rhombus-scribble/rhombus/scribble/tests/doc.scrbl
+++ b/rhombus-scribble/rhombus/scribble/tests/doc.scrbl
@@ -3,7 +3,8 @@
     meta_label:
       rhombus:
         expose:
-          fun)
+          fun
+      rhombus/draw)
 
 @docmodule(rhombus)
 
@@ -21,5 +22,21 @@
 ){
 
  Description.
+
+}
+
+@section{Draw}
+
+@docmodule(rhombus/draw)
+
+@doc(
+  property (dc :: draw.DC).handle :: Any
+  fun draw.DC.from_handle(hand :: Any) :: draw.DC
+  enum draw.DC.Fill:
+    even_odd
+    winding
+){
+
+ Draw description.
 
 }

--- a/rhombus-scribble/rhombus/scribble/tests/doc_expect.shrub
+++ b/rhombus-scribble/rhombus/scribble/tests/doc_expect.shrub
@@ -345,6 +345,226 @@
               »
             »;
             div:« {class:« "SIntrapara" »}; "Description." »
+          »;
+          h3:«»;
+          p:«
+            table:«
+              tr:«
+                td:«
+                  span:« {class:« "hspace" »}; nbsp »;
+                  span:«
+                    {class:« "stt" »};
+                    span:« {class:« "RktSym" »}; "import" »
+                  »;
+                  span:« {class:« "stt" »}; ": " »;
+                  a:«
+                    {class:« "RktModLink" »};
+                    span:« {class:« "stt" »}; "rhombus" »;
+                    span:« {class:« "stt" »}; "/" »;
+                    span:« {class:« "stt" »}; "draw" »
+                  »
+                »;
+                td:«
+                  span:«
+                    {class:« "RpackageSpec" »};
+                    span:« {class:« "Smaller" »}; nbsp; "package:" »;
+                    " ";
+                    a:« {}; span:« {class:« "stt" »}; "rhombus-draw-lib" » »
+                  »
+                »
+              »
+            »
+          »;
+          p:«
+            div:«
+              {class:« "SIntrapara" »};
+              table:«
+                tr:«
+                  td:«
+                    div:«
+                      {class:« "RBackgroundLabel SIEHidden" »};
+                      div:«
+                        {class:« "RBackgroundLabelInner" »};
+                        p:« "property" »
+                      »
+                    »
+                  »
+                »;
+                tr:«
+                  td:«
+                    table:«
+                      tr:«
+                        td:«
+                          p:«
+                            span:« {class:« "stt" »}; "property" »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            span:« {class:« "RktPn" »}; "(" »;
+                            span:« {class:« "RktVar" »}; "dc" »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            span:« {class:« "stt" »}; "::" »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            span:«
+                              {class:« "stt" »};
+                              span:« {class:« "RktSym" »}; "draw.DC" »
+                            »;
+                            span:« {class:« "RktPn" »}; ")" »;
+                            span:« {class:« "stt" »}; "." »;
+                            a:« {} »;
+                            span:«
+                              {};
+                              span:«
+                                {class:« "RktSym" »};
+                                a:«
+                                  {class:« "RktValDef RktValLink" »};
+                                  "handle"
+                                »
+                              »
+                            »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            span:« {class:« "stt" »}; "::" »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            span:« {class:« "stt" »}; "Any" »
+                          »
+                        »
+                      »
+                    »
+                  »
+                »;
+                tr:« td:« p:« span:« {class:« "hspace" »}; nbsp » » » »;
+                tr:«
+                  td:«
+                    div:«
+                      {class:« "RBackgroundLabel SIEHidden" »};
+                      div:«
+                        {class:« "RBackgroundLabelInner" »};
+                        p:« "function" »
+                      »
+                    »
+                  »
+                »;
+                tr:«
+                  td:«
+                    table:«
+                      tr:«
+                        td:«
+                          p:«
+                            span:«
+                              {class:« "stt" »};
+                              a:« {class:« "RktValLink" »}; "fun" »
+                            »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            a:« {} »;
+                            span:«
+                              {};
+                              span:« {class:« "RktSym" »}; "draw." »;
+                              span:«
+                                {class:« "RktSym" »};
+                                a:«
+                                  {class:« "RktValDef RktValLink" »};
+                                  "DC.from_handle"
+                                »
+                              »
+                            »;
+                            span:« {class:« "RktPn" »}; "(" »;
+                            span:« {class:« "RktVar" »}; "hand" »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            span:« {class:« "stt" »}; "::" »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            span:« {class:« "stt" »}; "Any" »;
+                            span:« {class:« "RktPn" »}; ")" »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            span:« {class:« "stt" »}; "::" »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            span:«
+                              {class:« "stt" »};
+                              span:« {class:« "RktSym" »}; "draw.DC" »
+                            »
+                          »
+                        »
+                      »
+                    »
+                  »
+                »;
+                tr:« td:« p:« span:« {class:« "hspace" »}; nbsp » » » »;
+                tr:«
+                  td:«
+                    div:«
+                      {class:« "RBackgroundLabel SIEHidden" »};
+                      div:«
+                        {class:« "RBackgroundLabelInner" »};
+                        p:« "enumeration" »
+                      »
+                    »
+                  »
+                »;
+                tr:«
+                  td:«
+                    table:«
+                      tr:«
+                        td:«
+                          p:«
+                            span:« {class:« "stt" »}; "enum" »;
+                            span:« {class:« "hspace" »}; nbsp »;
+                            a:« {} »;
+                            span:«
+                              {};
+                              span:« {class:« "RktSym" »}; "draw." »;
+                              span:«
+                                {class:« "RktSym" »};
+                                a:«
+                                  {class:« "RktValDef RktValLink" »};
+                                  "DC.Fill"
+                                »
+                              »
+                            »;
+                            span:« {class:« "stt" »}; ":" »
+                          »
+                        »
+                      »;
+                      tr:«
+                        td:«
+                          p:«
+                            span:« {class:« "hspace" »}; nbsp; nbsp »;
+                            a:« {} »;
+                            a:« {} »;
+                            span:«
+                              {};
+                              span:«
+                                {class:« "RktSym" »};
+                                a:«
+                                  {class:« "RktValDef RktValLink" »};
+                                  "even_odd"
+                                »
+                              »
+                            »
+                          »
+                        »
+                      »;
+                      tr:«
+                        td:«
+                          p:«
+                            span:« {class:« "hspace" »}; nbsp; nbsp »;
+                            a:« {} »;
+                            a:« {} »;
+                            span:«
+                              {};
+                              span:«
+                                {class:« "RktSym" »};
+                                a:«
+                                  {class:« "RktValDef RktValLink" »};
+                                  "winding"
+                                »
+                              »
+                            »
+                          »
+                        »
+                      »
+                    »
+                  »
+                »
+              »
+            »;
+            div:« {class:« "SIntrapara" »}; "Draw description." »
           »
         »
       »;

--- a/shrubbery-render-lib/shrubbery/render/private/render.rkt
+++ b/shrubbery-render-lib/shrubbery/render/private/render.rkt
@@ -526,7 +526,11 @@
         (cons (datum->syntax target
                              (render-in-space
                               (if root 'rhombus/namespace space-name)
-                              (shrubbery-syntax->string target)
+                              (let ([str (shrubbery-syntax->string target)]
+                                    [prefix (hash-ref resolved 'raw-prefix #f)])
+                                (if prefix
+                                    (string-append prefix str)
+                                    str))
                               (or (and root (add-space root 'rhombus/namespace))
                                   (add-space target space-name))
                               #:suffix (and root target)


### PR DESCRIPTION
There are two commits here, and for me, the question is whether to keep the second one.

The first commit changes the `rhombus/draw` documentation to use a `draw.` prefix everywhere. For example, `DC` is documented as `draw.DC` (but only the `DC` part is bold) and any reference is also written as `draw.DC`. There are not any examples, yet, in this start at documentation, but the intent is that examples would consistently use `draw.`. The intent is to encourage importing `rhombus/draw` without `open`.

The second commit tries to cut back on `draw.` noise in the documentation by using `draw.DC` for definitions, but just `DC` for references, such as in an annotation or in text. This choice seems consistent with the way that errors from annotation failures will omit the prefix.

I'm not sure whether it's better to just write `draw.` everywhere, but I lean toward keeping the second commit, reducing the number of `draw.`s in the documentation (and also not trying to change the implementation to add lots of `draw.`s).