### PR TITLE
add `Char` and `Byte` expressions/bindings

### DIFF
--- a/gui_demo.rhm
+++ b/gui_demo.rhm
@@ -123,7 +123,7 @@ def tabs:
   fun accum_key(ev :: gui.KeyEvent, area):
     keyed.update(fun (s :: String):
                    match ev.code
-                   | #{#\backspace} || #{#\rubout}:
+                   | Char"\b" || Char"\x7F" /* ASCII delete */:
                        if s.length() == 0 | s | s.substring(0, s.length() - 1)
                    | c :: Char: s ++ to_string(c)
                    | ~else: s)

--- a/rhombus-draw-lib/rhombus/draw/private/font.rhm
+++ b/rhombus-draw-lib/rhombus/draw/private/font.rhm
@@ -83,7 +83,7 @@ class Font(private _handle):
     ~is_a Int.in(100, 1000)
     { thin, ultralight, light, semilight, book, normal,
       medium, semibold, bold, ultrabold, heavy, ultraheavy }
-    
+
   symbol_map_annot Smoothing convert_smoothing unconvert_smoothing:
     { default: default,
       partly_smoothed: #{partly-smoothed},
@@ -99,11 +99,9 @@ class Font(private _handle):
 
   fun
   | is_feature_string(v :: String):
-      fun ok(c):
-         c == " "[0]
-           || c == "!"[0]
-           || (Char.to_int(c) >= Char.to_int("#"[0])
-                 && Char.to_int(c) <= Char.to_int("~"[0]))
+      fun ok(c :~ Char):
+         c matches (Char" " || Char"!")
+           || (c >= Char"#" && c <= Char"~")
       v.length() == 4 && ok(v[0]) && ok(v[1]) && ok(v[2]) && ok(v[3])
   | is_feature_string(_):
       #false

--- a/rhombus-lib/rhombus/private/amalgam/annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation.rkt
@@ -49,7 +49,6 @@
                     Exact
                     Inexact
                     Flonum
-                    Byte
                     Number
                     Void
                     False
@@ -811,7 +810,6 @@
 
 (void (set-primitive-contract! 'exact-integer? "Int"))
 (void (set-primitive-contract! 'exact-nonnegative-integer? "NonnegInt"))
-(void (set-primitive-contract! 'byte? "Byte"))
 (void (set-primitive-contract! 'number? "Number"))
 (void (set-primitive-contract! 'integer? "Integral"))
 (void (set-primitive-contract! 'real? "Real"))
@@ -822,7 +820,6 @@
 (define-annotation-syntax PosInt (identifier-annotation exact-positive-integer? #,(get-int-static-infos)))
 (define-annotation-syntax NegInt (identifier-annotation exact-negative-integer? #,(get-int-static-infos)))
 (define-annotation-syntax NonnegInt (identifier-annotation exact-nonnegative-integer? #,(get-int-static-infos)))
-(define-annotation-syntax Byte (identifier-annotation byte? #,(get-int-static-infos)))
 (define-annotation-syntax Flonum (identifier-annotation flonum? #,(get-flonum-static-infos)))
 (define-annotation-syntax Number (identifier-annotation number? #,(get-number-static-infos)))
 (define-annotation-syntax Integral (identifier-annotation integer? #,(get-rational-static-infos)))

--- a/rhombus-lib/rhombus/private/amalgam/apostrophe.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/apostrophe.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
+                     shrubbery/print
                      "srcloc.rkt")
          "provide.rkt"
          "expression.rkt"
@@ -51,7 +52,7 @@
        [(form-name q . tail)
         (check-quotable #'form-name #'q)
         (values (binding-form #'literal-infoer
-                              #'(q))
+                              #`([q #,(string-append "#'" (shrubbery-syntax->string #'q))]))
                 #'tail)]))))
 
 (define-for-syntax (check-quotable form-name q)

--- a/rhombus-lib/rhombus/private/amalgam/byte.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/byte.rkt
@@ -1,0 +1,66 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     shrubbery/print
+                     "srcloc.rkt"
+                     "extract-elem-from-literal.rkt")
+         "expression.rkt"
+         "binding.rkt"
+         "repetition.rkt"
+         (submod "annotation.rkt" for-class)
+         "number.rkt"
+         "rhombus-primitive.rkt"
+         "static-info.rkt"
+         "provide.rkt"
+         "literal.rkt")
+
+(provide (for-spaces (#f
+                      rhombus/repet
+                      rhombus/bind
+                      rhombus/annot)
+                     Byte))
+
+(define-syntax Byte
+  (expression-transformer
+   (lambda (tail)
+     (syntax-parse tail
+       [(form-id bstr . new-tail)
+        (define byte (extract-byte-from-bytes #'form-id #'bstr))
+        (values (wrap-static-info*
+                 (relocate+reraw
+                  (respan (datum->syntax #f (list #'form-id #'bstr)))
+                  #`(quote #,byte))
+                 (get-int-static-infos))
+                #'new-tail)]))))
+
+(define-repetition-syntax Byte
+  (repetition-transformer
+   (lambda (tail)
+     (syntax-parse tail
+       [(form-id bstr . new-tail)
+        (define byte (extract-byte-from-bytes #'form-id #'bstr))
+        (values (make-repetition-info (respan (datum->syntax #f (list #'form-id #'bstr)))
+                                      '()
+                                      #`(quote #,byte)
+                                      (get-int-static-infos)
+                                      0)
+                #'new-tail)]))))
+
+(define-binding-syntax Byte
+  (binding-transformer
+   (lambda (tail)
+     (syntax-parse tail
+       [(form-id bstr . new-tail)
+        (define byte (extract-byte-from-bytes #'form-id #'bstr))
+        (values (binding-form #'literal-infoer
+                              #`([#,byte #,(string-append "Byte" (shrubbery-syntax->string #'bstr))]))
+                #'new-tail)]))))
+
+(define-for-syntax (extract-byte-from-bytes form-id bstr-stx)
+  (extract-elem-from-literal form-id bstr-stx
+                             bytes? bytes-length bytes-ref
+                             "byte" "byte string"))
+
+(void (set-primitive-contract! 'byte? "Byte"))
+(define-annotation-syntax Byte
+  (identifier-annotation byte? #,(get-int-static-infos)))

--- a/rhombus-lib/rhombus/private/amalgam/charset.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/charset.rhm
@@ -178,64 +178,64 @@ class Charset(private _ranges):
 module test:
   import "check.rhm" open
   check Charset().int_ranges() ~is []
-  check Charset("a"[0]).int_ranges() ~is [[97, 97]]
-  check Charset("a"[0], "f"[0]).int_ranges() ~is [[97, 102]]
-  check Charset("a"[0], Char.from_int(0x10FFFF)).int_ranges() ~is [[97, 0xD7FF], [0x10000, 0x10FFFF]]
+  check Charset(Char"a").int_ranges() ~is [[97, 97]]
+  check Charset(Char"a", Char"f").int_ranges() ~is [[97, 102]]
+  check Charset(Char"a", Char.from_int(0x10FFFF)).int_ranges() ~is [[97, 0xD7FF], [0x10000, 0x10FFFF]]
 
   check Charset().length() ~is 0
   check Charset().invert().length() ~is 0x110000 - (0x10000 - 0xD800)
-  check Charset("a"[0]).length() ~is 1
-  check Charset("a"[0], "f"[0]).length() ~is 6
-  check Charset("a"[0], "f"[0]).union(Charset("y"[0], "z"[0])).length() ~is 8
+  check Charset(Char"a").length() ~is 1
+  check Charset(Char"a", Char"f").length() ~is 6
+  check Charset(Char"a", Char"f").union(Charset(Char"y", Char"z")).length() ~is 8
 
-  check Charset("a"[0], "f"[0])
-    .union(Charset("h"[0], "i"[0]))
+  check Charset(Char"a", Char"f")
+    .union(Charset(Char"h", Char"i"))
     .int_ranges() ~is [[97, 102], [104, 105]]
-  check Charset("a"[0], "f"[0])
-    .union(Charset("g"[0], "i"[0]))
+  check Charset(Char"a", Char"f")
+    .union(Charset(Char"g", Char"i"))
     .int_ranges() ~is [[97, 105]]
-  check Charset("a"[0], "z"[0])
-    .union(Charset("g"[0], "i"[0]))
+  check Charset(Char"a", Char"z")
+    .union(Charset(Char"g", Char"i"))
     .int_ranges() ~is [[97, 122]]
-  check Charset("a"[0], "f"[0])
-    .union(Charset("g"[0], "g"[0]))
+  check Charset(Char"a", Char"f")
+    .union(Charset(Char"g", Char"g"))
     .int_ranges() ~is [[97, 103]]
-  check Charset("g"[0], "g"[0])
-    .union(Charset("a"[0], "f"[0]))
+  check Charset(Char"g", Char"g")
+    .union(Charset(Char"a", Char"f"))
     .int_ranges() ~is [[97, 103]]
-  check Charset("a"[0], "c"[0]).union(Charset("g"[0], "i"[0]))
-    .union(Charset("a"[0], "d"[0]))
+  check Charset(Char"a", Char"c").union(Charset(Char"g", Char"i"))
+    .union(Charset(Char"a", Char"d"))
     .int_ranges() ~is [[97, 100], [103, 105]]
-  check Charset("a"[0], "c"[0]).union(Charset("g"[0], "i"[0]))
-    .union(Charset("a"[0], "d"[0]).union(Charset("z"[0], "z"[0])))
+  check Charset(Char"a", Char"c").union(Charset(Char"g", Char"i"))
+    .union(Charset(Char"a", Char"d").union(Charset(Char"z", Char"z")))
     .int_ranges() ~is [[97, 100], [103, 105], [122, 122]]
-  check Charset("a"[0], "d"[0]).union(Charset("z"[0], "z"[0]))
-    .union(Charset("a"[0], "c"[0]).union(Charset("g"[0], "i"[0])))
+  check Charset(Char"a", Char"d").union(Charset(Char"z", Char"z"))
+    .union(Charset(Char"a", Char"c").union(Charset(Char"g", Char"i")))
     .int_ranges() ~is [[97, 100], [103, 105], [122, 122]]
 
-  check Charset("a"[0], "f"[0])
-    .intersect(Charset("h"[0], "i"[0]))
+  check Charset(Char"a", Char"f")
+    .intersect(Charset(Char"h", Char"i"))
     .int_ranges() ~is []
-  check Charset("a"[0], "z"[0])
-    .intersect(Charset("h"[0], "i"[0]))
+  check Charset(Char"a", Char"z")
+    .intersect(Charset(Char"h", Char"i"))
     .int_ranges() ~is [[104, 105]]
-  check Charset("a"[0], "z"[0])
-    .intersect(Charset("a"[0], "c"[0]).union(Charset("h"[0], "i"[0])))
+  check Charset(Char"a", Char"z")
+    .intersect(Charset(Char"a", Char"c").union(Charset(Char"h", Char"i")))
     .int_ranges() ~is [[97, 99], [104, 105]]
-  check Charset("a"[0], "c"[0]).union(Charset("h"[0], "i"[0]))
-    .intersect(Charset("a"[0], "z"[0]))
+  check Charset(Char"a", Char"c").union(Charset(Char"h", Char"i"))
+    .intersect(Charset(Char"a", Char"z"))
     .int_ranges() ~is [[97, 99], [104, 105]]
-  check Charset("b"[0], "z"[0])
-    .intersect(Charset("a"[0], "c"[0]).union(Charset("h"[0], "i"[0])))
+  check Charset(Char"b", Char"z")
+    .intersect(Charset(Char"a", Char"c").union(Charset(Char"h", Char"i")))
     .int_ranges() ~is [[98, 99], [104, 105]]
-  check Charset("a"[0], "c"[0]).union(Charset("h"[0], "i"[0]))
-    .intersect(Charset("b"[0], "z"[0]))
+  check Charset(Char"a", Char"c").union(Charset(Char"h", Char"i"))
+    .intersect(Charset(Char"b", Char"z"))
     .int_ranges() ~is [[98, 99], [104, 105]]
-  check Charset("a"[0], "z"[0])
-    .intersect(Charset("b"[0], "c"[0]).union(Charset("h"[0], "i"[0])))
+  check Charset(Char"a", Char"z")
+    .intersect(Charset(Char"b", Char"c").union(Charset(Char"h", Char"i")))
     .int_ranges() ~is [[98, 99], [104, 105]]
-  check Charset("b"[0], "c"[0]).union(Charset("h"[0], "i"[0]))
-    .intersect(Charset("a"[0], "z"[0]))
+  check Charset(Char"b", Char"c").union(Charset(Char"h", Char"i"))
+    .intersect(Charset(Char"a", Char"z"))
     .int_ranges() ~is [[98, 99], [104, 105]]
 
   check Charset()
@@ -245,25 +245,25 @@ module test:
     .invert()
     .invert()
     .int_ranges() ~is []
-  check Charset("a"[0], "f"[0])
+  check Charset(Char"a", Char"f")
     .invert()
     .int_ranges() ~is [[0, 96], [103, 0xD7FF], [0x10000, 0x10FFFF]]
-  check Charset(Char.from_int(0), "f"[0])
+  check Charset(Char.from_int(0), Char"f")
     .invert()
     .int_ranges() ~is [[103, 0xD7FF], [0x10000, 0x10FFFF]]
-  check Charset(Char.from_int(0), "f"[0])
-    .union(Charset("z"[0], Char.from_int(0x10FFFF)))
+  check Charset(Char.from_int(0), Char"f")
+    .union(Charset(Char"z", Char.from_int(0x10FFFF)))
     .invert()
     .int_ranges() ~is [[103, 121]]
-  check Charset(Char.from_int(0), "f"[0])
-    .union(Charset("z"[0], Char.from_int(0x10FFFF)))
+  check Charset(Char.from_int(0), Char"f")
+    .union(Charset(Char"z", Char.from_int(0x10FFFF)))
     .invert()
     .invert()
     .int_ranges() ~is  [[0, 102], [122, 0xD7FF], [0x10000, 0x10FFFF]]
 
-  check Charset("a"[0], "f"[0])
+  check Charset(Char"a", Char"f")
     .subtract(Charset())
     .int_ranges() ~is [[97, 102]]
-  check Charset("a"[0], "f"[0])
-    .subtract(Charset("c"[0], "z"[0]))
+  check Charset(Char"a", Char"f")
+    .subtract(Charset(Char"c", Char"z"))
     .int_ranges() ~is [[97, 98]]

--- a/rhombus-lib/rhombus/private/amalgam/core.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core.rkt
@@ -79,6 +79,7 @@
         "string.rkt"
         "bytes.rkt"
         "char.rkt"
+        "byte.rkt"
         "symbol.rkt"
         "keyword.rkt"
         "dot.rkt"

--- a/rhombus-lib/rhombus/private/amalgam/error.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/error.rhm
@@ -154,14 +154,14 @@ fun reindent(s :~ String,
                          = 72 - (2 + label.length() + 1 + space.length())) :~ String:
   if (s.length() > max_len
         || (for any (c: s):
-              c == "\n"[0]))
+              c == Char"\n"))
   | "\n" ++ tab
       ++ (block:
             fun loop(i, start):
               cond
               | i == s.length():
                   s.substring(start, i)
-              | s[i] == "\n"[0]:
+              | s[i] == Char"\n":
                   s.substring(start, i) ++ "\n" ++ tab ++ loop(i+1, i+1)
               | ~else:
                   loop(i+1, start)

--- a/rhombus-lib/rhombus/private/amalgam/extract-elem-from-literal.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/extract-elem-from-literal.rkt
@@ -1,0 +1,16 @@
+#lang racket/base
+(require "srcloc.rkt")
+
+(provide extract-elem-from-literal)
+
+(define (extract-elem-from-literal form-id lit-stx
+                                   pred len ref
+                                   elem-type lit-type)
+  (define lit (syntax-e lit-stx))
+  (unless (and (pred lit)
+               (eqv? (len lit) 1))
+    (raise-syntax-error #f
+                        (string-append "expected a literal single-" elem-type " " lit-type)
+                        (respan (datum->syntax #f (list form-id lit-stx)))
+                        lit-stx))
+  (ref lit 0))

--- a/rhombus-lib/rhombus/private/amalgam/implicit.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/implicit.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
+                     shrubbery/print
                      "srcloc.rkt"
                      "pack.rkt")
          "expression.rkt"
@@ -105,7 +106,7 @@
        [(form-id datum . tail)
         (check-literal-term #'form-id #'datum)
         (values (binding-form #'literal-infoer
-                              #'(datum))
+                              #`([datum #,(shrubbery-syntax->string #'datum)]))
                 #'tail)]))))
 
 (define-repetition-syntax #%literal
@@ -130,7 +131,7 @@
             (null? d))
     (raise-syntax-error #f
                         "not an allowed literal term"
-                        form-id
+                        (respan (datum->syntax #f (list form-id d-stx)))
                         d-stx)))
 
 (define-syntax #%parens

--- a/rhombus-lib/rhombus/private/amalgam/match.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/match.rkt
@@ -149,7 +149,8 @@
                               [rhs (in-list lit-rhss)])
                      (syntax-parse parsed
                        [b::binding-form
-                        #`[b.data (rhombus-body-expression #,rhs)]]))
+                        #:with ([datum _] ...) #'b.data
+                        #`[(datum ...) (rhombus-body-expression #,rhs)]]))
                 [else #,(fallback-k #'val rst-bs rst-parseds rst-rhss)])]
            [else
             (fallback-k #'val bs b-parseds rhss)]))))

--- a/rhombus-lib/rhombus/private/amalgam/print.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/print.rkt
@@ -134,6 +134,14 @@
        ;; only print immutable (byte) strings as literals
        [(immutable? v) (write v op)]
        [else (other v mode op)])]
+    [(char? v)
+     (cond
+       [(display?)
+        (display v op)]
+       [else
+        (concat
+         (display "Char" op)
+         (write (string v) op))])]
     [(exact-integer? v)
      (write v op)]
     [(and (rational? v) (exact? v))
@@ -415,7 +423,7 @@
        [else
         (define rop (open-output-bytes))
         (display "#{" rop)
-        (unless (or (number? v) (char? v))
+        (unless (number? v)
           (display "'" rop))
         (racket-print (racket-print-redirect v) rop 1)
         (display "}" rop)

--- a/rhombus-lib/rhombus/private/amalgam/rx_charset.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx_charset.rhm
@@ -123,60 +123,60 @@ rx_charset.macro '$left -- $right':
 
 rx_charset.macro 'alpha':
   ~all_stx: stx
-  rx_charset_meta.pack(Charset("a"[0], "z"[0])
-                            .union(Charset("A"[0], "Z"[0])),
+  rx_charset_meta.pack(Charset(Char"a", Char"z")
+                         .union(Charset(Char"A", Char"Z")),
                        stx)
 rx_charset.macro 'upper':
   ~all_stx: stx
-  rx_charset_meta.pack(Charset("A"[0], "Z"[0]), stx)
+  rx_charset_meta.pack(Charset(Char"A", Char"Z"), stx)
 
 rx_charset.macro 'lower':
   ~all_stx: stx
-  rx_charset_meta.pack(Charset("a"[0], "z"[0]), stx)
+  rx_charset_meta.pack(Charset(Char"a", Char"z"), stx)
 
 rx_charset.macro 'digit':
   ~all_stx: stx
-  rx_charset_meta.pack(Charset("0"[0], "9"[0]), stx)
+  rx_charset_meta.pack(Charset(Char"0", Char"9"), stx)
 
 rx_charset.macro 'xdigit':
   ~all_stx: stx
-  rx_charset_meta.pack(Charset("0"[0], "9"[0])
-                         .union(Charset("a"[0], "f"[0]))
-                         .union(Charset("A"[0], "F"[0])),
+  rx_charset_meta.pack(Charset(Char"0", Char"9")
+                         .union(Charset(Char"a", Char"f"))
+                         .union(Charset(Char"A", Char"F")),
                        stx)
 
 rx_charset.macro 'alnum':
   ~all_stx: stx
-  rx_charset_meta.pack(Charset("0"[0], "9"[0])
-                         .union(Charset("a"[0], "z"[0]))
-                         .union(Charset("A"[0], "Z"[0])),
+  rx_charset_meta.pack(Charset(Char"0", Char"9")
+                         .union(Charset(Char"a", Char"z"))
+                         .union(Charset(Char"A", Char"Z")),
                        stx)
 
 rx_charset.macro 'word':
   ~all_stx: stx
-  rx_charset_meta.pack(Charset("0"[0], "9"[0])
-                         .union(Charset("a"[0], "z"[0]))
-                         .union(Charset("A"[0], "Z"[0]))
-                         .union(Charset("_"[0])),
+  rx_charset_meta.pack(Charset(Char"0", Char"9")
+                         .union(Charset(Char"a", Char"z"))
+                         .union(Charset(Char"A", Char"Z"))
+                         .union(Charset(Char"_")),
                        stx)
 
 rx_charset.macro 'blank':
   ~all_stx: stx
-  rx_charset_meta.pack(Charset("\t"[0])
-                         .union(Charset(" "[0])),
+  rx_charset_meta.pack(Charset(Char"\t")
+                         .union(Charset(Char" ")),
                        stx)
 
 rx_charset.macro 'newline':
   ~all_stx: stx
-  rx_charset_meta.pack(Charset("\n"[0]), stx)
+  rx_charset_meta.pack(Charset(Char"\n"), stx)
 
 rx_charset.macro 'space':
   ~all_stx: stx
-  rx_charset_meta.pack(Charset("\t"[0])
-                         .union(Charset(" "[0]))
-                         .union(Charset("\n"[0]))
-                         .union(Charset("\r"[0]))
-                         .union(Charset("\f"[0])),
+  rx_charset_meta.pack(Charset(Char"\t")
+                         .union(Charset(Char" "))
+                         .union(Charset(Char"\n"))
+                         .union(Charset(Char"\r"))
+                         .union(Charset(Char"\f")),
                        stx)
 
 rx_charset.macro 'graph':
@@ -186,7 +186,7 @@ rx_charset.macro 'graph':
 rx_charset.macro 'print':
   ~all_stx: stx
   rx_charset_meta.pack(Charset(Char.is_graphic, ~only_ascii: #true)
-                         .union(Charset(" "[0]).union(Charset("\t"[0]))),
+                         .union(Charset(Char" ").union(Charset(Char"\t"))),
                        stx)
 
 rx_charset.macro 'cntrl':

--- a/rhombus-lib/rhombus/private/amalgam/rx_compile.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx_compile.rhm
@@ -390,11 +390,11 @@ meta:
     | [[s, e]] when s == e:
         // single character
         cond
-        | s == "^"[0].to_int(): "\\^"
-        | s == "-"[0].to_int(): "\\-"
-        | s == "["[0].to_int(): "\\["
-        | s == "]"[0].to_int(): "\\]"
-        | s == "\\"[0].to_int(): "\\\\"
+        | s == Char"^".to_int(): "\\^"
+        | s == Char"-".to_int(): "\\-"
+        | s == Char"[".to_int(): "\\["
+        | s == Char"]".to_int(): "\\]"
+        | s == Char"\\".to_int(): "\\\\"
         | ~else: "[" +& Char.from_int(s) +& "]"
     | [[45, 45], [94, 94]]:
         // avoid generating `[^-]`:
@@ -406,19 +406,19 @@ meta:
               let one = Charset(ch)
               loop(cs.subtract(one))
             cond
-            | cs.has_edge("-"[0]):
+            | cs.has_edge(Char"-"):
                 // put `-` farthest at end
-                without_one("-"[0]) ++ "-"
-            | cs.has_edge("^"[0]):
+                without_one(Char"-") ++ "-"
+            | cs.has_edge(Char"^"):
                 // put `^` farthest at end, except maybe before `-`;
                 // there must be other things to go before `^` if we
                 // arrived at this case
-                without_one("^"[0]) ++ "^"
-            | cs.has_edge("]"[0]):
+                without_one(Char"^") ++ "^"
+            | cs.has_edge(Char"]"):
                 // put `[` at beginning
-                "[" ++ without_one("]"[0])
-            | cs.has_edge("\\"[0]):
-                "\\\\" ++ without_one("\\"[0])
+                "[" ++ without_one(Char"]")
+            | cs.has_edge(Char"\\"):
+                "\\\\" ++ without_one(Char"\\")
             | ~else:
                 // Note: we won't create a `[:` combination, because `:`
                 // is earlier in ASCII than `[`

--- a/rhombus-lib/rhombus/private/amalgam/str.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/str.rhm
@@ -53,7 +53,7 @@ namespace str:
       | max_width == 0: ""
       | n .= 0: zero_sign
       | n < 0 || n == -0.0: minus_sign
-      | ~else: plus_sign      
+      | ~else: plus_sign
     // attach sign to number if it's #'center sign alignment
     let (s :~ String, sign :~ String):
       if sign_align == #'center
@@ -79,16 +79,16 @@ namespace str:
           | #'center:
               let m = (min_width - len) div 2
               String.make(m, pad) ++ s ++ String.make(min_width - len - m, pad)
-          | ~else:                
+          | ~else:
               String.make(min_width - len, pad) ++ s
       | len > max_width:
           match clip_align
           | #'left:
               s.substring(0, max_width)
           | #'center:
-              let m = (len - max_width) div 2              
+              let m = (len - max_width) div 2
               s.substring(m, m + max_width)
-          | ~else:                
+          | ~else:
               s.substring(len - max_width, len)
       | ~else:
           s
@@ -101,7 +101,7 @@ namespace str:
     | ~else:
         s
 
-  decl.nestable_macro 'def_num $name($n :: $annot,                                                        
+  decl.nestable_macro 'def_num $name($n :: $annot,
                                      $xkw: $xarg :: $xres ...,
                                      ...):
                          $defn
@@ -112,13 +112,13 @@ namespace str:
       '(~width: width :: maybe(NonnegInt) = #false,
         ~min_width: min_width :: maybe(NonnegInt) = width,
         ~max_width: max_width :: maybe(NonnegInt) = width,
-        ~pad: pad :: Char = " "[0],
+        ~pad: pad :: Char = Char" ",
         ~align: align :: Align = #'left,
         ~clip_align: clip_align :: Align = align,
         ~minus_sign: minus_sign :: String  = "-",
         ~plus_sign: plus_sign :: String  = "",
         ~zero_sign: zero_sign :: String  = "",
-        ~sign_align: sign_align :: Align = #'center)'                                     
+        ~sign_align: sign_align :: Align = #'center)'
     'export:
        $name
      fun $name($n :: $annot,
@@ -134,7 +134,7 @@ namespace str:
                     $kw: $arg,
                     ...)'
 
-  decl.nestable_macro 'def_int $name $to_string':  
+  decl.nestable_macro 'def_int $name $to_string':
     'def_num $name(n :: Int):
        $to_string(math.abs(n))'
 
@@ -190,7 +190,7 @@ namespace str:
     cond
     | n == #inf || n == #neginf: "inf"
     | n == #nan: "nan"
-    | ~else:                       
+    | ~else:
         let n = math.abs(n)
         // get parts that preserves available precision, without keeping too much;
         // keeping only the needed precision is important for rounding correctly
@@ -237,7 +237,7 @@ namespace str:
               let frac:
                 if precision == 0
                 | ""
-                | String.make(precision - frac.length(), "0"[0]) ++ frac
+                | String.make(precision - frac.length(), Char"0") ++ frac
               values(to_string(mant), frac, 0)
           | ~else:
               let expo = real_exponent(n)
@@ -260,7 +260,7 @@ namespace str:
               values(mant,
                      if precision == 0
                      | ""
-                     | String.make(math.max(0, precision - frac.length()), "0"[0]) ++ frac,
+                     | String.make(math.max(0, precision - frac.length()), Char"0") ++ frac,
                      expo)
         let (mant :~ String, frac :~ String, expo :: Int):
           retry(n, precision, use_exponent)
@@ -299,7 +299,7 @@ namespace str:
         ~width: width :: maybe(NonnegInt) = #false,
         ~min_width: min_width :: maybe(NonnegInt) = width,
         ~max_width: max_width :: maybe(NonnegInt) = width,
-        ~pad: pad :: Char = " "[0],
+        ~pad: pad :: Char = Char" ",
         ~align: align :: Align = #'left,
         ~clip_align: clip_align :: Align = #'left) :~ String:
     build_number(#'s,

--- a/rhombus-lib/rhombus/private/amalgam/str_help.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/str_help.rhm
@@ -22,7 +22,7 @@ fun extract_flonum_parts(n :~ Flonum) :~ values(String, String, Int):
   cond
   | dot_or_exp == s.length():
       values(s, "", 0)
-  | s[dot_or_exp] == "."[0]:
+  | s[dot_or_exp] == Char".":
       let exp = next_non_digit(dot_or_exp + 1)
       cond
       | exp == s.length():
@@ -44,7 +44,7 @@ fun count_leading_zeros(s :~ String):
   fun loop(i):
     cond
     | i+1 == s.length(): i
-    | s[i] == "0"[0]: loop(i+1)
+    | s[i] == Char"0": loop(i+1)
     | ~else: i
   loop(0)
 
@@ -53,7 +53,7 @@ fun count_trailing_zeros(s :~ String):
   fun loop (i):
     cond
     | i == s.length(): i
-    | s[s.length() - i - 1] == "0"[0]: loop(i+1)
+    | s[s.length() - i - 1] == Char"0": loop(i+1)
     | ~else: i
   loop(0)
 
@@ -61,7 +61,7 @@ fun insert_decimal(s :~ String, expo, precision):
   let s:
     cond
     | s.length() <= -expo:
-        String.make((-expo - s.length()) + 1, "0"[0]) ++ s
+        String.make((-expo - s.length()) + 1, Char"0") ++ s
     | ~else:
         s
   fun trim(s :~ String):
@@ -73,10 +73,10 @@ fun insert_decimal(s :~ String, expo, precision):
       let mant = s.substring(0, m_len)
       let frac = s.substring(m_len, s.length())
       values(trim(mant),
-             (frac ++ String.make(math.max(0, precision - frac.length()), "0"[0])).substring(0, precision))
+             (frac ++ String.make(math.max(0, precision - frac.length()), Char"0")).substring(0, precision))
   | expo > 0:
-      values(trim(s ++ String.make(expo, "0"[0])),
-             String.make(precision, "0"[0]))
+      values(trim(s ++ String.make(expo, Char"0")),
+             String.make(precision, Char"0"))
 
 // determines `expo` so that `n` is between `10**expo` and `10**(expo+1)`;
 // assumes that `n` is nonnegative

--- a/rhombus-pict-lib/rhombus/pict/rhombus.rhm
+++ b/rhombus-pict-lib/rhombus/pict/rhombus.rhm
@@ -60,7 +60,7 @@ def (render_line,
                    rtt(str)
                ~render_whitespace:
                  fun (n):
-                   rtt(String.make(n, " "[0]))
+                   rtt(String.make(n, Char" "))
                ~render_line:
                  fun (elems):
                    fun flatten(p):
@@ -83,7 +83,7 @@ def (render_line,
                    if s
                    | let p = rtt(" ")
                      p.scale(s * n / m / p.width, 1)
-                   | tt(String.make(n, " "[0]))
+                   | tt(String.make(n, Char" "))
                ~is_rendered:
                  fun (v):
                    v is_a Pict)

--- a/rhombus-pict-lib/rhombus/pict/text.rhm
+++ b/rhombus-pict-lib/rhombus/pict/text.rhm
@@ -180,8 +180,8 @@ fun flatten_para_content(who, decode, c) :~ List:
                                                         #{#:decode?}: decode,
                                                         str)), #'sep],
                              ...)
-        let ps = if s[s.length()-1] == " "[0] | ps | ps.drop_last(1)
-        let ps = if s[0] == " "[0] | List.cons(#'sep, ps) | ps
+        let ps = if s[s.length()-1] == Char" " | ps | ps.drop_last(1)
+        let ps = if s[0] == Char" " | List.cons(#'sep, ps) | ps
         ps
     | p :: Pict: [#'sep, p, #'sep]
     | []: []

--- a/rhombus-scribble-lib/rhombus/scribble/private/section.rhm
+++ b/rhombus-scribble-lib/rhombus/scribble/private/section.rhm
@@ -50,7 +50,7 @@ meta:
                 match prefix
                 | s :: String:
                     if delta > 0
-                    | s ++ String.make(delta, " "[0])
+                    | s ++ String.make(delta, Char" ")
                     | s.substring(0, s.length() + delta)
                 | Pair(a, PairList.empty):
                     Pair(loop(a), PairList.empty)

--- a/rhombus/rhombus/scribblings/common.rhm
+++ b/rhombus/rhombus/scribblings/common.rhm
@@ -42,7 +42,7 @@ export:
 fun see_implicit(what, whn, context, ~is_infix = #false):
   @scribble.elem{The @what form is implicitly used when @whn is
                  used in @(if is_infix | @scribble.elem{after another @context} | "")
-                 in a@(if (context[0] == "e"[0] || context[0] == "i"[0]) | "n" | "")
+                 in a@(if (context[0] matches (Char"e" || Char"i")) | "n" | "")
                  @context position.
                  See also @scribble.secref("implicit").}
 

--- a/rhombus/rhombus/scribblings/reference/bytes.scrbl
+++ b/rhombus/rhombus/scribblings/reference/bytes.scrbl
@@ -4,9 +4,9 @@
 
 @title{Byte Strings}
 
-A @deftech{byte string} is a sequence of bytes (i.e., integers between 0
-and 255 inclusive). A byte string works with map-referencing @brackets
-to access a byte via @rhombus(#%index). A byte string also works with the
+A @deftech{byte string} is a sequence of @tech{bytes}. A byte string
+works with map-referencing @brackets to access a byte via
+@rhombus(#%index). A byte string also works with the
 @rhombus(++) operator to append bytes strings. A byte string can be used
 as @tech{sequence}, in which case it supplies its bytes in order.
 
@@ -63,7 +63,7 @@ like @rhombus(<) and @rhombus(>) work on byte strings.
  byte is initialized to @rhombus(byte).
 
 @examples(
-  Bytes.make(5, 33)
+  Bytes.make(5, Byte#"!")
 )
 
 }
@@ -111,9 +111,9 @@ like @rhombus(<) and @rhombus(>) work on byte strings.
 
 @examples(
   def b = #"abc".copy()
-  b[0] := 104
+  b[0] := Byte#"h"
   b
-  b.set(1, 104)
+  b.set(1, Byte#"h")
   b
 )
 

--- a/rhombus/rhombus/scribblings/reference/char.scrbl
+++ b/rhombus/rhombus/scribblings/reference/char.scrbl
@@ -44,6 +44,29 @@ like @rhombus(<) and @rhombus(>) work on characters.
 }
 
 @doc(
+  expr.macro 'Char $single_char_str'
+  repet.macro 'Char $single_char_str'
+  bind.macro 'Char $single_char_str'
+){
+
+ Produces or matches a character. The @rhombus(single_char_str)
+ literal @tech{string} must have exactly a single character, and that
+ character is produced or matched.
+
+@examples(
+  Char"a"
+  match Char"a"
+  | Char"a" || Char"b": "yes"
+  | ~else: "no"
+  ~error:
+    Char"too long"
+  ~error:
+    Char"a" matches Char"too long"
+)
+
+}
+
+@doc(
   fun Char.to_int(ch :: Char) :: NonnegInt
 ){
 
@@ -199,8 +222,8 @@ like @rhombus(<) and @rhombus(>) work on characters.
   ~hidden:
     use_static
   ~repl:
-    "a"[0] < "B"[0]
-    ("a"[0] :: CharCI) < ("B"[0] :: CharCI)
+    Char"a" < Char"B"
+    (Char"a" :: CharCI) < (Char"B" :: CharCI)
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/match.scrbl
+++ b/rhombus/rhombus/scribblings/reference/match.scrbl
@@ -59,11 +59,14 @@
  generated exception's message may be specialized to report the expected
  pattern, instead of just reporting that no cases matched.
 
- If an initial segment of @rhombus(bind) patterns are literals or combinations of literals
- with @rhombus(||, ~bind), then the match is implemented as a case
- dispatch, and a match is found with logarithmic rather than linear
- time complexity in the number of literals. The remaining patterns are
- handled as usual.
+ If an initial segment of @rhombus(bind) patterns are ``literal-like''
+ or combinations of such patterns with @rhombus(||, ~bind), then the
+ match is implemented as a case dispatch, and a match is found with
+ logarithmic rather than linear time complexity in the number of
+ literals. ``Literal-like'' patterns include (usually implicitly used)
+ @rhombus(#%literal, ~bind), @rhombus(#', ~bind),
+ @rhombus(Char, ~bind), and @rhombus(Byte, ~bind). The remaining
+ patterns are handled as usual.
 
 @examples(
   match 1+2

--- a/rhombus/rhombus/scribblings/reference/number.scrbl
+++ b/rhombus/rhombus/scribblings/reference/number.scrbl
@@ -191,11 +191,36 @@ operations like @rhombus(.<) and @rhombus(.>) work only on real numbers.
   annot.macro 'Byte'
 ){
 
- Matches integers in the range @rhombus(0) ro @rhombus(255) (inclusive).
+ Matches bytes. A @deftech{byte} is an integer in the range
+ @rhombus(0) to @rhombus(255) (inclusive).
 
 @examples(
   5 is_a Byte
   256 is_a Byte
+  Byte#"a" is_a Byte
+)
+
+}
+
+@doc(
+  expr.macro 'Byte $single_byte_bstr'
+  repet.macro 'Byte $single_byte_bstr'
+  bind.macro 'Byte $single_byte_bstr'
+){
+
+ Produces or matches a byte. The @rhombus(single_byte_bstr)
+ literal @tech{byte string} must have exactly a single byte, and that
+ byte is produced or matched.
+
+@examples(
+  Byte#"a"
+  match Byte#"a"
+  | Byte#"a" || Byte#"b": "yes"
+  | ~else: "no"
+  ~error:
+    Byte#"too long"
+  ~error:
+    Byte#"a" matches Byte#"too long"
 )
 
 }
@@ -239,7 +264,7 @@ operations like @rhombus(.<) and @rhombus(.>) work only on real numbers.
 ){
 
  Integer division (truncating), remainder, and modulo operations. These
- operators have stronger pecedence than @rhombus(+) and @rhombus(-) but
+ operators have stronger precedence than @rhombus(+) and @rhombus(-) but
  no precedence relationship to @rhombus(*), @rhombus(/), or @rhombus(**).
 
 @examples(
@@ -260,7 +285,7 @@ operations like @rhombus(.<) and @rhombus(.>) work only on real numbers.
 ){
 
  The usual comparison operators on real numbers prefixed with @litchar{.} to
- distinsguish them from generic operations like @rhombus(<) on
+ distinguish them from generic operations like @rhombus(<) on
  @tech{comparable} values. See also @rhombus(.=) and @rhombus(.!=),
  which work on all numbers.
 
@@ -477,7 +502,7 @@ operations like @rhombus(.<) and @rhombus(.>) work only on real numbers.
   def math.pi :: Flonum
 ){
 
- An appromation of @italic{π}, the ratio of a circle's circumference to its diameter.
+ An approximation of @italic{π}, the ratio of a circle's circumference to its diameter.
 
 @examples(
   math.pi

--- a/rhombus/rhombus/scribblings/reference/str.scrbl
+++ b/rhombus/rhombus/scribblings/reference/str.scrbl
@@ -38,7 +38,7 @@
             ~width: width :: maybe(NonnegInt) = #false,
             ~min_width: min_width :: maybe(NonnegInt) = width,
             ~max_width: max_width :: maybe(NonnegInt) = width,
-            ~pad: pad :: Char = " "[0],
+            ~pad: pad :: Char = Char" ",
             ~align: align :: str.Align = #'left,
             ~clip_align: clip_align :: str.Align = align)
     :: String
@@ -71,7 +71,7 @@
 
 @examples(
   str.s("hello", ~width: 10)
-  str.s("hello", ~width: 10, ~pad: "_"[0], ~align: #'center)
+  str.s("hello", ~width: 10, ~pad: Char"_", ~align: #'center)
   str.s("hello", ~max_width: 2)
   str.s("hello", ~max_width: 2, ~clip_align: #'right)
 )
@@ -84,7 +84,7 @@
             ~width: width :: maybe(NonnegInt) = #false,
             ~min_width: min_width :: maybe(NonnegInt) = width,
             ~max_width: max_width :: maybe(NonnegInt) = width,
-            ~pad: pad :: Char = " "[0],
+            ~pad: pad :: Char = Char" ",
             ~align: align :: str.Align = #'left,
             ~clip_align: clip_align :: str.Align = align,
             ~minus_sign: minus_sign :: String  = "-",
@@ -141,7 +141,7 @@
             ~width: width :: maybe(NonnegInt) = #false,
             ~min_width: min_width :: maybe(NonnegInt) = width,
             ~max_width: max_width :: maybe(NonnegInt) = width,
-            ~pad: pad :: Char = " "[0],
+            ~pad: pad :: Char = Char" ",
             ~align: align :: str.Align = #'left,
             ~clip_align: clip_align :: str.Align = align,
             ~minus_sign: minus_sign :: String  = "-",

--- a/rhombus/rhombus/scribblings/reference/string.scrbl
+++ b/rhombus/rhombus/scribblings/reference/string.scrbl
@@ -138,7 +138,7 @@ Strings are @tech{comparable}, which means that generic operations like
  string contains @rhombus(c).
 
 @examples(
-  String.make(5, "x"[0])
+  String.make(5, Char"x")
 )
 
 }

--- a/rhombus/rhombus/tests/byte.rhm
+++ b/rhombus/rhombus/tests/byte.rhm
@@ -1,0 +1,49 @@
+#lang rhombus/static
+
+check:
+  Byte#"h" ~is 104
+  Byte#"h" ~is_a Byte
+  Byte#"h" ~is_a NonnegInt
+
+block:
+  fun matcher(byte):
+    match byte
+    | Byte#"a" || Byte#"b" || Byte#"c": #true
+    | ~else: #false
+  check matcher(Byte#"a") ~is #true
+  check matcher(Byte#"b") ~is #true
+  check matcher(Byte#"c") ~is #true
+  check matcher(Byte#"z") ~is #false
+  check matcher(97) ~is #true
+  check matcher(98) ~is #true
+  check matcher(99) ~is #true
+  check matcher(122) ~is #false
+  check matcher(Char"a") ~is #false
+
+check:
+  repr(Byte#"a") ~is "97"
+  repr(Byte#"\n") ~is "10"
+
+block:
+  import:
+    rhombus/meta open
+  expr.macro 'source $expr':
+    '#%literal $(expr.to_source_string())'
+  check source Byte#"a" ~is "Byte#\"a\""
+  check source Byte#"\n" ~is "Byte#\"\\n\""
+
+check:
+  ~eval
+  Byte#"too long"
+  ~throws values(
+    "expected a literal single-byte byte string",
+    "Byte#\"too long\"",
+  )
+
+check:
+  ~eval
+  Byte#"a" matches Byte#"too long"
+  ~throws values(
+    "expected a literal single-byte byte string",
+    "Byte#\"too long\"",
+  )

--- a/rhombus/rhombus/tests/bytes.rhm
+++ b/rhombus/rhombus/tests/bytes.rhm
@@ -22,7 +22,7 @@ block:
 check:
   #"hello" :: Bytes ~is #"hello"
   Bytes.make(5) ~is_now #"\0\0\0\0\0"
-  Bytes.make(5, 104) ~is_now #"hhhhh"
+  Bytes.make(5, Byte#"h") ~is_now #"hhhhh"
 
 block:
   use_static
@@ -32,8 +32,8 @@ block:
     ~is 5
   check:
     #"hello".length() ~is 5
-    #"hello"[0] ~is 104
-    #"hello".get(0) ~is 104
+    #"hello"[0] ~is Byte#"h"
+    #"hello".get(0) ~is Byte#"h"
     #"hello" ++ #" " ++ #"world" ~is_now #"hello world"
     #"hello" ++ #" " ++ "world" ~throws values(
       "Bytes.append: contract violation",
@@ -64,12 +64,12 @@ block:
 
 check:
   dynamic(#"hello").length() ~is 5
-  dynamic(#"hello")[0] ~is 104
+  dynamic(#"hello")[0] ~is Byte#"h"
   dynamic(#"hello" ++ #" ") ++ #"world" ~is_now #"hello world"
   dynamic(#"hello" ++ #" ") ++ "world" ~throws "cannot append a byte string and other value"
   dynamic(#"hello").append(#" world") ~is_now #"hello world"
   dynamic(#"hello").append(#" world", #" and bye") ~is_now #"hello world and bye"
-  dynamic(#"hello").get(0) ~is 104
+  dynamic(#"hello").get(0) ~is Byte#"h"
   dynamic(#"hello").subbytes(1) ~is_now #"ello"
   dynamic(#"hello").subbytes(1, 4) ~is_now #"ell"
   dynamic(#"hello").copy() ~is_now #"hello"
@@ -86,13 +86,13 @@ check:
 block:
   use_static
   def bstr = #"hello".copy()
-  bstr[1] := 104
-  bstr.set(2, 104)
+  bstr[1] := Byte#"h"
+  bstr.set(2, Byte#"h")
   check bstr ~is_now #"hhhlo"
   block:
     use_dynamic
-    dynamic(bstr)[3] := 104
-    dynamic(bstr).set(4, 104)
+    dynamic(bstr)[3] := Byte#"h"
+    dynamic(bstr).set(4, Byte#"h")
     check bstr ~is_now #"hhhhh"
 
 check:
@@ -302,11 +302,11 @@ version_guard.at_least "8.14.0.7":
       "given: \"a\"",
     )
   check:
-    Bytes.make(5, "a"[0])
+    Bytes.make(5, Char"a")
     ~throws values(
       "Bytes.make: contract violation",
       "expected: Byte",
-      "given: #{#\\a}",
+      "given: Char\"a\"",
     )
   check:
     Bytes.make(5, -1)

--- a/rhombus/rhombus/tests/char.rhm
+++ b/rhombus/rhombus/tests/char.rhm
@@ -26,28 +26,54 @@ block:
     Char.grapheme_step(ch, state) ~method
 
 check:
-  "h"[0] :: Char ~is #{#\h}
-  Char.to_int("h"[0]) ~is 104
-  Char.from_int(104) ~is "h"[0]
-  Char.utf8_length("λ"[0]) ~is 2
-  Char.is_alphabetic("λ"[0]) ~is #true
-  Char.is_lowercase("a"[0]) ~is #true
-  Char.is_uppercase("a"[0]) ~is #false
-  Char.is_titlecase("a"[0]) ~is #false
-  Char.is_numeric("a"[0]) ~is #false
-  Char.is_symbolic("+"[0]) ~is #true
-  Char.is_punctuation("!"[0]) ~is #true
-  Char.is_graphic("!"[0]) ~is #true
-  Char.is_blank("!"[0]) ~is #false
-  Char.is_whitespace("!"[0]) ~is #false
-  Char.is_extended_pictographic("!"[0]) ~is #false
-  Char.general_category("a"[0]) ~is #'ll
-  Char.grapheme_break_property("a"[0]) ~is #'Other
-  Char.upcase("a"[0]) ~is "A"[0]
-  Char.downcase("A"[0]) ~is "a"[0]
-  Char.foldcase("A"[0]) ~is "a"[0]
-  Char.titlecase("a"[0]) ~is "A"[0]
-  Char.grapheme_step("a"[0], 0) ~is values(#false, 1)
+  Char"h" :: Char ~is Char"h"
+  Char.from_int(104) ~is Char"h"
+
+block:
+  use_static
+  check:
+    Char"h".to_int() ~is 104
+    Char"λ".utf8_length() ~is 2
+    Char"λ".is_alphabetic() ~is #true
+    Char"a".is_lowercase() ~is #true
+    Char"a".is_uppercase() ~is #false
+    Char"a".is_titlecase() ~is #false
+    Char"a".is_numeric() ~is #false
+    Char"+".is_symbolic() ~is #true
+    Char"!".is_punctuation() ~is #true
+    Char"!".is_graphic() ~is #true
+    Char"!".is_blank() ~is #false
+    Char"!".is_whitespace() ~is #false
+    Char"!".is_extended_pictographic() ~is #false
+    Char"a".general_category() ~is #'ll
+    Char"a".grapheme_break_property() ~is #'Other
+    Char"a".upcase() ~is Char"A"
+    Char"A".downcase() ~is Char"a"
+    Char"A".foldcase() ~is Char"a"
+    Char"a".titlecase() ~is Char"A"
+    Char"a".grapheme_step(0) ~is values(#false, 1)
+
+check:
+  dynamic(Char"h").to_int() ~is 104
+  dynamic(Char"λ").utf8_length() ~is 2
+  dynamic(Char"λ").is_alphabetic() ~is #true
+  dynamic(Char"a").is_lowercase() ~is #true
+  dynamic(Char"a").is_uppercase() ~is #false
+  dynamic(Char"a").is_titlecase() ~is #false
+  dynamic(Char"a").is_numeric() ~is #false
+  dynamic(Char"+").is_symbolic() ~is #true
+  dynamic(Char"!").is_punctuation() ~is #true
+  dynamic(Char"!").is_graphic() ~is #true
+  dynamic(Char"!").is_blank() ~is #false
+  dynamic(Char"!").is_whitespace() ~is #false
+  dynamic(Char"!").is_extended_pictographic() ~is #false
+  dynamic(Char"a").general_category() ~is #'ll
+  dynamic(Char"a").grapheme_break_property() ~is #'Other
+  dynamic(Char"a").upcase() ~is Char"A"
+  dynamic(Char"A").downcase() ~is Char"a"
+  dynamic(Char"A").foldcase() ~is Char"a"
+  dynamic(Char"a").titlecase() ~is Char"A"
+  dynamic(Char"a").grapheme_step(0) ~is values(#false, 1)
 
 block:
   use_static
@@ -56,20 +82,20 @@ block:
 
 check:
   ~eval
-  "a"[0] :: CharCI
+  Char"a" :: CharCI
   ~throws "not allowed in a dynamic context"
 
 check:
   ~eval
-  def c :: CharCI = "a"[0]
+  def c :: CharCI = Char"a"
   ~throws "not allowed in a dynamic context"
 
 block:
   use_static
-  let a :: CharCI = "a"[0]
-  let A :: CharCI = "A"[0]
-  let b :: CharCI = "b"[0]
-  let B :: CharCI = "B"[0]
+  let a :: CharCI = Char"a"
+  let A :: CharCI = Char"A"
+  let b :: CharCI = Char"b"
+  let B :: CharCI = Char"B"
   check:
     a < B ~is #true
     b < A ~is #false
@@ -88,3 +114,50 @@ block:
     a compares_unequal a ~is #false
     a compares_unequal A ~is #false
     a compares_unequal B ~is #true
+
+block:
+  fun matcher(char):
+    match char
+    | Char"a" || Char"b" || Char"c": #true
+    | ~else: #false
+  check matcher(Char"a") ~is #true
+  check matcher(Char"b") ~is #true
+  check matcher(Char"c") ~is #true
+  check matcher(Char"z") ~is #false
+  check matcher(Byte#"a") ~is #false
+  check matcher(97) ~is #false
+
+check:
+  to_string(Char"a") ~is "a"
+  to_string(Char"λ") ~is "λ"
+  to_string(Char"\n") ~is "\n"
+
+check:
+  repr(Char"a") ~is "Char\"a\""
+  repr(Char"λ") ~is "Char\"λ\""
+  repr(Char"\n") ~is "Char\"\\n\""
+
+block:
+  import:
+    rhombus/meta open
+  expr.macro 'source $expr':
+    '#%literal $(expr.to_source_string())'
+  check source Char"a" ~is "Char\"a\""
+  check source Char"λ" ~is "Char\"λ\""
+  check source Char"\n" ~is "Char\"\\n\""
+
+check:
+  ~eval
+  Char"too long"
+  ~throws values(
+    "expected a literal single-character string",
+    "Char\"too long\"",
+  )
+
+check:
+  ~eval
+  Char"a" matches Char"too long"
+  ~throws values(
+    "expected a literal single-character string",
+    "Char\"too long\"",
+  )

--- a/rhombus/rhombus/tests/class-field.rhm
+++ b/rhombus/rhombus/tests/class-field.rhm
@@ -5,16 +5,16 @@ block:
     fun enlist(v, b): [v, b]
     field more :~ List = enlist(s[1], b)
     field even_more = {more[0]}
-  check C("apple").more ~is ["p"[0], "a"[0]]
-  check C("banana").more ~is ["a"[0], "b"[0]]
-  check C("apple").even_more ~is {"p"[0]}
+  check C("apple").more ~is [Char"p", Char"a"]
+  check C("banana").more ~is [Char"a", Char"b"]
+  check C("apple").even_more ~is {Char"p"}
 
 block:
   class C(s :: String, private b = s[0]):
     fun enlist(v, b): [v, b]
     private field more = enlist(s[1], b)
     method get_more(): more
-  check C("apple").get_more() ~is ["p"[0], "a"[0]]
+  check C("apple").get_more() ~is [Char"p", Char"a"]
 
 block:
   class C(s :: String, b = s[0]):
@@ -22,8 +22,8 @@ block:
     constructor (s):
       super("1" ++ s)
   check C("apple").s ~is "1apple"
-  check C("apple").b ~is "1"[0]
-  check C("apple").more ~is "a"[0]
+  check C("apple").b ~is Char"1"
+  check C("apple").more ~is Char"a"
 
 check:
   class Posn(x, y):

--- a/rhombus/rhombus/tests/comparable.rhm
+++ b/rhombus/rhombus/tests/comparable.rhm
@@ -1,6 +1,4 @@
-#lang rhombus
-
-use_static
+#lang rhombus/static
 
 check 1 < 2 ~is #true
 check 1 <= 2 ~is #true
@@ -16,29 +14,44 @@ check 10 compares_equal 10 ~is #true
 check 10 compares_unequal 10 ~is #false
 check 10 >= 2 ~is #true
 check 10 > 2 ~is #true
-  
+
 check 1/2 < 2 ~is #true
 check 1/2 <= 2 ~is #true
 check 1/2 compares_equal 2 ~is #false
 check 1/2 compares_unequal 2 ~is #true
 check 1/2 >= 2 ~is #false
 check 1/2 > 2 ~is #false
-  
-check "a"[0] < "b"[0] ~is #true
-check "a"[0] <= "b"[0] ~is #true
-check "a"[0] compares_equal "b"[0] ~is #false
-check "a"[0] compares_unequal "b"[0] ~is #true
-check "a"[0] >= "b"[0] ~is #false
-check "a"[0] >= "a"[0] ~is #true
-check "a"[0] > "b"[0] ~is #false
-check "a"[0] < "B"[0] ~is #false
-check "a"[0] <= "B"[0] ~is #false
-check "a"[0] <= "a"[0] ~is #true
-check "a"[0] compares_equal "a"[0] ~is #true
-check "a"[0] compares_unequal "a"[0] ~is #false
-check "a"[0] >= "B"[0] ~is #true
-check "a"[0] > "B"[0] ~is #true
-  
+
+check Char"a" < Char"b" ~is #true
+check Char"a" <= Char"b" ~is #true
+check Char"a" compares_equal Char"b" ~is #false
+check Char"a" compares_unequal Char"b" ~is #true
+check Char"a" >= Char"b" ~is #false
+check Char"a" >= Char"a" ~is #true
+check Char"a" > Char"b" ~is #false
+check Char"a" < Char"B" ~is #false
+check Char"a" <= Char"B" ~is #false
+check Char"a" <= Char"a" ~is #true
+check Char"a" compares_equal Char"a" ~is #true
+check Char"a" compares_unequal Char"a" ~is #false
+check Char"a" >= Char"B" ~is #true
+check Char"a" > Char"B" ~is #true
+
+check Byte#"a" < Byte#"b" ~is #true
+check Byte#"a" <= Byte#"b" ~is #true
+check Byte#"a" compares_equal Byte#"b" ~is #false
+check Byte#"a" compares_unequal Byte#"b" ~is #true
+check Byte#"a" >= Byte#"b" ~is #false
+check Byte#"a" >= Byte#"a" ~is #true
+check Byte#"a" > Byte#"b" ~is #false
+check Byte#"a" < Byte#"B" ~is #false
+check Byte#"a" <= Byte#"B" ~is #false
+check Byte#"a" <= Byte#"a" ~is #true
+check Byte#"a" compares_equal Byte#"a" ~is #true
+check Byte#"a" compares_unequal Byte#"a" ~is #false
+check Byte#"a" >= Byte#"B" ~is #true
+check Byte#"a" > Byte#"B" ~is #true
+
 check "a" < "b" ~is #true
 check "a" <= "b" ~is #true
 check "a" compares_equal "b" ~is #false
@@ -53,7 +66,7 @@ check "a" compares_equal "a" ~is #true
 check "a" compares_unequal "a" ~is #false
 check "a" >= "B" ~is #true
 check "a" > "B" ~is #true
-  
+
 check #"a" < #"b" ~is #true
 check #"a" <= #"b" ~is #true
 check #"a" compares_equal #"b" ~is #false
@@ -107,42 +120,48 @@ block:
 block:
   use_dynamic
   check dynamic(1) < dynamic(2) ~is #true
-  check dynamic(#{#\a}) < dynamic(#{#\b}) ~is #true
+  check dynamic(Char"a") < dynamic(Char"b") ~is #true
+  check dynamic(Byte#"a") < dynamic(Byte#"b") ~is #true
   check dynamic("a") < dynamic("b") ~is #true
   check dynamic(#"a") < dynamic(#"b") ~is #true
   check dynamic(#'a) < dynamic(#'b) ~is #true
   check dynamic(#'~a) < dynamic(#'~b) ~is #true
 
   check dynamic(1) <= dynamic(2) ~is #true
-  check dynamic(#{#\a}) <= dynamic(#{#\b}) ~is #true
+  check dynamic(Char"a") <= dynamic(Char"b") ~is #true
+  check dynamic(Byte#"a") <= dynamic(Byte#"b") ~is #true
   check dynamic("a") <= dynamic("b") ~is #true
   check dynamic(#"a") <= dynamic(#"b") ~is #true
   check dynamic(#'a) <= dynamic(#'b) ~is #true
   check dynamic(#'~a) <= dynamic(#'~b) ~is #true
 
   check dynamic(1) >= dynamic(2) ~is #false
-  check dynamic(#{#\a}) >= dynamic(#{#\b}) ~is #false
+  check dynamic(Char"a") >= dynamic(Char"b") ~is #false
+  check dynamic(Byte#"a") >= dynamic(Byte#"b") ~is #false
   check dynamic("a") >= dynamic("b") ~is #false
   check dynamic(#"a") >= dynamic(#"b") ~is #false
   check dynamic(#'a) >= dynamic(#'b) ~is #false
   check dynamic(#'~a) >= dynamic(#'~b) ~is #false
 
   check dynamic(1) > dynamic(2) ~is #false
-  check dynamic(#{#\a}) > dynamic(#{#\b}) ~is #false
+  check dynamic(Char"a") > dynamic(Char"b") ~is #false
+  check dynamic(Byte#"a") > dynamic(Byte#"b") ~is #false
   check dynamic("a") > dynamic("b") ~is #false
   check dynamic(#"a") > dynamic(#"b") ~is #false
   check dynamic(#'a) > dynamic(#'b) ~is #false
   check dynamic(#'~a) > dynamic(#'~b) ~is #false
 
   check dynamic(1) compares_equal dynamic(2) ~is #false
-  check dynamic(#{#\a}) compares_equal dynamic(#{#\b}) ~is #false
+  check dynamic(Char"a") compares_equal dynamic(Char"b") ~is #false
+  check dynamic(Byte#"a") compares_equal dynamic(Byte#"b") ~is #false
   check dynamic("a") compares_equal dynamic("b") ~is #false
   check dynamic(#"a") compares_equal dynamic(#"b") ~is #false
   check dynamic(#'a) compares_equal dynamic(#'b) ~is #false
   check dynamic(#'~a) compares_equal dynamic(#'~b) ~is #false
 
   check dynamic(1) compares_unequal dynamic(2) ~is #true
-  check dynamic(#{#\a}) compares_unequal dynamic(#{#\b}) ~is #true
+  check dynamic(Char"a") compares_unequal dynamic(Char"b") ~is #true
+  check dynamic(Byte#"a") compares_unequal dynamic(Byte#"b") ~is #true
   check dynamic("a") compares_unequal dynamic("b") ~is #true
   check dynamic(#"a") compares_unequal dynamic(#"b") ~is #true
   check dynamic(#'a) compares_unequal dynamic(#'b) ~is #true

--- a/rhombus/rhombus/tests/indexable.rhm
+++ b/rhombus/rhombus/tests/indexable.rhm
@@ -135,12 +135,12 @@ check:
     "expected: Indexable",
     "#'apple",
   )
-  ("apple" :~ MutableIndexable)[0] := "b"[0] ~throws values(
+  ("apple" :~ MutableIndexable)[0] := Char"b" ~throws values(
     "MutableIndexable.set: contract violation",
     "expected: MutableIndexable",
     "\"apple\"",
   )
-  ("apple".copy() :~ MutableIndexable)[0] := "b"[0] ~throws values(
+  ("apple".copy() :~ MutableIndexable)[0] := Char"b" ~throws values(
     "MutableIndexable.set: contract violation",
     "expected: MutableIndexable",
     "String.copy(\"apple\")",

--- a/rhombus/rhombus/tests/pipeline.rhm
+++ b/rhombus/rhombus/tests/pipeline.rhm
@@ -42,17 +42,17 @@ check:
 check:
   use_static
   "apple" |> (_[0])
-  ~is "a"[0]
+  ~is Char"a"
 
 check:
   use_static
   "apple" |> (fun (x): x[0])
-  ~is "a"[0]
+  ~is Char"a"
 
 check:
   use_static
   "apple" |> (fun | (x): x[0])
-  ~is "a"[0]
+  ~is Char"a"
 
 check:
   use_static

--- a/rhombus/rhombus/tests/port.rhm
+++ b/rhombus/rhombus/tests/port.rhm
@@ -32,16 +32,16 @@ block:
   let p = Port.Input.open_string("abλcdefμ")
   check p is_a Port.Input ~is #true
   check p is_a Port.Input.String ~is #true
-  check p.peek_byte() ~is "a"[0].to_int()
-  check p.peek_byte(~skip_bytes: 1) ~is "b"[0].to_int()
-  check p.read_byte() ~is "a"[0].to_int()
-  check p.peek_byte(~skip_bytes: 3) ~is "c"[0].to_int()
-  check p.peek_char() ~is "b"[0]
-  check p.peek_char(~skip_bytes: 1) ~is "λ"[0]
-  check p.peek_char(~skip_bytes: 3) ~is "c"[0]
-  check p.read_char() ~is "b"[0]
-  check p.read_char() ~is "λ"[0]
-  check p.peek_char() ~is "c"[0]
+  check p.peek_byte() ~is Char"a".to_int()
+  check p.peek_byte(~skip_bytes: 1) ~is Char"b".to_int()
+  check p.read_byte() ~is Char"a".to_int()
+  check p.peek_byte(~skip_bytes: 3) ~is Char"c".to_int()
+  check p.peek_char() ~is Char"b"
+  check p.peek_char(~skip_bytes: 1) ~is Char"λ"
+  check p.peek_char(~skip_bytes: 3) ~is Char"c"
+  check p.read_char() ~is Char"b"
+  check p.read_char() ~is Char"λ"
+  check p.peek_char() ~is Char"c"
   check p.read_bytes(2) ~is_now #"cd".copy()
   check p.read_string(3) ~is "efμ"
 

--- a/rhombus/rhombus/tests/printable.rhm
+++ b/rhombus/rhombus/tests/printable.rhm
@@ -40,10 +40,10 @@ check:
   ~prints "1\n2\napple"
 
 check:
-  print([1, String.make(80, "a"[0]), 2], ~pretty: #true)
+  print([1, String.make(80, Char"a"), 2], ~pretty: #true)
   ~prints @str{[
                  1,
-                 "@(String.make(80, "a"[0]))",
+                 "@(String.make(80, Char"a"))",
                  2
                ]}
 

--- a/rhombus/rhombus/tests/repetition.rhm
+++ b/rhombus/rhombus/tests/repetition.rhm
@@ -31,7 +31,7 @@ block:
     ['$x+1', ...]
     ~matches ['1+1', '2+1', '3+1']
 
-// operator uses as reptitions
+// operator uses as repetitions
 block:
   def [x, ...] = [1, 4, 3]
   def four = 4
@@ -52,7 +52,7 @@ block:
   check:
     fun f(x, y): {x: y}
     [f(x, 0), ...]
-    ~is [{1: 0}, {2: 0}, {3: 0}]    
+    ~is [{1: 0}, {2: 0}, {3: 0}]
   check:
     fun f(~x: x, y): {x: y}
     [f(~x: x, 0), ...]
@@ -212,6 +212,17 @@ block:
   check:
     [s.tl, ...][0].x
     ~is 0
+
+// literal-like repetitions
+block:
+  def [x, ...] = [1, 2, 3]
+  check:
+    [[x, 0, #false, #'symbol, #'~keyword, Char"a", Byte#"\0"], ...]
+    ~is [
+      [1, 0, #false, #'symbol, #'~keyword, Char"a", Byte#"\0"],
+      [2, 0, #false, #'symbol, #'~keyword, Char"a", Byte#"\0"],
+      [3, 0, #false, #'symbol, #'~keyword, Char"a", Byte#"\0"],
+    ]
 
 // splicing
 block:

--- a/rhombus/rhombus/tests/sequenceable.rhm
+++ b/rhombus/rhombus/tests/sequenceable.rhm
@@ -242,12 +242,12 @@ block:
     for List:
       each elem: Posn(1, 2) :: Sequence
       elem
-    ~is ["o"[0], "o"[0], "p"[0], "s"[0]]
+    ~is [Char"o", Char"o", Char"p", Char"s"]
   check:
     for List:
       each elem: Posn(1, 2).to_sequence()
       elem
-    ~is ["o"[0], "o"[0], "p"[0], "s"[0]]
+    ~is [Char"o", Char"o", Char"p", Char"s"]
   check:
     Posn(1, 2).to_sequence()
     ~is "oops"

--- a/rhombus/rhombus/tests/str.rhm
+++ b/rhombus/rhombus/tests/str.rhm
@@ -9,9 +9,9 @@ check:
   str.s("apple", ~width: 8) ~is "apple   "
   str.s("apple", ~width: 8, ~align: #'right) ~is "   apple"
   str.s("apple", ~width: 8, ~align: #'center) ~is " apple  "
-  str.s("apple", ~width: 8, ~pad: "#"[0]) ~is "apple###"
-  str.s("apple", ~width: 8, ~align: #'right, ~pad: "!"[0]) ~is "!!!apple"
-  str.s("apple", ~width: 8, ~align: #'center, ~pad: "_"[0]) ~is "_apple__"
+  str.s("apple", ~width: 8, ~pad: Char"#") ~is "apple###"
+  str.s("apple", ~width: 8, ~align: #'right, ~pad: Char"!") ~is "!!!apple"
+  str.s("apple", ~width: 8, ~align: #'center, ~pad: Char"_") ~is "_apple__"
 
   str.d(100) ~is "100"
   str.d(-100) ~is "-100"
@@ -26,7 +26,7 @@ check:
   str.d(-100, ~width: 8, ~sign_align: #'left, ~align: #'right) ~is "-    100"
   str.d(-100, ~width: 8, ~sign_align: #'left, ~align: #'center) ~is "-  100  "
   str.d(-100, ~width: 8, ~sign_align: #'right, ~align: #'center) ~is "  100  -"
-  str.d(-100, ~width: 8, ~sign_align: #'left, ~align: #'center, ~pad: "x"[0]) ~is "-xx100xx"
+  str.d(-100, ~width: 8, ~sign_align: #'left, ~align: #'center, ~pad: Char"x") ~is "-xx100xx"
   str.d(-10, ~max_width: 0, ~sign_align: #'left) ~is ""
   str.d(-123456, ~width: 4, ~align: #'right, ~sign_align: #'left) ~is "-456"
   str.d(-123456, ~width: 4, ~sign_align: #'right) ~is "123-"
@@ -36,14 +36,14 @@ check:
   str.d(-100, ~max_width: 3, ~align: #'right) ~is "100"
 
   str.d(100, ~min_width: 4, ~max_width: 3) ~throws "maximum width is less than minimum width"
-  
+
   str.f(100) ~is "100.000000"
   str.f(-100) ~is "-100.000000"
   str.f(#inf) ~is "inf"
   str.f(#neginf) ~is "-inf"
   str.f(#nan) ~is "nan"
   str.f(0) ~is "0.000000"
-  
+
   str.f(100, ~precision: 2) ~is "100.00"
   str.f(-100, ~precision: 2) ~is "-100.00"
   str.f(#inf, ~precision: 2) ~is "inf"

--- a/rhombus/rhombus/tests/string.rhm
+++ b/rhombus/rhombus/tests/string.rhm
@@ -32,7 +32,7 @@ block:
 check:
   "hello" :: String ~is "hello"
   1 +& 2 ++ "3" ~is "123"
-  String.make(5, "h"[0]) ~is "hhhhh"
+  String.make(5, Char"h") ~is "hhhhh"
 
 block:
   use_static
@@ -42,8 +42,8 @@ block:
     ~is 5
   check:
     "hello".length() ~is 5
-    "hello"[0] ~is "h"[0]
-    "hello".get(0) ~is "h"[0]
+    "hello"[0] ~is Char"h"
+    "hello".get(0) ~is Char"h"
     "hello" ++ " " ++ "world" ~is "hello world"
     "hello" ++ " " ++ #"world" ~throws values(
       "String.append: contract violation",
@@ -85,8 +85,8 @@ block:
 
 check:
   dynamic("hello").length() ~is 5
-  dynamic("hello")[0] ~is "h"[0]
-  dynamic("hello").get(0) ~is "h"[0]
+  dynamic("hello")[0] ~is Char"h"
+  dynamic("hello").get(0) ~is Char"h"
   dynamic("hello" ++ " ") ++ "world" ~is "hello world"
   dynamic("hello" ++ " ") ++ #"world" ~throws "cannot append a string and other value"
   dynamic("hello").append(" world") ~is "hello world"
@@ -222,15 +222,15 @@ block:
   check:
     for List (x: str):
       x
-    ~is ["a"[0], "b"[0], "c"[0]]
+    ~is [Char"a", Char"b", Char"c"]
   check:
     for List (x: String.to_sequence(str)):
       x
-    ~is ["a"[0], "b"[0], "c"[0]]
+    ~is [Char"a", Char"b", Char"c"]
   check:
     for List (x: str.to_sequence()):
       x
-    ~is ["a"[0], "b"[0], "c"[0]]
+    ~is [Char"a", Char"b", Char"c"]
 
 version_guard.at_least "8.13.0.1":
   check:
@@ -332,14 +332,14 @@ check:
 
 version_guard.at_least "8.14.0.7":
   check:
-    String.make("oops", "a"[0])
+    String.make("oops", Char"a")
     ~throws values(
       "String.make: contract violation",
       "expected: NonnegInt",
       "given: \"oops\"",
     )
   check:
-    String.make(-1, "a"[0])
+    String.make(-1, Char"a")
     ~throws values(
       "String.make: contract violation",
       "expected: NonnegInt",
@@ -360,7 +360,7 @@ version_guard.at_least "8.14.0.7":
       "given: \"a\"",
     )
   check:
-    String.make(5, 97)
+    String.make(5, Byte#"a")
     ~throws values(
       "String.make: contract violation",
       "expected: Char",
@@ -376,4 +376,4 @@ block:
   check "a"[0] compares_unequal "b"[0] ~is #true
   check "a"[0] >= "b"[0] ~is #false
   check "a"[0] > "b"[0] ~is #false
-  check Char.from_int("a"[0].to_int()) ~is "a"[0]
+  check Char.from_int("a"[0].to_int()) ~is Char"a"

--- a/rhombus/rhombus/tests/veneer.rhm
+++ b/rhombus/rhombus/tests/veneer.rhm
@@ -56,7 +56,7 @@ veneer InfiniteString(this :: ReadableString.to_string):
   converter
   implements Indexable
   override get(i):
-    if i >= this.length() | #{#\space} | this[i]
+    if i >= this.length() | Char" " | this[i]
   implements Appendable
   override append(other :: InfiniteString) :: InfiniteString:
     this
@@ -66,8 +66,8 @@ veneer InfiniteString(this :: ReadableString.to_string):
 check:
   InfiniteString("apple") ~is "apple"
   "apple" :: InfiniteString ~is "apple"
-  InfiniteString("apple")[1000] ~is #{#\space}
-  ("apple" :: InfiniteString)[1000] ~is #{#\space}
+  InfiniteString("apple")[1000] ~is Char" "
+  ("apple" :: InfiniteString)[1000] ~is Char" "
   InfiniteString("apple").m() ~is "m"
   InfiniteString.m("apple") ~is "m"
   ("apple" :: InfiniteString).m() ~is "m"


### PR DESCRIPTION
Mainly, this change aims to provide a "literal"(-like) form to produce or match a character.  Previously, characters can be produced in pure shrubbery notation by using string indexing, but bindings don't work that way.  Alternatively, characters can be produced or matched in S-expression notation, by using `#{}` escape.  This is not very ideal.

Instead, this change provides a `Char` expression/binding form that expects a single-character string.  There are several benefits of this approach:

- it's not too much longer than using string indexing (just one character longer);
- it's in pure shrubbery notation, without needing to extend the lexical syntax;
- it statically verifies that the string *does* have exactly one character (because Unicode is confusing!).

Accordingly, printing of characters now uses `Char`.

A `Byte` expression/binding form is also provided, just to parallel `Char`, but it can be handy when dealing with byte strings.

A large part of this commit also changes existing code to use the new forms where it makes sense.