### PR TITLE
`rhombus/runtime` -> `rhombus/memory`

### DIFF
--- a/rhombus-lib/rhombus/measure.rhm
+++ b/rhombus-lib/rhombus/measure.rhm
@@ -3,7 +3,7 @@ import:
   lib("racket/base.rkt"):
     expose:
       time as rkt_time
-  rhombus/runtime
+  rhombus/memory
 
 export:
   time
@@ -15,7 +15,7 @@ expr.macro
     let [tag, _, ...] = b.unwrap()
     let body = Syntax.make([tag, body, ...])
     'block:
-       base.#{collect-garbage}()
+       memory.gc()
        $(expr_meta.pack_s_exp(['rkt_time', expr_meta.pack_expr('block $body')]))'
 | 'time: $(body :: Block)':
     expr_meta.pack_s_exp(['rkt_time', expr_meta.pack_expr('block $body')])
@@ -24,12 +24,12 @@ expr.macro 'memory: $(body :: Block)':
   'call_with_memory_use(fun () $body)'
 
 fun call_with_memory_use(proc):
-  let before = runtime.cumulative_memory_use()
+  let before = memory.cumulative_use()
   let (after, results):
     call_with_values(proc,
                      fun
-                     | (x): values(runtime.cumulative_memory_use(), [x])
-                     | (& xs): values(runtime.cumulative_memory_use(), xs))
+                     | (x): values(memory.cumulative_use(), [x])
+                     | (& xs): values(memory.cumulative_use(), xs))
   println("allocated: " +& (after - before))
   values(& results)
 

--- a/rhombus-lib/rhombus/memory.rhm
+++ b/rhombus-lib/rhombus/memory.rhm
@@ -7,8 +7,8 @@ export:
   minor_gc
   incremental_gc
 
-  current_memory_use
-  cumulative_memory_use
+  current_use
+  cumulative_use
 
 fun gc():
   base.#{collect-garbage}()
@@ -19,8 +19,8 @@ fun minor_gc():
 fun incremental_gc():
   base.#{collect-garbage}(#'incremental)
 
-fun current_memory_use():
+fun current_use():
   base.#{current-memory-use}()
   
-fun cumulative_memory_use():
+fun cumulative_use():
   base.#{current-memory-use}(#'cumulative)

--- a/rhombus/rhombus/scribblings/reference/measure.scrbl
+++ b/rhombus/rhombus/scribblings/reference/measure.scrbl
@@ -4,7 +4,7 @@
     "nonterminal.rhm".body
     meta_label:
       rhombus/measure
-      rhombus/runtime)
+      rhombus/memory)
 
 @title(~style: #'toc, ~tag: "measure"){Measuring Time and Space}
 
@@ -24,7 +24,7 @@
  prints to the current output port the amount of time elapsed during the
  evaluation of @rhombus(body) sequence.
 
- If the @rhombus(~gc) option is specified, then @rhombus(runtime.gc) is
+ If the @rhombus(~gc) option is specified, then @rhombus(memory.gc) is
  called before the @rhombus(body) sequence, and time required for the
  garbage collection is not counted as part of the reported time.
 

--- a/rhombus/rhombus/scribblings/reference/memory.scrbl
+++ b/rhombus/rhombus/scribblings/reference/memory.scrbl
@@ -2,28 +2,28 @@
 @(import:
     "common.rhm" open
     meta_label:
-      rhombus/runtime)
+      rhombus/memory)
 
 @title(~tag: "memory"){Memory Management}
 
-@docmodule(~use_sources: lib("rhombus/runtime.rhm"),
-           rhombus/runtime)
+@docmodule(~use_sources: lib("rhombus/memory.rhm"),
+           rhombus/memory)
 
 @doc(
-  fun runtime.gc() :: Void
-  fun runtime.minor_gc() :: Void
-  fun runtime.incremental_gc() :: Void
+  fun memory.gc() :: Void
+  fun memory.minor_gc() :: Void
+  fun memory.incremental_gc() :: Void
 ){
 
  Forces an immediate garbage collection:
 
 @itemlist(
 
- @item{@rhombus(runtime.gc) forces a major collection that inspects all generations.}
+ @item{@rhombus(memory.gc) forces a major collection that inspects all generations.}
 
- @item{@rhombus(runtime.minor_gc) function forces only a minor collection.}
+ @item{@rhombus(memory.minor_gc) function forces only a minor collection.}
 
- @item{@rhombus(runtime.incremental_gc) function may perform a minor collection,
+ @item{@rhombus(memory.incremental_gc) function may perform a minor collection,
   but also requests incremental collection for future automatic
   collections. The request expires if it is not renewed frequently.}
 
@@ -32,19 +32,19 @@
 }
 
 @doc(
-  fun runtime.current_memory_use() :: Int
-  fun runtime.cumulative_memory_use() :: Int
+  fun memory.current_use() :: Int
+  fun memory.cumulative_use() :: Int
 ){
 
  Returns the amount of memory allocated:
 
 @itemlist(
 
- @item{@rhombus(runtime.current_memory_use) reports the number of bytes occupied
+ @item{@rhombus(memory.current_use) reports the number of bytes occupied
   by all currently allocated objects, not counting overhead, but including
   objects that might be reclaimed immediately by a garbage collection.}
 
- @item{@rhombus(runtime.cumulative_memory_use) reports the total number of bytes
+ @item{@rhombus(memory.cumulative_use) reports the total number of bytes
   that have been allocated since the process started, including bytes that
   have been subsequently reclaimed by garbage collection.}
 

--- a/rhombus/rhombus/tests/map.rhm
+++ b/rhombus/rhombus/tests/map.rhm
@@ -1,7 +1,7 @@
 #lang rhombus
 import:
   "version_guard.rhm"
-  rhombus/runtime
+  rhombus/memory
 
 block:
   import "static_arity.rhm"
@@ -1052,7 +1052,7 @@ block:
        m5[boson] := boson
        check m5[boson] ~is boson
        boson := #false
-       runtime.gc()
+       memory.gc()
        check m5.length() ~is 0'
   check_map_by ==
   check_map_by ===

--- a/rhombus/rhombus/tests/set.rhm
+++ b/rhombus/rhombus/tests/set.rhm
@@ -1,7 +1,7 @@
 #lang rhombus
 import:
   "version_guard.rhm"
-  rhombus/runtime
+  rhombus/memory
 
 block:
   import "static_arity.rhm"
@@ -655,7 +655,7 @@ block:
                                                                     WeakMutableSet.by($key_comp){ 3 }]
        // make sure the set is weak:
        boson := #false
-       runtime.gc()
+       memory.gc()
        check m5.length() ~is 0'
   check_set_by ==
   check_set_by ===


### PR DESCRIPTION
Rename the `racket/runtime` module to `racket/memory` and adjust some exported names to not repeat `memory` in the name.