### PR TITLE
add `->` and `Function.all_of` annotation forms

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annotation-converting.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation-converting.rkt
@@ -31,14 +31,15 @@
    (lambda (stx)
      (syntax-parse stx
        #:datum-literals (group)
-       [(form-id (_::parens
-                  (~or* (group _::fun-id
-                               (_::parens (~and bind-g (group _ ...)))
-                               op::annotate-op result-ann ...
-                               (tag::block body ...))
-                        (group _::fun-id
-                               (_::parens (~and bind-g (group _ ...)))
-                               (tag::block body ...))))
+       [(form-id (~and args
+                       (_::parens
+                        (~or* (group _::fun-id
+                                     (_::parens (~and bind-g (group _ ...)))
+                                     op::annotate-op result-ann ...
+                                     (tag::block body ...))
+                              (group _::fun-id
+                                     (_::parens (~and bind-g (group _ ...)))
+                                     (tag::block body ...)))))
                  . tail)
         (define bind-parsed (syntax-parse #'bind-g [bind::binding #'bind.parsed]))
         (define plain-body #'(rhombus-body-at tag body ...))
@@ -61,5 +62,7 @@
             [else
              (values plain-body #'())]))
         (values
-         (annotation-binding-form bind-parsed wrapped-body static-infos)
+         (relocate+reraw
+          (datum->syntax #f (list #'form-id #'args))
+          (annotation-binding-form bind-parsed wrapped-body static-infos))
          #'tail)]))))

--- a/rhombus-lib/rhombus/private/amalgam/array.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/array.rkt
@@ -25,7 +25,8 @@
          "class-primitive.rkt"
          "rhombus-primitive.rkt"
          "../version-case.rkt"
-         (submod "list.rkt" for-compound-repetition))
+         (submod "list.rkt" for-compound-repetition)
+         (only-in "name-root-ref.rkt" replace-head-dotted-name))
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -116,16 +117,18 @@
    `((default . stronger))
    'macro
    (lambda (stx)
-     (syntax-parse stx
-       [(_ (_::parens len-g) . tail)
+     (syntax-parse (replace-head-dotted-name stx)
+       [(form-id (~and args (_::parens len-g)) . tail)
         (values
-         (annotation-predicate-form
-          #'(let ([n (rhombus-expression len-g)])
-              (check-nonneg-int 'Array.of_length n)
-              (lambda (v)
-                (and (vector? v)
-                     (= (vector-length v) n))))
-          (get-array-static-infos))
+         (relocate+reraw
+          (datum->syntax #f (list #'form-id #'args))
+          (annotation-predicate-form
+           #'(let ([n (rhombus-expression len-g)])
+               (check-nonneg-int 'Array.of_length n)
+               (lambda (v)
+                 (and (vector? v)
+                      (= (vector-length v) n))))
+           (get-array-static-infos)))
          #'tail)]))))
 
 (define (check-nonneg-int who v)

--- a/rhombus-lib/rhombus/private/amalgam/arrow-annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/arrow-annotation.rkt
@@ -1,0 +1,1009 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     shrubbery/print
+                     enforest/name-parse
+                     shrubbery/property
+                     "annotation-string.rkt"
+                     "srcloc.rkt")
+         racket/unsafe/undefined
+         shrubbery/print
+         "treelist.rkt"
+         (only-in "annotation.rkt" ::)
+         (submod "annotation.rkt" for-class)
+         (submod "annotation.rkt" for-arrow)
+         "binding.rkt"
+         (submod "equal.rkt" for-parse)
+         "op-literal.rkt"
+         "call-result-key.rkt"
+         "function-arity-key.rkt"
+         "function-arity.rkt"
+         (submod "define-arity.rkt" for-info)
+         (only-in "values.rkt"
+                  [values rhombus:values])
+         "values-key.rkt"
+         "static-info.rkt"
+         "if-blocked.rkt"
+         "parens.rkt"
+         "realm.rkt"
+         "sorted-list-subset.rkt"
+         "parse.rkt")
+
+(provide (for-space rhombus/annot
+                    ->
+                    #%parens))
+
+(module+ for-arrow-annot
+  (provide (for-syntax parse-arrow-all-of)))
+
+(define-annotation-syntax #%parens
+  (annotation-prefix-operator
+   '((default . stronger))
+   'macro
+   (lambda (stxes)
+     (syntax-parse stxes
+       [(_ (~and head (_::parens . args)) . tail)
+        (let ([args (syntax->list #'args)])
+          (syntax-parse #'tail
+            [(arrow::name . _)
+             #:when (free-identifier=? (in-annotation-space #'arrow.name) (annot-quote ->))
+             (parens-arrow-annotation #'arrow.name args #'head #'tail)]
+            [_
+             (cond
+               [(null? args)
+                (raise-syntax-error #f "empty annotation" #'head)]
+               [(pair? (cdr args))
+                (raise-syntax-error #f "too many annotations" #'head)]
+               [else
+                (syntax-parse (car args)
+                  [c::annotation
+                   (values (relocate+reraw #'head #'c.parsed) #'tail)])])]))]))))
+
+(define-annotation-syntax ->
+  (annotation-infix-operator
+   (lambda () `((default . stronger)))
+   'macro
+   (lambda (lhs stx)
+     (arrow-annotation (list (list #f #f #f lhs)) #f #f #f #f lhs stx))
+   'right))
+
+(begin-for-syntax
+  (define-syntax-class ::-bind
+    #:attributes ()
+    #:description "`::` operator"
+    #:opaque
+    (pattern ::name
+             #:when (free-identifier=? (in-binding-space #'name)
+                                       (bind-quote ::)))))
+
+(define-for-syntax (parens-arrow-annotation arrow-name args head tail)
+  (define-values (multi-kw+name+opt+lhs rest-name+ann rest-ann-whole? kw-rest-name+ann kw-rest-first?)
+    (syntax-parse args
+      #:datum-literals (group)
+      [((group #:any))
+       (values null '#:any #f '#:any #f)]
+      [else
+       (parse-annotation-sequence arrow-name args #f)]))
+  (arrow-annotation multi-kw+name+opt+lhs
+                    rest-name+ann rest-ann-whole?
+                    kw-rest-name+ann kw-rest-first?
+                    head tail))
+
+(define-for-syntax (parse-annotation-sequence arrow-name args as-result?)
+  (define-values (non-rest-args rest-name+ann rest-ann-whole? kw-rest-name+ann kw-rest-first?)
+    (extract-rest-args arrow-name args as-result?))
+  (define (check-keyword kw)
+    (when as-result?
+      (raise-syntax-error #f "keywords are not allowed on result annotations"
+                          arrow-name
+                          kw)))
+  (define (check-optional eql)
+    (when as-result?
+      (raise-syntax-error #f "optional results are not allowed"
+                          arrow-name
+                          eql)))
+  (define multi-kw+name+opt+lhs
+    (let loop ([args non-rest-args] [has-opt? #f])
+      (cond
+        [(null? args) null]
+        [else
+         (define arg (car args))
+         (define (non-opt)
+           (when has-opt?
+             (raise-syntax-error #f "non-optional argument follows an optional by-position argument"
+                                 arrow-name
+                                 arg)))
+         (define-values (a opt?)
+           (syntax-parse arg
+             #:datum-literals (group op)
+             [(group (~and kw #:any))
+              (raise-syntax-error #f (string-append "`~any` allowed only by itself as "
+                                                    (if as-result?
+                                                        "a result"
+                                                        "an argument"))
+                                  arrow-name
+                                  #'kw)]
+             [(group kw:keyword (_::block (group name:identifier _:::-bind c ... _::equal _::_-bind)))
+              (check-keyword #'kw)
+              (values (list #'kw #'name #t (syntax-parse #'(group c ...)
+                                             [c::annotation #'c.parsed]))
+                      #f)]
+             [(group kw:keyword (_::block (group c ... _::equal _::_-bind)))
+              (check-keyword #'kw)
+              (values (list #'kw #f #t (syntax-parse #'(group c ...)
+                                         [c::annotation #'c.parsed]))
+                      #f)]
+             [(group kw:keyword (_::block (group name:identifier _:::-bind c ...)))
+              (check-keyword #'kw)
+              (values (list #'kw #'name #f (syntax-parse #'(group c ...)
+                                             [c::annotation #'c.parsed]))
+                      #f)]
+             [(group kw:keyword (_::block c::annotation))
+              (check-keyword #'kw)
+              (values (list #'kw #f #f #'c.parsed)
+                      #f)]
+             [(group name:identifier _:::-bind c ... eql::equal _::_-bind)
+              (check-optional #'eql)
+              (values (list #f #'name #t (syntax-parse #'(group c ...)
+                                           [c::annotation #'c.parsed]))
+                      #t)]
+             [(group c ... eql::equal _::_-bind)
+              (check-optional #'eql)
+              (values (list #f #f #t (syntax-parse #'(group c ...)
+                                       [c::annotation #'c.parsed]))
+                      #t)]
+             [(group name:identifier _:::-bind c ...)
+              (non-opt)
+              (values (list #f #'name #f (syntax-parse #'(group c ...)
+                                           [c::annotation #'c.parsed]))
+                      #f)]
+             [c::annotation
+              (non-opt)
+              (values (list #f #f #f #'c.parsed)
+                      #f)]))
+         (cons a (loop (cdr args) (or has-opt? opt?)))])))
+  (if as-result?
+      (values (map (lambda (l) (list (cadr l) (cadddr l))) multi-kw+name+opt+lhs) rest-name+ann rest-ann-whole?)
+      (values multi-kw+name+opt+lhs rest-name+ann rest-ann-whole? kw-rest-name+ann kw-rest-first?)))
+
+(define-for-syntax (extract-rest-args arrow-name args as-result?)
+  (define (no-second)
+    (if as-result?
+        "second rest result not allowed"
+        "second rest argument not allowed"))
+  (let loop ([args args] [non-rest-accum '()] [rest-name+ann #f] [rest-ann-whole? #f]
+                         [kw-rest-name+ann #f] [kw-rest-first? #f])
+    (define (parse-ann c)
+      (syntax-parse #`(group . #,c)
+        #:datum-literals (group)
+        [(group name:identifier _:::-bind . c)
+         (syntax-parse #'(group . c)
+           [c::annotation (list #'name #'c.parsed)])]
+        [c::annotation (list #f #'c.parsed)]))
+    (syntax-parse args
+      #:datum-literals (group)
+      [() (values (reverse non-rest-accum) rest-name+ann rest-ann-whole? kw-rest-name+ann kw-rest-first?)]
+      [((group dots::...-bind) . _)
+       (raise-syntax-error #f "misplaced ellipsis" arrow-name #'dots)]
+      [(g (group dots::...-bind) . args)
+       (when rest-name+ann
+         (raise-syntax-error #f (no-second) arrow-name #'dots))
+       (syntax-parse #'g
+         #:datum-literals (group)
+         [(group name:identifier _:::-bind . c)
+          (raise-syntax-error #f "name not allowed for repeated rest" arrow-name #'name)]
+         [c::annotation
+          (loop #'args non-rest-accum (list #f #'c.parsed) #f kw-rest-name+ann kw-rest-first?)])]
+      [((group amp::&-bind . c) . args)
+       (when rest-name+ann
+         (raise-syntax-error #f (no-second) arrow-name #'amp))
+       (define name+ann (parse-ann #'c))
+       (loop #'args non-rest-accum name+ann #t kw-rest-name+ann kw-rest-first?)]
+      [((group amp::~&-bind . c) . args)
+       (when as-result?
+         (raise-syntax-error #f "keyword-rest result not allowed" arrow-name #'amp))
+       (when kw-rest-name+ann
+         (raise-syntax-error #f "second keyword-rest argument not allowed" arrow-name #'amp))
+       (define name+ann (parse-ann #'c))
+       (loop #'args non-rest-accum rest-name+ann rest-ann-whole? name+ann (not rest-name+ann))]
+      [(g . args)
+       (when (or rest-name+ann kw-rest-name+ann)
+         (raise-syntax-error #f "non-rest argument not allowed after rest argument" arrow-name #'g))
+       (loop #'args (cons #'g non-rest-accum) rest-name+ann rest-ann-whole? kw-rest-name+ann kw-rest-first?)])))
+
+(define-for-syntax (arrow-annotation multi-kw+name+opt+lhs
+                                     rest-name+ann rest-ann-whole?
+                                     kw-rest-name+ann kw-rest-first?
+                                     head stx)
+  (define arrow (syntax-parse stx [(a . _) #'a]))
+  (define-values (multi-name+rhs res-rest-name+ann res-rest-ann-whole? loc tail)
+    (let ([multi (lambda (args p-res tail)
+                   (define-values (multi-name+rhs res-rest-name+ann res-rest-ann-whole?)
+                     (parse-annotation-sequence head args #t))
+                   (values multi-name+rhs
+                           res-rest-name+ann res-rest-ann-whole?
+                           (datum->syntax #f (list head arrow p-res))
+                           tail))])
+      (define (any-result tail) (values null '#:any #t #f tail))
+      (syntax-parse stx
+        #:datum-literals (group)
+        [(_ #:any . tail) (any-result #'tail)]
+        [(_ (_::parens (group #:any)) . tail) (any-result #'tail)]
+        [(_ vals (~and p-res (_::parens res ...)) . tail)
+         #:when (free-identifier=? (in-annotation-space #'vals) (annot-quote rhombus:values))
+         (multi (syntax->list #'(res ...)) #'p-res #'tail)]
+        [(_ (~and p-res (_::parens res ...)) . tail)
+         (multi (syntax->list #'(res ...)) #'p-res #'tail)]
+        [(_ . tail)
+         #:with (~var res (:annotation-infix-op+form+tail arrow)) #`(group . tail)
+         (values (list (list #f #'res.parsed))
+                 #f #f
+                 (datum->syntax #f (list head arrow #'res.parsed))
+                 #'res.tail)])))
+  (define multi-kws (map car multi-kw+name+opt+lhs))
+  (define multi-names (map cadr multi-kw+name+opt+lhs))
+  (define multi-opts (map caddr multi-kw+name+opt+lhs))
+  (define multi-lhs (map cadddr multi-kw+name+opt+lhs))
+  (define multi-rhs (map cadr multi-name+rhs))
+  (define arity (if (eq? rest-name+ann '#:any)
+                    #false
+                    (summarize-arity (datum->syntax #f multi-kws) (datum->syntax #f multi-opts)
+                                     (and rest-name+ann #t) (and kw-rest-name+ann #t))))
+  (syntax-parse (list multi-lhs multi-name+rhs)
+    [((l::annotation-binding-form ...) ((rhs-name r::annotation-binding-form) ...))
+     #:with (lhs-i::binding-form ...) #'(l.binding ...)
+     #:with (lhs-impl::binding-impl ...) #'((lhs-i.infoer-id () lhs-i.data) ...)
+     #:with (lhs::binding-info ...) #'(lhs-impl.info ...)
+     #:with (arg-id ...) (for/list ([name-id (in-list (syntax->list #'(lhs.name-id ...)))])
+                           ((make-syntax-introducer) (datum->syntax #f (syntax-e name-id))))
+     #:with (lhs-str ...) (map shrubbery-syntax->string multi-lhs)
+     #:with (rhs-str ...) (map shrubbery-syntax->string multi-rhs)
+     #:with (lhs-kw ...) multi-kws
+     #:with (lhs-name ...) multi-names
+     #:with (lhs-opt ...) multi-opts
+     #:with who 'function
+     (define static-infos
+       #`(#,@(if (eq? rest-name+ann '#:any)
+                 null
+                 #`((#%function-arity #,arity)))
+          #,@(if res-rest-name+ann
+                 null
+                 #`((#%call-result #,(let ([sis #'(r.static-infos ...)])
+                                       (define sis-l (syntax->list sis))
+                                       (if (= 1 (length sis-l))
+                                           (car sis-l)
+                                           #`((#%values #,sis)))))))
+          #,@(indirect-get-function-static-infos)))
+     (values
+      (relocate+reraw
+       loc
+       (annotation-binding-form
+        (binding-form
+         #'arrow-infoer
+         #`[who #,arity
+                'who
+                ([lhs l.body l.static-infos lhs-str lhs-kw lhs-name lhs-opt] ...)
+                #,(and rest-name+ann
+                       (syntax-parse rest-name+ann
+                         [#:any rest-name+ann]
+                         [(name a::annotation-binding-form)
+                          #`(name a.binding a.body a.static-infos #,rest-ann-whole? #,(shrubbery-syntax->string #'a))]
+                         [_ #f]))
+                #,(and kw-rest-name+ann
+                       (syntax-parse kw-rest-name+ann
+                         [#:any kw-rest-name+ann]
+                         [(name a::annotation-binding-form)
+                          #`(name a.binding a.body a.static-infos #,(shrubbery-syntax->string #'a))]
+                         [_ #f]))
+                #,kw-rest-first?
+                ([r.binding r.body r.static-infos rhs-name rhs-str] ...)
+                #,(and res-rest-name+ann
+                       (syntax-parse res-rest-name+ann
+                         [#:any res-rest-name+ann]
+                         [(name a::annotation-binding-form)
+                          #`(name a.binding a.body a.static-infos #,res-rest-ann-whole? #,(shrubbery-syntax->string #'a))]))
+                #,static-infos])
+        (if (and (andmap not multi-kws)
+                 (andmap not multi-opts)
+                 (not rest-name+ann)
+                 (not kw-rest-name+ann))
+            ;; simple case, indirection through `lambda` to get name from context
+            #'(lambda (arg-id ...) (who arg-id ...))
+            ;; complex case:
+            #'who)
+        static-infos))
+      tail)]))
+
+(define-for-syntax (parse-arrow-all-of stx)
+  (syntax-parse stx
+    [(form-id (~and args (p-tag::parens in-g ...)) . tail)
+     #:with (who-expr (g ...)) (extract-name stx #'(in-g ...))
+     #:with (a::annotation ...) #'(g ...)
+     (define loc (datum->syntax #f (list #'form-id
+                                         ;; drop `~name` from reported annotation form
+                                         (cons #'p-tag (syntax->list #'(g ...))))))
+     (for ([a (in-list (syntax->list #'(a.parsed ...)))]
+           [g (in-list (syntax->list #'(g ...)))])
+       (unless (syntax-parse a
+                 [a::annotation-binding-form
+                  #:with b::binding-form #'a.binding
+                  (free-identifier=? #'b.infoer-id #'arrow-infoer)]
+                 [_ #f])
+         (raise-syntax-error #f "not a function annotation" loc g)))
+     (cond
+       [(= 1 (length (syntax->list #'(a.parsed ...))))
+        (define a1 (car (syntax-e #'(a.parsed ...))))
+        (values
+         (cond
+           [(syntax-e #'who-expr)
+            (syntax-parse a1
+              [a::annotation-binding-form
+               #:with ab::binding-form #'a.binding
+               (syntax-parse #'ab.data
+                 [[id arity orig-who-expr . rest]
+                  (relocate+reraw
+                   a1
+                   (annotation-binding-form
+                    (binding-form #'ab.infoer-id
+                                  #`[id arity who-expr . rest])
+                    #'a.body
+                    #'a.static-infos))])])]
+           [else a1])
+         #'tail)]
+       [else
+        (syntax-parse #'(a.parsed ...)
+          [(a::annotation-binding-form ...)
+           #:with (ab::binding-form ...) #'(a.binding ...)
+           #:with ([_ arity . _] ...) #'(ab.data ...)
+           #:with who 'function
+           (define all-arity (union-arity-summaries (syntax->datum #'(arity ...))))
+           (define static-infos
+             #`(#,@(if all-arity
+                       #`((#%function-arity #,all-arity))
+                       null)
+                (#%call-result (#:at_arities
+                                #,(for/list ([sis (syntax->list #'(a.static-infos ...))]
+                                             [arity (syntax->list #'(arity ...))])
+                                    #:break (not (syntax-e arity))
+                                    #`[#,arity
+                                       #,(static-info-lookup sis #'#%call-result)])))
+                #,@(indirect-get-function-static-infos)))
+           (values
+            (relocate+reraw
+             loc
+             (annotation-binding-form
+              (binding-form #'all-of-infoer
+                            #`(who #,all-arity who-expr ([ab.infoer-id ab.data] ...) #,static-infos))
+              #'who
+              static-infos))
+            #'tail)])])]))
+
+(define-syntax (arrow-infoer stx)
+  (syntax-parse stx
+    [(_ in-static-infos (result-id arity who-expr lhss rest kw-rest kw-rest-first? rhs res-rest static-infos))
+     (binding-info "function"
+                   #'function
+                   #'static-infos
+                   #'((result (0) . static-infos))
+                   #'arrow-matcher
+                   #'arrow-committer
+                   #'arrow-binder
+                   #'(result-id arity who-expr lhss rest kw-rest kw-rest-first? rhs res-rest))]))
+
+(define-syntax (arrow-matcher stx)
+  (syntax-parse stx
+    [(_ arg-id (result-id arity _ lhss _ _ _ _ _) IF success fail)
+     #`(IF (and (procedure? arg-id)
+                #,(let ([a (syntax-e #'arity)])
+                    (cond
+                      [(not a) #'#t]
+                      [(and (integer? a)
+                            (positive? a)
+                            (zero? (bitwise-and a (sub1 a))))
+                       #`(procedure-arity-includes? arg-id #,(sub1 (integer-length a)))]
+                      [else
+                       #`(function-arity-match? arg-id 'arity)])))
+           success
+           fail)]))
+
+(define-syntax (arrow-committer stx)
+  (syntax-parse stx
+    [(_ arg-id data)
+     #'(begin)]))
+
+(define-syntax (arrow-binder stx)
+  (syntax-parse stx
+    [(_ arg-id data)
+     (do-arrow-binder #'arg-id #'data #'#%app #f)]))
+
+(define-for-syntax (do-arrow-binder arg-id data fail-k who-stx)
+  (syntax-parse data
+    [(result-id arity who-expr
+                ([lhs::binding-info lhs-body lhs-static-infos lhs-str lhs-kw lhs-name lhs-opt] ...)
+                rest
+                kw-rest
+                kw-rest-first?
+                ([rhs-i::binding-form rhs-body rhs-static-infos rhs-name rhs-str] ...)
+                res-rest)
+     #:with (rhs-impl::binding-impl ...) #`((rhs-i.infoer-id () rhs-i.data) ...)
+     #:with (rhs::binding-info ...) #'(rhs-impl.info ...)
+     #:with (((lhs-bind-id lhs-bind-use . lhs-bind-static-infos) ...) ...) #'(lhs.bind-infos ...)
+     #:with (((rhs-bind-id rhs-bind-use . rhs-bind-static-infos) ...) ...) #'(rhs.bind-infos ...)
+     #:with (lhs-arg-id ...) (for/list ([name-id (in-list (syntax->list #'(lhs.name-id ...)))])
+                               ((make-syntax-introducer) (datum->syntax #f (syntax-e name-id))))
+     #:with (left-id ...) (for/list ([name (in-list (syntax->list #'(lhs-name ...)))]
+                                     [default-id (in-list (generate-temporaries #'(lhs-arg-id ...)))])
+                            (if (syntax-e name)
+                                name
+                                default-id))
+     #:with (res-in-id ...)  (for/list ([name-id (in-list (syntax->list #'(rhs.name-id ...)))])
+                               ((make-syntax-introducer) (datum->syntax #f (syntax-e name-id))))
+     #:with (res-id ...)  (for/list ([name (in-list (syntax->list #'(rhs-name ...)))]
+                                     [default-id (in-list (generate-temporaries #'(res-in-id ...)))])
+                            (if (syntax-e name)
+                                name
+                                default-id))
+     #:with (check-not-undefined ...) (for/list ([opt (in-list (syntax->list #'(lhs-opt ...)))])
+                                        (if (syntax-e #'p)
+                                            #'(lambda (v) (not (eq? v unsafe-undefined)))
+                                            #'(lambda (v) #t)))
+     #:with fail-k fail-k
+     (with-syntax ([((lhs-arg ...) ...)
+                    (for/list ([arg-id (in-list (syntax->list #'(lhs-arg-id ...)))]
+                               [kw (in-list (syntax->list #'(lhs-kw ...)))]
+                               [opt (in-list (syntax->list #'(lhs-opt ...)))]
+                               ;; If there's a keyword-rest arg, we'll have to
+                               ;; extract arguments manually
+                               #:unless (and (syntax-e #'kw-rest) (syntax-e kw)))
+                      (define var (if (not (syntax-e opt))
+                                      arg-id
+                                      (list arg-id #'unsafe-undefined)))
+                      (if (syntax-e kw)
+                          (list kw var)
+                          (list var)))]
+                   [((left-kw+id ...) ...)
+                    (for/list ([left-id (in-list (syntax->list #'(left-id ...)))]
+                               [kw (in-list (syntax->list #'(lhs-kw ...)))])
+                      (if (syntax-e kw)
+                          (list kw left-id)
+                          (list left-id)))])
+       (define (generate-rest rest kw-rest success-k fail-k raise-rest-argument-annotation-failure check-always?)
+         (define (add-normal-cwv l)
+           (if check-always? (cons #'call-with-values l) l))
+         (with-syntax ([success-k success-k]
+                       [fail-k fail-k]
+                       [raise-rest-argument-annotation-failure raise-rest-argument-annotation-failure])
+           (define (any-result) (list #'call-with-unchanged-values #'#%app '() '() '()))
+           (syntax-parse rest
+             [#f (add-normal-cwv (list #'#%app '() (if (syntax-e kw-rest) '(null) '()) '()))]
+             [#:any (if check-always?
+                        (any-result)
+                        (list #'apply #'rest-arg-id #'(rest-id) #'([(rest-id) () (success-k rest-arg-id)])))]
+             [(name a-i::binding-form a-body a-static-infos whole? a-str)
+              #:with a-impl::binding-impl #`(a-i.infoer-id () a-i.data)
+              #:with a::binding-info #'a-impl.info
+              #:with ((a-bind-id a-bind-use . a-bind-static-infos) ...) #'a.bind-infos
+              #:with rest-list-id (or (and (syntax-e #'name) #'name) #'rest-list)
+              (cond
+                [(and check-always?
+                      (free-identifier=? #'a.matcher-id #'always-succeed)
+                      (null? (syntax-e #'(res-id ...))))
+                 ;; no argument checking or constraint on number of result => tail-call original
+                 (any-result)]
+                [else
+                 (define a-block
+                   #'(let ()
+                       (a.matcher-id rest-arg-id a.data
+                                     if/blocked
+                                     (let ()
+                                       (a.committer-id rest-arg-id a.data)
+                                       (a.binder-id rest-arg-id a.data)
+                                       (define-static-info-syntax/maybe a-bind-id . a-bind-static-infos)
+                                       ...
+                                       (success-k
+                                        a-body))
+                                     (fail-k
+                                      (lambda ()
+                                        (raise-rest-argument-annotation-failure (who) rest-arg-id 'a-str whole?))))))
+                 (add-normal-cwv
+                  (list #'apply #'rest-arg-id #'(rest-id)
+                        (if (syntax-e #'whole?)
+                            #`([(rest-list-id)
+                                a-static-infos
+                                (let ([rest-arg-id (list->treelist rest-arg-id)])
+                                  #,a-block)]
+                               [(rest-id) () (success-k (rest-treelist->list rest-list-id))])
+                            #`([(rest-id)
+                                ()
+                                (let loop ([args rest-arg-id] [accum '()])
+                                  (if (null? args)
+                                      (success-k (reverse accum))
+                                      (let ([success-k
+                                             (lambda (v)
+                                               (loop (cdr args) (cons v accum)))]
+                                            [rest-arg-id (car args)])
+                                        #,a-block)))]))))])])))
+       (with-syntax ([(f-apply rest-arg-id rest-id (rest-bind ...))
+                      (generate-rest #'rest #'kw-rest #'success-k #'fail-k #'raise-rest-argument-annotation-failure #f)])
+         (with-syntax ([((maybe-make-keyword-procedure ...) (kw-arg-id ...) (kw-id ...) f/kw-apply (kw-preamble ...) (kw-rest-bind ...))
+                        (syntax-parse #'kw-rest
+                          [#f (list #'(begin) '() '() #'f-apply '() '())]
+                          [#:any (list #'(make-keyword-procedure/reduce-arity-like f)
+                                       #'(kws-arg-id kw-vals-arg-id) #'(kws-id kw-vals-id) #'keyword-apply
+                                       #'()
+                                       #'([(kws-id kw-vals-id) () (success-k kws-arg-id kw-vals-arg-id)]))]
+                          [(name a-i::binding-form a-body a-static-infos a-str)
+                           #:with a-impl::binding-impl #`(a-i.infoer-id () a-i.data)
+                           #:with a::binding-info #'a-impl.info
+                           #:with ((a-bind-id a-bind-use . a-bind-static-infos) ...) #'a.bind-infos
+                           #:with kw-rest-map-id (or (and (syntax-e #'name) #'name) #'kw-rest-map)
+                           (define kws (for/list ([kw (in-list (syntax->list #'(lhs-kw ...)))]
+                                                  #:when (syntax-e kw))
+                                         kw))
+                           (define req-kws (for/list ([kw (in-list (syntax->list #'(lhs-kw ...)))]
+                                                      [opt (in-list (syntax->list #'(lhs-opt ...)))]
+                                                      #:when (and (syntax-e kw)
+                                                                  (not (syntax-e opt))))
+                                             kw))
+                           (define arity-mask (car (syntax-e #'arity)))
+                           (list #`(make-keyword-procedure/reduce-arity #,req-kws #,arity-mask)
+                                 #'(kws-arg-id kw-vals-arg-id) #'(kws-id kw-vals-id) #'keyword-apply
+                                 (if (null? kws)
+                                     (list #'(define kw-map (keywords->map kws-arg-id kw-vals-arg-id)))
+                                     (append
+                                      (list #'(define kw-map/all (keywords->map kws-arg-id kw-vals-arg-id)))
+                                      (for/list ([arg-id (in-list (syntax->list #'(lhs-arg-id ...)))]
+                                                 [kw (in-list (syntax->list #'(lhs-kw ...)))]
+                                                 [opt (in-list (syntax->list #'(lhs-opt ...)))]
+                                                 ;; If there's a keyword-rest arg, we'll have to
+                                                 ;; extract arguments manually
+                                                 #:when (syntax-e kw))
+                                        #`(define #,arg-id (hash-ref kw-map/all '#,kw unsafe-undefined)))
+                                      (list #`(define kw-map (drop-keywords kw-map/all '#,kws)))))
+                                 #'([(kw-rest-map-id)
+                                     a-static-infos
+                                     (let ()
+                                       (a.matcher-id kw-map a.data
+                                                     if/blocked
+                                                     (let ()
+                                                       (a.committer-id kw-map a.data)
+                                                       (a.binder-id kw-map a.data)
+                                                       (define-static-info-syntax/maybe a-bind-id . a-bind-static-infos)
+                                                       ...
+                                                       (success-k
+                                                        a-body))
+                                                     (fail-k
+                                                      (lambda ()
+                                                        (raise-keyword-rest-argument-annotation-failure (who) kw-map 'a-str)))))]
+                                    [(kws-id kw-vals-id)
+                                     ()
+                                     (call-with-values (lambda () (rest-map->keywords kw-rest-map-id))
+                                                       (lambda (kws vals) (success-k kws vals)))]))])])
+           (with-syntax ([(rest-bind ...) (if (syntax-e #'kw-rest-first?)
+                                              #'(kw-rest-bind ... rest-bind ...)
+                                              #'(rest-bind ... kw-rest-bind ...))]
+                         [(call-with-values/rest r-apply res-rest-arg-id res-rest-id (res-rest-bind ...))
+                          (generate-rest #'res-rest #'#f #'values #'#%app #'raise-rest-result-annotation-failure #t)])
+             (define inner-proc
+               (no-srcloc
+                #`(lambda (kw-arg-id ... lhs-arg ... ... . rest-arg-id)
+                    (let ([who (lambda () #,(or who-stx
+                                                #'who-expr))])
+                      kw-preamble ...
+                      (let*-values-with-static-infos/k
+                       success-k
+                       ([(left-id)
+                         lhs-static-infos
+                         (cond
+                           [(check-not-undefined lhs-arg-id)
+                            (lhs.matcher-id lhs-arg-id lhs.data
+                                            if/blocked
+                                            (let ()
+                                              (lhs.committer-id lhs-arg-id lhs.data)
+                                              (lhs.binder-id lhs-arg-id lhs.data)
+                                              (define-static-info-syntax/maybe lhs-bind-id . lhs-bind-static-infos)
+                                              ...
+                                              (let ([left-id lhs-body])
+                                                (success-k left-id)))
+                                            (fail-k
+                                             (lambda ()
+                                               (raise-argument-annotation-failure (who) lhs-arg-id 'lhs-str))))]
+                           [else (success-k lhs-arg-id)])]
+                        ...
+                        rest-bind ...)
+                       (call-with-values/rest
+                        (lambda ()
+                          ;; At first by-position argument that's `undefined`, stop passing by-position arguments
+                          (cond
+                            #,@(let loop ([args (syntax->list #'((left-kw+id ...) ...))]
+                                          [kws (syntax->list #'(lhs-kw ...))]
+                                          [opts (syntax->list #'(lhs-opt ...))]
+                                          [accum '()])
+                                 (cond
+                                   [(null? args) '()]
+                                   [(or (not (syntax-e (car opts)))
+                                        (syntax-e (car kws)))
+                                    (loop (cdr args) (cdr kws) (cdr opts)
+                                          (cons (car args) accum))]
+                                   [else
+                                    (cons
+                                     #`[(eq? #,(car (syntax-e (car args))) unsafe-undefined)
+                                        #,(with-syntax ([((left-kw+id ...) ...)
+                                                         (append (reverse accum)
+                                                                 (for/list ([arg (in-list (cdr args))]
+                                                                            [kw (in-list (cdr kws))]
+                                                                            #:when (syntax-e kw))
+                                                                   arg))])
+                                            #`(f/kw-apply f kw-id ... left-kw+id ... ... . rest-id))]
+                                     (loop (cdr args) (cdr kws) (cdr opts) (cons (car args) accum)))]))
+                            [else
+                             (f/kw-apply f kw-id ... left-kw+id ... ... . rest-id)]))
+                        (case-lambda
+                          [(res-in-id ... . res-rest-arg-id)
+                           (let*-values-with-static-infos
+                            ([(res-id)
+                              rhs-static-infos
+                              (let ()
+                                (rhs.matcher-id res-in-id rhs.data
+                                                if/flattened
+                                                (void)
+                                                (raise-result-annotation-failure (who) res-in-id 'rhs-str))
+                                (rhs.committer-id result rhs.data)
+                                (rhs.binder-id res-in-id rhs.data)
+                                (define-static-info-syntax/maybe rhs-bind-id . rhs-bind-static-infos)
+                                ...
+                                rhs-body)]
+                             ...
+                             res-rest-bind ...)
+                            (r-apply values res-id ... . res-rest-id))]
+                          [args
+                           (raise-result-arity-error (who) '#,(length (syntax->list #'(res-in-id ...))) args)])))))))
+             (if (not arg-id)
+                 inner-proc
+                 #`(define result-id
+                     (let ([f #,arg-id])
+                       (maybe-make-keyword-procedure
+                        ...
+                        #,inner-proc))))))))]))
+
+(define-syntax (all-of-infoer stx)
+  (syntax-parse stx
+    [(_ in-static-infos (result-id all-arity who-expr cases static-infos))
+     (binding-info "function"
+                   #'function
+                   #'static-infos
+                   #'((result (0) . static-infos))
+                   #'all-of-matcher
+                   #'all-of-committer
+                   #'all-of-binder
+                   #'(result-id all-arity who-expr cases))]))
+
+(define-syntax (all-of-matcher stx)
+  (syntax-parse stx
+    [(_ arg-id (result-id all-arity who-expr ([a-infoer (~and a-data (_ arity . _))] ...)) IF success fail)
+     #`(IF (and (procedure? arg-id)
+                #,@(for/list ([arity (in-list (syntax->list #'(arity ...)))]
+                              [a-infoer (in-list (syntax->list #'(a-infoer ...)))]
+                              [a-data (in-list (syntax->list #'(a-data ...)))])
+                     (let ([a (syntax-e arity)])
+                       (cond
+                         [(not a) #'#t]
+                         [(and (integer? a)
+                               (positive? a)
+                               (zero? (bitwise-and a (sub1 a))))
+                          #`(procedure-arity-includes? arg-id #,(sub1 (integer-length a)))]
+                         [else
+                          #`(function-arity-match? arg-id '#,arity)]))))
+           success
+           fail)]))
+
+(define-syntax (all-of-committer stx)
+  (syntax-parse stx
+    [(_ arg-id data)
+     #'(begin)]))
+
+(define-syntax (all-of-binder stx)
+  (syntax-parse stx
+    [(_ arg-id (result-id all-arity who-expr ([a-infoer (~and a-data (_ arity . _))] ...)))
+     (define arities (syntax->list #'(arity ...)))
+     (define no-keywords? (andmap (lambda (a) (integer? (syntax-e a))) arities))
+     (cond
+       [(and no-keywords?
+             (andmap (lambda (a)
+                       (let* ([a (abs (syntax-e a))])
+                         (zero? (bitwise-and a (sub1 a)))))
+                     arities)
+             (for/fold ([covered 0]) ([a (in-list arities)])
+               (and covered
+                    (syntax-e a)
+                    (zero? (bitwise-and covered (syntax-e a)))
+                    (bitwise-ior covered (syntax-e a)))))
+        ;; No keywords, no optional arguments other than rests, and
+        ;; independent arities; generate a `case-lambda` for the dispatch
+        #`(define result-id
+            (let ([f arg-id]
+                  [who (lambda () #,(if (syntax-e #'who-expr)
+                                        #'who-expr
+                                        #'(quote result-id)))])
+              (case-lambda
+                #,@(for/list ([arity (in-list arities)]
+                              [infoer (in-list (syntax->list #'(a-infoer ...)))]
+                              [data (in-list (syntax->list #'(a-data ...)))])
+                     (syntax-parse #`(#,infoer () #,data)
+                       [a-impl::binding-impl
+                        #:with a::binding-info #'a-impl.info
+                        #:with ((a-bind-id a-bind-use . a-bind-static-infos) ...) #'a.bind-infos
+                        ;; Since we started with `->` annotations, we know that we can
+                        ;; skip the matcher and committer
+                        (define mask (syntax-e arity))
+                        (define args (let loop ([a mask] [n 0])
+                                       (cond
+                                         [(= a 1) '()]
+                                         [(= a -1) 'rest-args]
+                                         [else (cons (string->symbol (format "arg~a" n))
+                                                     (loop (arithmetic-shift a -1)
+                                                           (add1 n)))])))
+                        (if (mask . < . 0)
+                            #`[#,args (apply #,(do-arrow-binder #f #'a.data #'#%app #'(who))
+                                             #,@(let loop ([args args])
+                                                  (if (pair? args)
+                                                      (cons (car args) (loop (cdr args)))
+                                                      (list args))))]
+                            #`[#,args (#,(do-arrow-binder #f #'a.data #'#%app #'(who))
+                                       #,@args)])])))))]
+       [else
+        ;; Some keywords, optional arguments, or overlapping arities that
+        ;; might be decided by argument annotations
+        (define body
+          #`(let ([who (lambda () #,(if (syntax-e #'who-expr)
+                                        #'who-expr
+                                        #'(quote result-id)))])
+              (let ([len (length args)])
+                #,(let loop ([arities arities]
+                             [infoers (syntax->list #'(a-infoer ...))]
+                             [datas (syntax->list #'(a-data ...))])
+                  (cond
+                    [(null? arities)
+                     #'(error (who) "no matching case for arguments")]
+                    [else
+                     (define arity (car arities))
+                     (define infoer (car infoers))
+                     (define data (car datas))
+                     (syntax-parse #`(#,infoer () #,data)
+                       [a-impl::binding-impl
+                        #:with a::binding-info #'a-impl.info
+                        #:with ((a-bind-id a-bind-use . a-bind-static-infos) ...) #'a.bind-infos
+                        ;; Since we started with `->` annotations, we know that we can
+                        ;; skip the matcher and committer
+                        (define-values (mask required-kws allowed-kws)
+                          (syntax-parse arity
+                            [(mask required allowed) (values (syntax-e #'mask)
+                                                             (syntax->datum #'required)
+                                                             (syntax->datum #'allowed))]
+                            [_ (values (syntax-e arity) null null)]))
+                        (define has-kw-rest? (or (not mask)
+                                                 (not allowed-kws)))
+                        #`(let ([next (lambda ()
+                                        #,(loop (cdr arities)
+                                                (cdr infoers)
+                                                (cdr datas)))])
+                            (if (and #,(if mask
+                                           #`(bitwise-bit-set? #,mask len)
+                                           #'#t)
+                                     #,(if (null? required-kws)
+                                           #'#t
+                                           #`(sorted-list-subset? '#,required-kws kws))
+                                     #,(if (or no-keywords?
+                                               (eq? allowed-kws #f))
+                                           #'#t
+                                           #`(sorted-list-subset? kws '#,allowed-kws)))
+                                (let ([esc-next (lambda (err) (next))])
+                                  #,(let ([proc (do-arrow-binder #f #'a.data #'esc-next #'(who))])
+                                      (cond
+                                        [no-keywords?
+                                         #`(apply #,proc args)]
+                                        [has-kw-rest?
+                                         ;; `do-arrow-binder` skips the `make-keyword-proc` wrapper
+                                         #`(apply #,proc kws kw-args args)]
+                                        [else
+                                         #`(keyword-apply #,proc kws kw-args args)])))
+                                (next)))])])))))
+        (if no-keywords?
+            #`(define result-id
+                (let ([f arg-id])
+                  (procedure-reduce-arity-mask
+                   (lambda args #,body)
+                   'all-arity)))
+            (syntax-parse #'all-arity
+              [#false
+               #`(define result-id
+                   (let ([f arg-id])
+                     (procedure-reduce-arity-like
+                      f
+                      (make-keyword-procedure (lambda (kws kw-args . args) #,body)))))]
+              [(mask req allow)
+               #`(define result-id
+                   (let ([f arg-id])
+                     (procedure-reduce-keyword-arity-mask
+                      (make-keyword-procedure (lambda (kws kw-args . args) #,body))
+                      'mask
+                      'req
+                      'allow)))]))])]))
+
+(define-syntax (let*-values-with-static-infos stx)
+  (syntax-parse stx
+    [(_ () body)
+     #'body]
+    [(_ ([ids () rhs] . binds) body)
+     #'(let-values ([ids rhs])
+         (let*-values-with-static-infos
+          binds
+          body))]
+    [(_ ([(id) static-infos rhs] . binds) body)
+     #'(let-values ([(tmp) (let ([id  rhs]) id)])
+         (define id tmp)
+         (define-static-info-syntax/maybe id . static-infos)
+         (let*-values-with-static-infos
+          binds
+          body))]))
+
+(define-syntax (let*-values-with-static-infos/k stx)
+  (syntax-parse stx
+    [(_ success-k () body)
+     #'(let ([success-k values])
+         body)]
+    [(_ success-k ([ids () rhs] . binds) body)
+     #'(let ([success-k
+              (lambda ids
+                (let*-values-with-static-infos/k
+                 success-k
+                 binds
+                 body))])
+         rhs)]
+    [(_ success-k ([(id) static-infos rhs] . binds) body)
+     #'(let ([success-k
+              (lambda (tmp)
+                (define id tmp)
+                (define-static-info-syntax/maybe id . static-infos)
+                (let*-values-with-static-infos/k
+                 success-k
+                 binds
+                 body))])
+         rhs)]))
+
+(define (raise-argument-annotation-failure who val ctc)
+  (raise-binding-failure who "argument" val ctc))
+
+(define (raise-result-annotation-failure who val ctc)
+  (raise-binding-failure who "result" val ctc))
+
+(define (raise-rest-argument-annotation-failure who val ctc whole?)
+  (if whole?
+      (raise-binding-failure who "rest-argument list" val ctc)
+      (raise-binding-failure who "argument" val ctc)))
+
+(define (raise-rest-result-annotation-failure who val ctc whole?)
+  (if whole?
+      (raise-binding-failure who "rest-result list" val ctc)
+      (raise-binding-failure who "result" val ctc)))
+
+(define (raise-keyword-rest-argument-annotation-failure who val ctc)
+  (raise-binding-failure who "keyword rest-argument map" val ctc))
+
+(define (raise-result-arity-error who n args)
+  (apply raise-result-arity-error*
+         who rhombus-realm
+         n
+         #f
+         args))
+
+(define (function-arity-match? f arity)
+  (define-values (f-req-kws f-allow-kws) (procedure-keywords f))
+  (cond
+    [(number? arity)
+     (define mask arity)
+     (and (null? f-req-kws)
+          (= mask (bitwise-and mask (procedure-arity-mask f))))]
+    [else
+     (define mask (car arity))
+     (define req-kws (cadr arity))
+     (define allow-kws (caddr arity))
+     (and (= mask (bitwise-and mask (procedure-arity-mask f)))
+          (if (not allow-kws)
+              (not f-allow-kws)
+              (or (not f-allow-kws)
+                  (for/and ([allow-kw (in-list allow-kws)])
+                    (memq allow-kw f-allow-kws))))
+          (for/and ([f-req-kw (in-list f-req-kws)])
+            (memq f-req-kw req-kws)))]))
+
+(define (rest-treelist->list l)
+  (cond
+    [(treelist? l)
+     (treelist->list l)]
+    [else (error "rest annotation converted to a non-List value")]))
+
+(define (keywords->map kws kw-vals)
+  (for/hashalw ([kw (in-list kws)]
+                [kw-val (in-list kw-vals)])
+    (values kw kw-val)))
+
+(define (rest-map->keywords h)
+  (cond
+    [(hash? h)
+     (define kws (hash-keys h #t))
+     (values kws
+             (for/list ([kw (in-list kws)])
+               (hash-ref h kw)))]
+    [else (error "keyword-rest annotation converted to a non-Map value")]))
+
+(define (drop-keywords h kws)
+  (for/fold ([h h]) ([kw (in-list kws)])
+    (hash-remove h kw)))
+
+(define-syntax (make-keyword-procedure/reduce-arity stx)
+  (syntax-parse stx
+    [(_ () _ e) #'(make-keyword-procedure e)]
+    [(_ (kw ...) arity-mask e) #'(procedure-reduce-keyword-arity-mask
+                                  (make-keyword-procedure e)
+                                  arity-mask
+                                  '(kw ...)
+                                  #f)]))
+
+(define (make-keyword-procedure/reduce-arity-like like-proc proc)
+  (procedure-reduce-arity-like like-proc (make-keyword-procedure proc)))
+
+(define (procedure-reduce-arity-like like-proc proc)
+  (define-values (req-kws allowed-kws) (procedure-keywords like-proc))
+  (procedure-reduce-keyword-arity-mask
+   proc
+   (procedure-arity-mask like-proc)
+   req-kws
+   allowed-kws))
+
+(define-syntax (call-with-unchanged-values stx)
+  (syntax-parse stx
+    [(_ generator receiver) #'(generator)]
+    [_ (error "should not get here")]))
+
+(define-for-syntax (extract-name stx gs)
+  (define (shift prop from to)
+    (datum->syntax
+     #f
+     (cons (prop (car (syntax-e to)) (prop (car (syntax-e from))))
+           (cdr (syntax-e to)))))
+  (let loop ([gs (syntax->list gs)] [name #f] [accum null])
+    (cond
+      [(null? gs) (list name (reverse accum))]
+      [else
+       (syntax-parse (car gs)
+         #:datum-literals (group)
+         [(group #:name (b-tag::block . b))
+          (when name
+            (raise-syntax-error #f "second name expression not allowed"
+                                stx
+                                (car gs)))
+          (define new-name #'(who-to-symbol (rhombus-body-at b-tag . b)))
+          (cond
+            [(and (null? accum) (pair? (cdr gs)))
+             ;; shift prefix
+             (loop (cons (shift syntax-raw-prefix-property (car gs) (cadr gs))
+                         (cddr gs))
+                   new-name
+                   accum)]
+            [(pair? accum)
+             ;; shift suffix
+             (loop (cdr gs) new-name (cons (shift syntax-raw-suffix-property (car gs) (car accum))
+                                           (cdr accum)))]
+            [else
+             (loop (cdr gs) new-name accum)])]
+         [_
+          (loop (cdr gs) name (cons (car gs) accum))])])))
+
+(define (who-to-symbol s)
+  (cond
+    [(symbol? s) s]
+    [(string? s) (string->symbol s)]
+    [(syntax? s) (string->symbol (format "~a" (shrubbery-syntax->string s)))]
+    [else
+     (raise-annotation-failure '|-> ~name result| s "error.Who")]))

--- a/rhombus-lib/rhombus/private/amalgam/binding.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/binding.rkt
@@ -177,6 +177,10 @@
          what val
          (append extra
                  (list "annotation" (unquoted-printing-string
-                                     (error-contract->adjusted-string
-                                      annotation-str
-                                      rhombus-realm))))))
+                                     (regexp-replace*
+                                      #rx"\n"
+                                      (error-contract->adjusted-string
+                                       annotation-str
+                                       rhombus-realm)
+                                      ;; number of spaces here depends on "annotation:"
+                                      "\n              "))))))

--- a/rhombus-lib/rhombus/private/amalgam/boolean-annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/boolean-annotation.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
-                     "annotation-string.rkt")
+                     "annotation-string.rkt"
+                     "srcloc.rkt")
          (submod "annotation.rkt" for-class)
          "binding.rkt"
          "static-info.rkt"
@@ -20,21 +21,23 @@
    (lambda () `((,(annot-quote \|\|) . stronger)))
    'automatic
    (lambda (lhs rhs stx)
-     (syntax-parse (list lhs rhs)
-       [(l::annotation-predicate-form r::annotation-predicate-form)
-        (annotation-predicate-form
-         #`(let ([l-pred l.predicate]
-                 [r-pred r.predicate])
-             (lambda (v)
-               (and (l-pred v) (r-pred v))))
-         (static-infos-union #'r.static-infos #'l.static-infos))]
-       [(l::annotation-binding-form r::annotation-binding-form)
-        (annotation-binding-form
-         (binding-form
-          #'and-infoer
-          #`[result l.binding r.binding l.body r.body r.static-infos])
-         #'result
-         #'r.static-infos)]))
+     (relocate+reraw
+      (datum->syntax #f (list lhs stx rhs))
+      (syntax-parse (list lhs rhs)
+        [(l::annotation-predicate-form r::annotation-predicate-form)
+         (annotation-predicate-form
+          #`(let ([l-pred l.predicate]
+                  [r-pred r.predicate])
+              (lambda (v)
+                (and (l-pred v) (r-pred v))))
+          (static-infos-union #'r.static-infos #'l.static-infos))]
+        [(l::annotation-binding-form r::annotation-binding-form)
+         (annotation-binding-form
+          (binding-form
+           #'and-infoer
+           #`[result l.binding r.binding l.body r.body r.static-infos])
+          #'result
+          #'r.static-infos)])))
    'left))
 
 (define-syntax (and-infoer stx)
@@ -91,21 +94,23 @@
    null
    'automatic
    (lambda (lhs rhs stx)
-     (syntax-parse (list lhs rhs)
-       [(l::annotation-predicate-form r::annotation-predicate-form)
-        (annotation-predicate-form
-         #'(let ([l-pred l.predicate]
-                 [r-pred r.predicate])
-             (lambda (v)
-               (or (l-pred v) (r-pred v))))
-         (static-infos-intersect #'l.static-infos #'r.static-infos))]
-       [(l::annotation-binding-form r::annotation-binding-form)
-        (annotation-binding-form
-         (binding-form
-          #'or-infoer
-          #'[result l.binding l.body l.static-infos r.binding r.body r.static-infos])
-         #'result
-         (static-infos-intersect #'l.static-infos #'r.static-infos))]))
+     (relocate+reraw
+      (datum->syntax #f (list lhs stx rhs))
+      (syntax-parse (list lhs rhs)
+        [(l::annotation-predicate-form r::annotation-predicate-form)
+         (annotation-predicate-form
+          #'(let ([l-pred l.predicate]
+                  [r-pred r.predicate])
+              (lambda (v)
+                (or (l-pred v) (r-pred v))))
+          (static-infos-intersect #'l.static-infos #'r.static-infos))]
+        [(l::annotation-binding-form r::annotation-binding-form)
+         (annotation-binding-form
+          (binding-form
+           #'or-infoer
+           #'[result l.binding l.body l.static-infos r.binding r.body r.static-infos])
+          #'result
+          (static-infos-intersect #'l.static-infos #'r.static-infos))])))
    'left))
 
 (define-syntax (or-infoer stx)
@@ -173,20 +178,22 @@
                 (,(annot-quote \|\|) . stronger)))
    'automatic
    (lambda (form stx)
-     (syntax-parse form
-       [f::annotation-predicate-form
-        (annotation-predicate-form
-         #'(let ([pred f.predicate])
-             (lambda (v)
-               (not (pred v))))
-         #'())]
-       [f::annotation-binding-form
-        (annotation-binding-form
-         (binding-form
-          #'not-infoer
-          #'[result f.binding])
-         #'result
-         #'())]))))
+     (relocate+reraw
+      (datum->syntax #f (list stx form))
+      (syntax-parse form
+        [f::annotation-predicate-form
+         (annotation-predicate-form
+          #'(let ([pred f.predicate])
+              (lambda (v)
+                (not (pred v))))
+          #'())]
+        [f::annotation-binding-form
+         (annotation-binding-form
+          (binding-form
+           #'not-infoer
+           #'[result f.binding])
+          #'result
+          #'())])))))
 
 (define-syntax (not-infoer stx)
   (syntax-parse stx

--- a/rhombus-lib/rhombus/private/amalgam/core.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core.rkt
@@ -141,6 +141,7 @@
         "boolean-annotation.rkt"
         "boolean-reducer.rkt"
         "boolean-repet.rkt"
+        "arrow-annotation.rkt"
         "equatable.rkt"
         "sequenceable.rkt"
         "eval.rkt"

--- a/rhombus-lib/rhombus/private/amalgam/described_as.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/described_as.rhm
@@ -7,10 +7,15 @@ use_static
 export:
   described_as
 
-bind.macro '$left described_as $right ...':
-  ~weaker_than: ~other
-  bind_meta.pack('(described_as_infoer,
-                   ($('$right ...'.to_source_string()), $left))')
+bind.macro
+| '$left described_as ($right ...) $tail ...':
+    ~weaker_than: ~other
+    values(bind_meta.pack('(described_as_infoer,
+                            ($('$right ...'.to_source_string()), $left))'),
+           '$tail ...')
+| '$left described_as $right ...':
+    bind_meta.pack('(described_as_infoer,
+                     ($('$right ...'.to_source_string()), $left))')
 
 bind.infoer 'described_as_infoer($static_info, ($str, $left))':
   let left_info = bind_meta.get_info(left, static_info)

--- a/rhombus-lib/rhombus/private/amalgam/function-arity.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/function-arity.rkt
@@ -82,9 +82,9 @@
 
 (define-for-syntax (combine-arity-summaries as combine)
   (cond
-    [(null? as) #f]
+    [(null? as) 0]
     [(null? (cdr as)) (car as)]
-    [else
+    [(andmap values as)
      (define (normalize a)
        (if (pair? a)
            (list (car a) (list->hash (cadr a)) (and (caddr a) (list->hash (caddr a))))
@@ -97,7 +97,8 @@
      (if (and (null? required-kws)
               (null? allowed-kws))
          (car norm-a)
-         (list (car norm-a) required-kws allowed-kws))]))
+         (list (car norm-a) required-kws allowed-kws))]
+    [else #f]))
 
 (define-for-syntax (union-arity-summaries as)
   (combine-arity-summaries
@@ -129,12 +130,13 @@
     (cond
       [(null? kws)
        (and
-        (if (zero? (bitwise-and (if rsts
-                                    (if (zero? n)
-                                        -1
-                                        (bitwise-not (sub1 (arithmetic-shift 1 (sub1 n)))))
-                                    (arithmetic-shift 1 n))
-                                (if (pair? a) (car a) a)))
+        (if (and a
+                 (zero? (bitwise-and (if rsts
+                                         (if (zero? n)
+                                             -1
+                                             (bitwise-not (sub1 (arithmetic-shift 1 (sub1 n)))))
+                                         (arithmetic-shift 1 n))
+                                     (if (pair? a) (car a) a))))
             (and kind
                  (raise-syntax-error #f
                                      (case kind

--- a/rhombus-lib/rhombus/private/amalgam/function-parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/function-parse.rkt
@@ -11,7 +11,8 @@
                      "static-info-pack.rkt"
                      "entry-point-adjustment.rkt"
                      (only-in "annotation-string.rkt" annotation-any-string)
-                     "to-list.rkt")
+                     "to-list.rkt"
+                     "sorted-list-subset.rkt")
          racket/unsafe/undefined
          "treelist.rkt"
          "to-list.rkt"
@@ -1036,7 +1037,9 @@
                                  => (lambda (results)
                                       (find-call-result-at
                                        results
-                                       (+ (length rands) (length extra-args))))]
+                                       (+ (length rands) (length extra-args))
+                                       null
+                                       #f))]
                                 [else #'()])
                               result-static-infos))
         (define arity (arithmetic-shift 1 (length formals)))
@@ -1145,9 +1148,17 @@
                                         [(and call-result?
                                               (rator-static-info #'#%call-result))
                                          => (lambda (results)
+                                              (define sorted-kws
+                                                (sort (for/list ([kw (in-list kws)]
+                                                                 #:when (syntax-e kw))
+                                                        (syntax-e kw))
+                                                      keyword<?))
                                               (find-call-result-at
                                                results
-                                               (+ num-rands (length extra-rands))))]
+                                               (- (+ num-rands (length extra-rands))
+                                                  (length sorted-kws))
+                                               sorted-kws
+                                               kwrsts))]
                                         [else #'()])
                                       extra-result-static-infos))
          (values w-call-e result-static-infos)))])
@@ -1156,14 +1167,26 @@
    #f))
 
 ;; does not support keyword arguments, for now
-(define-for-syntax (find-call-result-at results arity)
+(define-for-syntax (find-call-result-at results arity kws kw-rest?)
   (syntax-parse results
     [(#:at_arities r)
      (let loop ([r #'r])
        (syntax-parse r
-         [((mask results) . rest)
-          (if (bitwise-bit-set? (syntax-e #'mask) arity)
-              #'results
+         [((a results) . rest)
+          (define-values (mask req-kws allow-kws)
+            (syntax-parse #'a
+              [(mask req-kws allow-kws) (values #'mask #'req-kws #'allow-kws)]
+              [mask (values #'mask #'() #'())]))
+          (if (and (bitwise-bit-set? (syntax-e mask) arity)
+                   (or kw-rest? (sorted-list-subset? (syntax->datum req-kws) kws))
+                   (or (not (syntax-e allow-kws))
+                       (sorted-list-subset? kws (syntax->datum allow-kws))))
+              (if (or (not kw-rest?)
+                      (and (not allow-kws)
+                           (sorted-list-subset? (syntax->datum req-kws) kws)))
+                  #'results
+                  ;; we don't know whether the call matches or not, so stop searching
+                  #'())
               (loop #'rest))]
          [_ #'()]))]
     [_ results]))

--- a/rhombus-lib/rhombus/private/amalgam/implicit.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/implicit.rkt
@@ -22,7 +22,8 @@
          "is-static.rkt"
          "operator-compare.rkt"
          (only-in "op-literal.rkt"
-                  :_-expr))
+                  :_-expr)
+         "arrow-annotation.rkt")
 
 (provide (for-space #f
                     #%body

--- a/rhombus-lib/rhombus/private/amalgam/map.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/map.rkt
@@ -504,9 +504,11 @@
                                                map-annotation-make-predicate
                                                map-annotation-make-static-info
                                                #'map-build-convert #`(#,(key-comp-empty-stx mapper)))]
-                         [(_ . tail)
-                          (values (annotation-predicate-form (key-comp-map?-id mapper)
-                                                             (get-map-static-infos))
+                         [(form-id . tail)
+                          (values (relocate+reraw
+                                   #'form-id
+                                   (annotation-predicate-form (key-comp-map?-id mapper)
+                                                              (get-map-static-infos)))
                                   #'tail)]))))))
 
 (define-syntax (map-build-convert arg-id build-convert-stxs kws data)
@@ -660,9 +662,11 @@
      (parse-key-comp stx
                      (lambda (stx arg-stxes str mapper)
                        (syntax-parse stx
-                         [(_ . tail)
-                          (values (annotation-predicate-form (key-comp-mutable-map?-id mapper)
-                                                             (get-mutable-map-static-infos))
+                         [(form-id . tail)
+                          (values (relocate+reraw
+                                   #'form-id
+                                   (annotation-predicate-form (key-comp-mutable-map?-id mapper)
+                                                              (get-mutable-map-static-infos)))
                                   #'tail)]))))))
 
 (define MutableMap-build
@@ -690,9 +694,11 @@
      (parse-key-comp stx
                      (lambda (stx arg-stxes str mapper)
                        (syntax-parse stx
-                         [(_ . tail)
-                          (values (annotation-predicate-form (key-comp-weak-mutable-map?-id mapper)
-                                                             (get-weak-mutable-map-static-infos))
+                         [(form-id . tail)
+                          (values (relocate+reraw
+                                   #'form-id
+                                   (annotation-predicate-form (key-comp-weak-mutable-map?-id mapper)
+                                                              (get-weak-mutable-map-static-infos)))
                                   #'tail)]))))))
 
 (define WeakMutableMap-build

--- a/rhombus-lib/rhombus/private/amalgam/name-root-ref.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/name-root-ref.rkt
@@ -234,17 +234,18 @@
     [_ #f]))
 
 (define-for-syntax (relocate-field root-id field-id new-field-id)
+  (define name (string->symbol
+                (format "~a.~a"
+                        (or (syntax-property root-id 'syntax-error-name)
+                            (syntax-e root-id))
+                        (syntax-e field-id))))
   (syntax-property
    (syntax-property (datum->syntax new-field-id
                                    (syntax-e new-field-id)
                                    (span-srcloc root-id field-id)
                                    field-id)
                     'rhombus-dotted-name
-                    (string->symbol
-                     (format "~a.~a"
-                             (or (syntax-property root-id 'syntax-error-name)
-                                 (syntax-e root-id))
-                             (syntax-e field-id))))
+                    name)
    'disappeared-use
    (let ([root (syntax-local-introduce (in-name-root-space root-id))])
      (if (syntax-original? (syntax-local-introduce field-id))

--- a/rhombus-lib/rhombus/private/amalgam/set.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/set.rkt
@@ -686,9 +686,11 @@
                                                set-annotation-make-predicate
                                                set-annotation-make-static-info
                                                #'set-build-convert #`(#,(key-comp-empty-stx mapper)))]
-                         [(_ . tail)
-                          (values (annotation-predicate-form (key-comp-set?-id mapper)
-                                                             (get-set-static-infos))
+                         [(form-id . tail)
+                          (values (relocate+reraw
+                                   #'form-id
+                                   (annotation-predicate-form (key-comp-set?-id mapper)
+                                                              (get-set-static-infos)))
                                   #'tail)]))))))
 
 (define-syntax (set-build-convert arg-id build-convert-stxs kws data)
@@ -836,9 +838,11 @@
      (parse-key-comp stx
                      (lambda (stx arg-stxes str mapper)
                        (syntax-parse stx
-                         [(_ . tail)
-                          (values (annotation-predicate-form (key-comp-mutable-set?-id mapper)
-                                                             (get-mutable-set-static-infos))
+                         [(form-id . tail)
+                          (values (relocate+reraw
+                                   #'form-id
+                                   (annotation-predicate-form (key-comp-mutable-set?-id mapper)
+                                                              (get-mutable-set-static-infos)))
                                   #'tail)]))))))
 
 (define-annotation-syntax WeakMutableSet.by
@@ -849,9 +853,11 @@
      (parse-key-comp stx
                      (lambda (stx arg-stxes str mapper)
                        (syntax-parse stx
-                         [(_ . tail)
-                          (values (annotation-predicate-form (key-comp-weak-mutable-set?-id mapper)
-                                                             (get-mutable-set-static-infos))
+                         [(form-id . tail)
+                          (values (relocate+reraw
+                                   #'form-id
+                                   (annotation-predicate-form (key-comp-weak-mutable-set?-id mapper)
+                                                              (get-mutable-set-static-infos)))
                                   #'tail)]))))))
 
 (define-syntax MutableSet

--- a/rhombus-lib/rhombus/private/amalgam/sorted-list-subset.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/sorted-list-subset.rkt
@@ -1,0 +1,11 @@
+#lang racket/base
+
+(provide sorted-list-subset?)
+
+(define (sorted-list-subset? req-kws kws)
+  (let loop ([req-kws req-kws] [kws kws])
+    (cond
+      [(null? req-kws) #t]
+      [(null? kws) #f]
+      [(eq? (car req-kws) (car kws)) (loop (cdr req-kws) (cdr kws))]
+      [else (loop req-kws (cdr kws))])))

--- a/rhombus-pict-lib/rhombus/pict/private/anim.rhm
+++ b/rhombus-pict-lib/rhombus/pict/private/anim.rhm
@@ -54,22 +54,18 @@ namespace bend:
 
 enum SequentialJoin:  step splice
 
+annot.macro 'named($name, $ann)':
+  match ann
+  | '$arrow && $arity ...':
+      '($arity ... && Function.all_of(~name: $name, $arrow))'.relocate_span([ann])
+
 fun animate(~children: children :: List.of(Pict) = [],
-            proc :: Function.of_arity(1 + children.length()),
-            ~bend: bend :: Function.of_arity(1) = rkt.#{fast-middle},
+            proc :: named("animate function",
+                          ((~any) -> StaticPict)
+                            && Function.of_arity(1 + children.length())),
+            ~bend: bend :: Real.in(0, 1) -> Real.in(0, 1) = rkt.#{fast-middle},
             ~extent: extent :: NonnegReal = 0.5,
             ~sustain_edge: sustain_edge :: matching(TimeOrder) = #'after) :~ Pict:
-  let proc:
-    fun (n, child_or_config, ...):
-      let p = proc(bend(n), child_or_config, ...)
-      unless p is_a StaticPict
-      | error(~who: #'animate,
-              ~exn: Exn.Fail.Annot,
-              error.annot_msg("procedure result"),
-              error.annot("StaticPict"),
-              error.val(~label: "procedure", proc),
-              error.val(~label: "result", p))
-      p
   AnimPict(~children: children,
            proc,
            ~extent: extent,
@@ -77,15 +73,10 @@ fun animate(~children: children :: List.of(Pict) = [],
 
 fun rebuildable(~children: children :: List.of(Pict) = [],
                 ~config: config :: maybe(Map) = #false,
-                proc :: Function.of_arity(children.length() + (if config | 1 | 0))) :~ Pict:
+                proc :: named("rebuildable function",
+                              ((~any) -> Pict)
+                                && Function.of_arity(children.length() + (if config | 1 | 0)))) :~ Pict:
   let p = proc(& children ++ (if config | [config] | []))
-  unless p is_a Pict
-  | error(~who: #'rebuildable,
-          ~exn: Exn.Fail.Annot,
-          error.annot_msg("procedure result"),
-          error.annot("Pict"),
-          error.val(~label: "procedure", proc),
-          error.val(~label: "result", p))
   let rebuild:
     if config
     | fun ([child, ..., config]):

--- a/rhombus-pict-lib/rhombus/pict/private/static.rhm
+++ b/rhombus-pict-lib/rhombus/pict/private/static.rhm
@@ -223,11 +223,11 @@ class Pict():
                                 [p],
                                 0 /* extent */))
 
-  method rebuild(~pre: pre_adjuster :: Function.of_arity(1)
+  method rebuild(~pre: pre_adjuster :: Function.of_arity(1) described_as Pict -> Pict
                          = fun (p): p,
-                 ~post: adjuster :: Function.of_arity(1)
+                 ~post: adjuster :: Function.of_arity(1) described_as Pict -> Pict
                           = fun (p): p,
-                 ~config: config_adjuster :: Function.of_arity(1)
+                 ~config: config_adjuster :: Function.of_arity(1) described_as Map -> Map
                             = fun (config): config) :~ Pict:
     let (p, _) = _replace(pre_adjuster,
                           adjuster,
@@ -495,10 +495,12 @@ fun set_convert(proc):
   do_convert := proc
 
 fun animate_map(p :~ List.of(Pict),
-                ~combine: combine :: Function.of_arity(3),
+                ~combine: combine :: Function.of_arity(3) described_as (List.of(Pict), Int, Real.in(0, 1)) -> Pict,
                 ~duration: duration :: DurationAlignment = #'sustain,
                 ~epoch: epoch :: EpochAlignment = #'center,
-                ~non_sustain_combine: non_sustain_combine :: Function.of_arity(3) = combine) :~ Pict:
+                ~non_sustain_combine: non_sustain_combine
+                                        :: Function.of_arity(3) described_as (List.of(Pict), Int, Real.in(0, 1)) -> Pict
+                                        = combine) :~ Pict:
   do_convert(p, epoch, duration, combine, non_sustain_combine, #false, #false)
 
 // used by `sequential` and `concurrent`
@@ -1175,7 +1177,7 @@ fun polygon([pt :: draw.PointLike.to_point, ...],
 fun bitmap(path :: Path || String) :~ Pict:
   static_pict(rkt.bitmap(path), [], empty_instances)
 
-fun dc(draw :: Function.of_arity(3),
+fun dc(draw :: Function.of_arity(3) described_as (draw.DC, Real, Real) -> ~any,
        ~width: width :: Real,
        ~height: height :: Real,
        ~ascent: ascent :: Real = height,
@@ -1387,7 +1389,7 @@ fun animate(xy_proc :: Function.of_arity(2) || Function.of_arity(3),
 
 fun interpolate(from :: Find,
                 to :: Find,
-                ~bend: bend :: Function.of_arity(1) = rkt.#{fast-middle}) :: Find:
+                ~bend: bend :: Real.in(0, 1) -> Real.in(0, 1) = rkt.#{fast-middle}) :: Find:
   _Find(#false,
         fun (p, q, epoch, n):
           let i_n:

--- a/rhombus-pict-lib/rhombus/pict/radial.rhm
+++ b/rhombus-pict-lib/rhombus/pict/radial.rhm
@@ -193,11 +193,11 @@ defn.macro 'def_radial:
       $body
   '
 
-fun evenly_spaced(i, n):
+fun evenly_spaced(i :: Int, n :: PosInt):
   2 * math.pi * i / n
 
 fun jitter_spaced(jitter):
-  fun (i, n):
+  fun (i :: Int, n :: PosInt):
     let a = evenly_spaced(i, n)
     let delta = 2 * math.pi / n
     a + 0.25 * math.sin(jitter * (if i == n | 0 | a)) * delta
@@ -206,7 +206,7 @@ def_radial:
   radial(~points: n :: PosInt = 6,
          ~width: width :: Real = 64,
          ~height: height :: Real = width,
-         ~angle_at: point_angle :: Function.of_arity(2) = evenly_spaced,
+         ~angle_at: point_angle :: (Int, PosInt) -> Real = evenly_spaced,
          ~inner_radius: d :: Real = 0.5,
          ~outer_radius: od :: Real = 1,
          ~inner_pause: inner_pause :: Real = 0,
@@ -222,7 +222,7 @@ def_radial:
   flower_radial(~petals: n :: PosInt = 6,
                 ~width: width :: Real = 64,
                 ~height: height :: Real = width,
-                ~angle_at: point_angle :: Function.of_arity(2) = evenly_spaced,
+                ~angle_at: point_angle :: (Int, PosInt) -> Real = evenly_spaced,
                 ~inner_radius: d :: Real = 0.5,
                 ~outer_radius: od :: Real = 1,
                 ~inner_pause: inner_pause :: Real = 0,
@@ -238,7 +238,7 @@ def_radial:
   cloud_radial(~bumps: n :: PosInt = 6,
                ~width: width :: Real = 64,
                ~height: height :: Real = width / 2,
-               ~angle_at: point_angle :: Function.of_arity(2) = jitter_spaced(0.3),
+               ~angle_at: point_angle :: (Int, PosInt) -> Real = jitter_spaced(0.3),
                ~inner_radius: d :: Real = 0.8,
                ~outer_radius: od :: Real = 1,
                ~inner_pause: inner_pause :: Real = 0,
@@ -254,7 +254,7 @@ def_radial:
   flash_radial(~points: n :: PosInt = 10,
                ~width: width :: Real = 64,
                ~height: height :: Real = width / 2,
-               ~angle_at: point_angle :: Function.of_arity(2) = evenly_spaced,
+               ~angle_at: point_angle :: (Int, PosInt) -> Real = evenly_spaced,
                ~inner_radius: d :: Real = 0.75,
                ~outer_radius: od :: Real = 1,
                ~inner_pause: inner_pause :: Real = 0,
@@ -280,7 +280,7 @@ def_radial:
   star_radial(~points: n :: PosInt = 5,
               ~width: width :: Real = 64,
               ~height: height :: Real = width,
-              ~angle_at: point_angle :: Function.of_arity(2) = evenly_spaced,
+              ~angle_at: point_angle :: (Int, PosInt) -> Real = evenly_spaced,
               ~inner_radius: d :: Real = star_inner(n),
               ~outer_radius: od :: Real = 1,
               ~inner_pause: inner_pause :: Real = 0,
@@ -296,7 +296,7 @@ def_radial:
   sun_radial(~rays: n :: PosInt = 10,
              ~width: width :: Real = 64,
              ~height: height :: Real = width,
-             ~angle_at: point_angle :: Function.of_arity(2) = evenly_spaced,
+             ~angle_at: point_angle :: (Int, PosInt) -> Real = evenly_spaced,
              ~inner_radius: d :: Real = 0.6,
              ~outer_radius: od :: Real = 1,
              ~inner_pause: inner_pause :: Real = 0.5,
@@ -312,7 +312,7 @@ def_radial:
   gear_radial(~arms: n :: PosInt = 5,
               ~width: width :: Real = 64,
               ~height: height :: Real = width,
-              ~angle_at: point_angle :: Function.of_arity(2) = evenly_spaced,
+              ~angle_at: point_angle :: (Int, PosInt) -> Real = evenly_spaced,
               ~inner_radius: d :: Real = 0.7,
               ~outer_radius: od :: Real = 1,
               ~inner_pause: inner_pause :: Real = 0.5,
@@ -333,7 +333,7 @@ def_radial:
   circle_radial(~sides: n :: PosInt = 5,
                 ~width: width :: Real = 64,
                 ~height: height :: Real = width,
-                ~angle_at: point_angle :: Function.of_arity(2) = evenly_spaced,
+                ~angle_at: point_angle :: (Int, PosInt) -> Real = evenly_spaced,
                 ~inner_radius: d :: Real = 1,
                 ~outer_radius: od :: Real = 1,
                 ~inner_pause: inner_pause :: Real = 0,
@@ -349,7 +349,7 @@ def_radial:
   regular_polygon_radial(~sides: n :: PosInt = 5,
                          ~width: width :: Real = 64,
                          ~height: height :: Real = 64,
-                         ~angle_at: point_angle :: Function.of_arity(2) = evenly_spaced,
+                         ~angle_at: point_angle :: (Int, PosInt) -> Real = evenly_spaced,
                          ~inner_radius: d :: Real = math.cos(math.pi/n),
                          ~outer_radius: od :: Real = 1,
                          ~inner_pause: inner_pause :: Real = 0,

--- a/rhombus-pict-lib/rhombus/pict/rhombus.rhm
+++ b/rhombus-pict-lib/rhombus/pict/rhombus.rhm
@@ -27,18 +27,13 @@ Parameter.def current_identifier_color :: Color || String = "black"
 Parameter.def current_comment_color :: Color || String = "chocolate"
 Parameter.def current_result_color :: Color || String = "darkblue"
 
-Parameter.def current_rhombus_tt :: Function.of_arity(1):
+Parameter.def current_rhombus_tt :: Function.all_of(~name: "current_rhombus_tt function",
+                                                    String -> Pict):
   fun (str_s):
     boldly: tt(str_s)
 
 fun rtt(str_s) :~ Pict:
-  let p = current_rhombus_tt()(str_s)
-  unless p is_a Pict
-  | error(error.annot_msg("Rhombus `tt` function result"),
-          ~exn: Exn.Fail.Annot,
-          error.annot("Pict"),
-          error.val(~label: "result", p))
-  p
+  current_rhombus_tt()(str_s)
 
 def (render_line,
      render_block):

--- a/rhombus-pict/rhombus/pict/scribblings/radial.scrbl
+++ b/rhombus-pict/rhombus/pict/scribblings/radial.scrbl
@@ -58,7 +58,7 @@
     ~width: width :: Real = 64,
     ~height: height :: Real = width,
     ~rotate: rotate :: Real = 0,
-    ~angle_at: angle_at :: Function.of_arity(2) = evenly_spaced,
+    ~angle_at: angle_at :: (Int, PosInt) -> Real = evenly_spaced,
     ~inner_radius: inner :: Real = 0.5,
     ~outer_radius: outer :: Real = 1,
     ~inner_pause: inner_pause :: Real = 0,
@@ -164,7 +164,7 @@
     ~width: width :: Real = 64,
     ~height: height :: Real = width,
     ~rotate: rotate :: Real = 0,
-    ~angle_at: angle_at :: Function.of_arity(2) = evenly_spaced,
+    ~angle_at: angle_at :: (Int, PosInt) -> Real = evenly_spaced,
     ~inner_radius: inner :: Real = 0.5,
     ~outer_radius: outer :: Real = 1,
     ~inner_pause: inner_pause :: Real = 0,
@@ -325,8 +325,8 @@
 }
 
 @doc(
-  fun evenly_spaced(i :: Int, out_of_n :: Int) :: Real
-  fun jitter_spaced(jitter :: Real) :: Function.of_arity(2)
+  fun evenly_spaced(i :: Int, out_of_n :: PosInt) :: Real
+  fun jitter_spaced(jitter :: Real) :: (Int, PosInt) -> Real
 ){
 
  Functions useful for @rhombus(~angle_at) arguments to

--- a/rhombus-pict/rhombus/pict/scribblings/shape.scrbl
+++ b/rhombus-pict/rhombus/pict/scribblings/shape.scrbl
@@ -236,7 +236,7 @@
 }
 
 @doc(
-  fun dc(draw :: Function.of_arity(3),
+  fun dc(draw :: (draw.DC, Real, Real) -> ~any,
          ~width: width :: Real,
          ~height: height :: Real,
          ~ascent: ascent :: Real = height,
@@ -244,7 +244,7 @@
 ){
 
  Creates a @tech{pict} with an arbitrary drawing context. The
- @rhombus(draw) function receives a s @rhombus(draw.DC), an x-offset, and
+ @rhombus(draw) function receives a @rhombus(draw.DC), an x-offset, and
  a y-offset.
 
 @examples(
@@ -263,9 +263,11 @@
 @doc(
   fun animate(
     ~children: children :: List.of(Pict) = [],
-    proc :: Function.of_arity(1 + children.length()),
+    proc :: (((~any) -> StaticPict)
+               && Function.of_arity(1 + children.length())),
     ~extent: extent :: NonnegReal = 0.5,
-    ~bend: bender = bend.fast_middle,
+    ~bend: bender :: (Real.in(0, 1) -> Real.in(0, 1))
+             = bend.fast_middle,
     ~sustain_edge: sustain_edge :: TimeOrder = #'before
   ) :: Pict
 ){
@@ -322,8 +324,9 @@
 @doc(
   fun rebuildable(~children: children :: List.of(Pict) = [],
                   ~config: config :: maybe(Map) = #false,
-                  proc :: Function.of_arity(children.length()
-                                              + (if config | 1 | 0)))
+                  proc :: (((~any) -> Pict)
+                             && Function.of_arity(children.length()
+                                                    + (if config | 1 | 0))))
     :: Pict
 ){
 

--- a/rhombus/rhombus/scribblings/reference/annotation.scrbl
+++ b/rhombus/rhombus/scribblings/reference/annotation.scrbl
@@ -119,6 +119,7 @@
 
 
 @doc(
+  bind.macro '$bind described_as ($term ...)'
   bind.macro '$bind described_as $term ...'
 ){
 
@@ -126,7 +127,8 @@
  that triggers an error message (as opposed to moving on to a different
  binding pattern), the message describes the expected annotation as
  @rhombus(term ...). The @rhombus(term ...) sequence is not parsed, so it
- can be any sequence of terms.
+ can be any sequence of terms, but the first @rhombus(term) can be parenthesized
+ only if the @rhombus(term ...) sequence is parenthesized.
 
 @examples(
   ~error:

--- a/rhombus/rhombus/scribblings/reference/function.scrbl
+++ b/rhombus/rhombus/scribblings/reference/function.scrbl
@@ -38,6 +38,8 @@ normally bound to implement function calls.
  @rhombus(keyword)s that are listed. Each @rhombus(keyword) must be
  distinct.
 
+ See also @rhombus(->, ~annot) and @rhombus(Function.all_of, ~annot).
+
 @margin_note_block{Due to the current limitation in the function arity
  protocol, a function must require an exact set of keywords across all
  arities, even though Rhombus multi-case @rhombus(fun)s allow
@@ -56,7 +58,6 @@ normally bound to implement function calls.
 )
 
 }
-
 
 @doc(
   ~nonterminal:
@@ -507,6 +508,243 @@ Only one @rhombus(~& map_bind) can appear in a @rhombus(rest) sequence.
 
 }
 
+
+@doc(
+  ~nonterminal:
+    annot: ::
+    list_annot: :: annot
+    map_annot: :: annot
+  ~literal: = _ :: values
+  annot.macro '$args -> $results'
+  grammar args:
+    $annot
+    ($arg, ..., $rest_arg, ...)
+    (~any)
+  grammar results:
+    $annot
+    ($result, ..., $rest_result, ...)
+    #,(@rhombus(values, ~annot)) ($result, ..., $rest_result, ...)
+    ~any
+    (~any)
+  grammar arg:
+    plain_arg
+    named_arg
+    rest_arg
+  grammar plain_arg:
+    $annot
+    $annot = _
+    $keyword: $annot
+    $keyword: $annot = _
+  grammar named_arg:
+    $id :: $annot
+    $id :: $annot = _
+    $keyword: $id :: $annot
+    $keyword: $id :: $annot = _
+  grammar rest_arg:
+    $annot #,(@litchar{,}) $ellipsis
+    & $list_annot
+    ~& $map_annot
+    & $id :: $list_annot
+    ~& $id :: $map_annot
+  grammar result:
+    $annot
+    $id :: $annot
+  grammar rest_result:
+    $annot #,(@litchar{,}) $ellipsis
+    & $list_annot
+    & $id :: $list_annot
+  grammar ellipsis:
+    #,(dots_expr)
+){
+
+ A @tech(~doc: guide_doc){converter annotation} that is immediately satisfied by a
+ function that has a compatible argument count and keyword arguments.
+ When a function converted by the annotation is called, then the argument
+ annotations are applied to the actual arguments, and the result
+ annotations are applied to the results. An error is reported if the
+ number of actual results does not match the number of result
+ annotations.
+
+@examples(
+  ~repl:
+    def f :: Real -> Int = (fun (x): x)
+    f(1)
+    ~error:
+      f("hello")
+    ~error:
+      f(1.5)
+  ~repl:
+    ~error:
+      def f2 :: (Int, Int) -> Int = (fun (x): x)
+)
+
+ An @rhombus(arg) that starts with a @rhombus(keyword) represents a
+ keyword argument. An @rhombus(arg) that ends @rhombus(= _) is an
+ optional argument; the default value is not specified, and it is left up
+ to the called function; along the same lines, the @rhombus(annot) before
+ @rhombus(= _) is not applied to the argument default.
+
+@examples(
+  ~repl:
+    def g :: (Int, Int, ~mode: Symbol) -> Int:
+      fun (x, y, ~mode: mode):
+        (x + y) * (if mode == #'minus | -1 | 1)
+    g(1, 2, ~mode: #'minus)
+    ~error:
+      g(1, 2, ~mode: 3)
+  ~repl:
+    def g2 :: (Int, Int, ~mode: Symbol = _) -> Int:
+      fun (x, y, ~mode: mode = "plus"):
+        (x + y) * (if mode == #'minus | -1 | 1)
+    g2(1, 2)
+)
+
+ When an @rhombus(arg) has an @rhombus(id) and @rhombus(::), the
+ argument is named for use in later argument annotations, including
+ result annotations. As in @rhombus(fun), each name refers to the
+ argument after any conversion implied by its annotation.
+
+@examples(
+  def both :: (x :: String, satisfying(fun (y): x < y)) -> List:
+    fun (x, y): [x, y]
+  both("apple", "banana")
+  ~error:
+    both("apple", "aadvark")
+)
+
+ An @rhombus(arg) written with @rhombus(&) or @rhombus(~&) stands for
+ any number of by-position and by-keyword arguments, respectively.
+ By-position arguments for @rhombus(&) are gathered into a list, and
+ by-keyword arguments for @rhombus(~&) are gathered into a map whose keys
+ are keywords. Alternatively, extra by-position arguments can be covered
+ by an @rhombus(annot) followed by @dots_expr. Arguments gathers with
+ @rhombus(&) or @rhombus(~&) can be named for later reference.
+
+@examples(
+  ~repl:
+    (fun (x, y, z, ...): 0) :: (Int, Int) -> Int
+    ~error:
+      (fun (x, y, z, ...): 0) :: (Int, Int, ...) -> Int
+  ~repl:
+    def k :: (~& kws :: Map) -> satisfying(fun (r):
+                                             r.length() == kws.length()):
+      fun (~& kws):
+        kws.keys()
+    k(~a: 1, ~b: 2, ~c: 3)
+)
+
+ If @rhombus(args) is @rhombus((~any)), then no constraint is placed on
+ the function arguments. Note that @rhombus((~any)) is different than
+ @rhombus((Any, ...)) or @rhombus((& Any)), which require that the
+ function accept any number of arguments. The arity of the converted
+ function is the same as the original function.
+
+@examples(
+  def m :: (~any) -> Int:
+    fun (x, y = x): x + y
+  m(1)
+  m(1, 2)
+  ~error:
+    m(1.0)
+  m is_a Function.of_arity(3)
+)
+
+ Result annotations are analogous to argument annotations, except that
+ keywords cannot be used for results. A multiple-annotation result
+ sequence in parentheses can be preceded optionally with
+ @rhombus(values, ~annot). Note that using @rhombus(Any, ~annot) as the result
+ annotation implies a check that the converted function produces a single
+ result when it is called. In the special case that the result annotation
+ sequence is @rhombus(~any), @rhombus((~any)), or equivalent
+ to @rhombus((Any, ...), ~annot) or @rhombus((& Any), ~annot),
+ then a call to the original function converted by the @rhombus(->, ~annot)
+ annotation is a tail call with respect to the converting wrapper.
+
+@examples(
+  def n_values :: (Int) -> (Any, ...):
+    fun (n):
+      values(& 0..n)
+  n_values(1)
+  n_values(3)
+)
+
+ To accept multiple argument annotations in parentheses,
+ @rhombus(->, ~annot) relies on help from @rhombus(#%parens, ~annot).
+ Relying on @rhombus(#%parens, ~annot) for non-annotation to the left of
+ @rhombus(->, ~annot) is why @rhombus(~any) for an argument must be in
+ parentheses.
+
+ See also @rhombus(Function.all_of, ~annot), which can be used not only
+ to join multiple @rhombus(->), but to provide a name that the converted
+ function uses for reporting failed annotation checks.
+
+}
+
+@doc(
+  ~nonterminal:
+    arrow_annot: :: annot
+  annot.macro 'Function.all_of($annot_or_name, ...)'
+  grammar annot_or_name:
+    $arrow_annot
+    ~name:
+      $body
+      ...
+){
+
+ Creates an annotation that is satisfied by a function that satisfies
+ every @rhombus(arrow_annot), each of which should correspond to a
+ @rhombus(->, ~annot) annotation (or one that is ultimately defined by
+ expansion to @rhombus(->, ~annot)).
+
+ The difference between using @rhombus(Function.all_of, ~annot) to
+ combine the @rhombus(arrow_annot)s and using @rhombus(&&, ~annot) is
+ that @rhombus(&&, ~annot) would effectively apply every
+ @rhombus(arrow_annot) to every call of the function, while
+ @rhombus(Function.all_of, ~annot) selects only the first
+ @rhombus(arrow_annot) whose argument annotations are satisfied by the
+ supplied arguments for each call to the function.
+
+ If a @rhombus(~name) form is among the @rhombus(annot_or_name)s, it can
+ appear only once. The @rhombus(body) forms under @rhombus(~name) are
+ evaluated only when an error is to be reported, and the result must
+ satisfy @rhombus(error.Who, ~annot). The @rhombus(~name) clause is
+ removed from the textual representation of
+ @rhombus(Function.all_of, ~annot) when reporting a failure to match the
+ overall annotation. The textual representation of
+ @rhombus(Function.all_of, ~annot) is further reduced to
+ @rhombus(arrow_annot) when only one is provided (with or without
+ @rhombus(~name)).
+
+@examples(
+  ~repl:
+    def mutable saved = 0
+    def f :: Function.all_of(() -> Int,
+                             Int -> Void):
+      fun | (): saved
+          | (v): saved := v
+    f(1)
+    f()
+    saved := #false
+    ~error:
+      f()
+  ~repl:
+    def f :: Function.all_of(Int -> Int,
+                             String -> String):
+      fun (x): x
+    f(1)
+    f("apple")
+    ~error:
+      f(#'apple)
+  ~repl:
+    fun build(filter :: Function.all_of(Int -> Int,
+                                        String -> String,
+                                        ~name: "filter for build")):
+      [filter(1), filter("apple")]
+    ~error:
+      build(fun (x): "apple")
+)
+
+}
 
 @doc(
   fun Function.map(f :: Function,

--- a/rhombus/rhombus/scribblings/reference/implicit.scrbl
+++ b/rhombus/rhombus/scribblings/reference/implicit.scrbl
@@ -88,6 +88,9 @@ Here are all of the implicit forms:
 }
 
 @doc(
+  ~nonterminal:
+    arg: -> ~annot
+    results: -> ~annot
   ~also_meta
   expr.macro '#%parens ($expr)'
   bind.macro '#%parens ($bind)'
@@ -97,6 +100,7 @@ Here are all of the implicit forms:
   expr.macro '#%parens ($term ... _ $term ...)'
   entry_point.macro '#%parens ($term ... _ $term ...)'
   immediate_callee.macro '#%parens ($term ... _ $term ...)'
+  annot.macro '#%parens ($arg, ...) #,(@rhombus(->, ~annot)) $results'
 ){
 
  Produces the same value as @rhombus(expr), same binding as
@@ -111,6 +115,12 @@ Here are all of the implicit forms:
  The @tech{entry point} and @tech{immediate callee} bindings allow
  parentheses to be used around such forms, and they allow the function
  shorthand to cooperate in those positions.
+
+ The @rhombus(#%parens, ~annot) annotation form cooperates with
+ @rhombus(->, ~annot) to enable multiple argument annotations in
+ parentheses. A @rhombus(->, ~annot) annotation is assumed whenever the
+ parenthesized term for @rhombus(#%parens, ~annot) is followed by
+ @rhombus(->, ~annot).
 
 @examples(
   (1+2)

--- a/rhombus/rhombus/tests/annotation.rhm
+++ b/rhombus/rhombus/tests/annotation.rhm
@@ -77,7 +77,8 @@ block:
   import:
     rhombus/meta open
   annot.macro 'one_to_two':
-    'converting(fun ([x]): [x, x])'
+    ~all_stx: self
+    '(converting(fun ([x]): [x, x]))'.relocate_span([self])
   check:
     def List(_, _) :: one_to_two = [1]
     ~completes

--- a/rhombus/rhombus/tests/arrow-annotation.rhm
+++ b/rhombus/rhombus/tests/arrow-annotation.rhm
@@ -1,0 +1,706 @@
+#lang rhombus
+
+// Basic `->` annotations
+
+check: (fun (x): #false) :: Int -> Int
+       ~completes
+
+check: (fun (x): #false) :: (Int) -> Int
+       ~completes
+
+check: (fun (x): x) :: (Int, Int) -> Int
+       ~throws error.annot_msg()
+
+check: ((fun (x): #false) :: Int -> Int)(10)
+       ~throws error.annot_msg("result")
+
+check: ((fun (x): #false) :: Int -> Int)("no")
+       ~throws error.annot_msg("argument")
+
+check: (fun (x, y, ...): x) :: Int -> Int
+       ~completes
+
+check: ((fun (x, y, ...): x) :: Int -> Int)(1, 2)
+       ~throws "arity mismatch"
+
+check: (fun (x): #false) :: Int -> Int -> Int
+       ~completes
+
+check: ((fun (x): #false) :: Int -> Int -> Int)(0)
+       ~throws values(error.annot_msg("result"),
+                      "Int -> Int")
+
+check: ((fun (x): fun (y): #false) :: Int -> Int -> Int)(0)
+       ~completes
+
+check: ((fun (x): fun (y): #false) :: Int -> Int -> Int)(0)("no")
+       ~throws error.annot_msg("argument")
+
+check: ((fun (x): fun (y): #false) :: Int -> Int -> Int)(0)(1)
+       ~throws error.annot_msg("result")
+
+check: ((fun (f): f(0)) :: (Int -> Int) -> Int)(fun (v): v)
+       ~is 0
+
+check: ((fun (f): f(0)) :: (Int -> Int) -> Int)(fun (v): "oops")
+       ~throws error.annot_msg("result")
+
+check: ((fun (f): f(0)) :: (String -> Int) -> Int)(fun (v): 5)
+       ~throws error.annot_msg("argument")
+
+check:
+  use_static
+  fun f(x) :: Any -> List:
+    fun (y): [x, y]
+  f(1)(2)[0]
+  ~is 1
+
+check:
+  ~eval
+  use_static
+  def f = dynamic(fun (x): x) :: Int -> Int
+  f(1, 2)
+  ~throws values("wrong number of arguments",
+                 "(based on static information)")
+
+check:
+  ~eval
+  use_static
+  def f = dynamic(fun (x): fun (y): x) :: Int -> (Int -> Int)
+  f(1)(2, 3)
+  ~throws values("wrong number of arguments",
+                 "(based on static information)")
+
+// Multiple result values
+
+check: (fun (x): #false) :: Int -> (Int, Int)
+       ~completes
+
+check: ((fun (x): values(x, x)) :: Int -> (Int, Int))(1)
+       ~is values(1, 1)
+
+check: ((fun (x): values(x, x)) :: Int -> values(Int, Int))(1)
+       ~is values(1, 1)
+
+check: ((fun (x): values("no", x)) :: Int -> (Int, Int))(1)
+       ~throws error.annot_msg("result")
+
+check:
+  use_static
+  let g :: Int -> (Int, Int -> Int) = (fun (x): values(x, fun (y): y + x))
+  let (v, f) = g(1)
+  f("no")
+  ~throws error.annot_msg("argument")
+
+check:
+  ~eval
+  use_static
+  def g :: Int -> (Int, Int -> Int) = (fun (x): values(x, fun (y): y + x))
+  def (v, f) = g(1)
+  f("no", 2)
+  ~throws values("wrong number of arguments",
+                 "(based on static information)")
+
+// Optional arguments
+
+check: (fun (x): x) :: (Int = _) -> Int
+       ~throws error.annot_msg()
+
+check: (fun (x = 0): x) :: (Int = _) -> Int
+       ~completes
+
+check: ((fun (x = 0): x) :: (Int = _) -> Int)()
+       ~is 0
+
+check: ((fun (x = 0): x) :: (Int = _) -> Int)(1)
+       ~is 1
+
+check: ((fun (y = 0, x = 0): [x, y]) :: (Int, Int = _) -> List)(1)
+       ~is [0, 1]
+
+check: ((fun (x = 0): x) :: (Int = _) -> Int)("no")
+       ~throws error.annot_msg("argument")
+
+check:
+  ~eval
+  use_static
+  def f = dynamic(fun (x, y = 0): x) :: (Int, Int = _) -> Int
+  f(1, 2, 3)
+  ~throws values("wrong number of arguments",
+                 "(based on static information)")
+
+check:
+  ~eval
+  1 :: (Int, Int = _, Int) -> Int
+  ~throws "non-optional argument follows an optional by-position argument"
+
+// Rest arguments
+
+check: (fun (x, y, ...): #false) :: Int -> Int
+       ~completes
+
+check: (fun (x, y, ...): #false) :: (Int, Int, ...) -> Int
+       ~completes
+
+check: (fun (x, y, ...): #false) :: (Int, & List) -> Int
+       ~completes
+
+check: (fun (x, y, ...): #false) :: (& List) -> Int
+       ~throws values(error.annot_msg(),
+                      "(& List) -> Int")
+
+check: ((fun (x, y, ...): math.sum(x, y, ...)) :: (Int, & List.of(Int)) -> Int)(1, 2, 3)
+       ~is 6
+
+check: ((fun (x, y = -3, z, ...): math.sum(x, y, z, ...)) :: (Int, & List.of(Int)) -> Int)(1, 2, 3)
+       ~is 6
+
+check: ((fun (x, y = -3, z, ...): math.sum(x, y, z, ...)) :: (Int, & List.of(Int)) -> Int)(1)
+       ~is -2
+
+check: ((fun (x, y = -3, z, ...): math.sum(x, y, z, ...)) :: (Int, & List.of(Int)) -> Int)()
+       ~throws "arity mismatch"
+
+check: ((fun (x, y, ...): math.sum(x, y, ...)) :: (Int, Int, ...) -> Int)(1, "no", 3)
+       ~throws error.annot_msg("argument")
+
+check: ((fun (x, y, ...): math.sum(x, y, ...)) :: (Int, & List.of(Int)) -> Int)(1, "no", 3)
+       ~throws error.annot_msg("rest-argument list")
+
+check: ((fun (x, y, ...): math.sum(x, y, ...)) :: (Int, & List.of(Int)) -> Int)("no", 2, 3)
+       ~throws error.annot_msg("argument")
+
+check:
+  ~eval
+  use_static
+  def f = dynamic(fun (x, y, ...): x) :: (Int, Int, ...) -> Int
+  f()
+  ~throws values("wrong number of arguments",
+                 "(based on static information)")
+
+check:
+  ~eval
+  1 :: (Int, ..., Int) -> Int
+  ~throws "non-rest argument not allowed after rest argument"
+
+check:
+  ~eval
+  1 :: (& List, Int) -> Int
+  ~throws "non-rest argument not allowed after rest argument"
+
+check:
+  ~eval
+  1 :: (Int, ..., Int, ...) -> Int
+  ~throws "second rest argument not allowed"
+
+check:
+  ~eval
+  1 :: (Int, ..., & List) -> Int
+  ~throws "second rest argument not allowed"
+
+check:
+  ~eval
+  1 :: (& List, Int, ...) -> Int
+  ~throws "second rest argument not allowed"
+
+// Keyword arguments
+
+check: (fun (x, ~y: y): #false) :: (Int, ~y: Int) -> Int
+       ~completes
+
+check: (fun (x, ~y: y = 10): #false) :: (Int, ~y: Int) -> Int
+       ~completes
+
+check: (fun (x, ~y: y): #false) :: (Int, ~y: Int = _) -> Int
+       ~throws error.annot_msg()
+
+check: ((fun (x, ~y: y = 10): [x, y]) :: (Int, ~y: Int) -> List)(1)
+       ~throws "required keyword argument not supplied"
+
+check: ((fun (x, ~y: y = 10): [x, y]) :: (Int, ~y: Int) -> List)(1, ~y: 2)
+       ~is [1, 2]
+
+check: ((fun (x, ~y: y = 10): [x, y]) :: (Int, ~y: Int = _) -> List)(1)
+       ~is [1, 10]
+
+check: ((fun (x, ~y: y = 10): [x, y]) :: (Int, ~y: Int = _) -> List)(1, ~y: 2)
+       ~is [1, 2]
+
+check: ((fun (x, ~y: y = math.abs): y) :: (Int, ~y: Int -> Int = _) -> Any)(1, ~y: fun (x): x)(-10)
+       ~is -10
+
+check: ((fun (x, ~y: y = math.abs): y) :: (Int, ~y: Int -> Int = _) -> Any)(1, ~y: fun (x): x)("no")
+       ~throws error.annot_msg("argument")
+
+check: ((fun (x, ~y: y = 10, ~z: z): [x, y, z]) :: (Int, ~y: Int = _, ~z: Int) -> List)(1, ~y: 2, ~z: 3)
+       ~is [1, 2, 3]
+
+check: ((fun (x, ~y: y, z, ...): [x, y, z, ...]) :: (Int, ~y: Int, & List.of(Int)) -> List)(1, 3, 4, ~y: 2)
+       ~is [1, 2, 3, 4]
+
+check: ((fun (x, ~y: y, & zs): [x, y, & zs]) :: (Int, ~y: Int, & List.of(Int)) -> List)(1, 3, 4, ~y: 2)
+       ~is [1, 2, 3, 4]
+
+check: ((fun (x, ~y: y = 10, z, ...): [x, y, z, ...]) :: (Int, ~y: Int = _, & List.of(Int)) -> List)(1, 3, 4, ~y: 2)
+       ~is [1, 2, 3, 4]
+
+check: ((fun (x, ~y: y = 10, & zs): [x, y, & zs]) :: (Int, ~y: Int = _, & List.of(Int)) -> List)(1, 3, 4, ~y: 2)
+       ~is [1, 2, 3, 4]
+
+check: ((fun (x, ~y: y = 10, z, ...): [x, y, z, ...]) :: (Int, ~y: Int = _, & List.of(Int)) -> List)(1, 3, 4)
+       ~is [1, 10, 3, 4]
+
+check: ((fun (x, ~y: y = 10, & zs): [x, y, & zs]) :: (Int, ~y: Int = _, & List.of(Int)) -> List)(1, 3, 4)
+       ~is [1, 10, 3, 4]
+
+check:
+  ~eval
+  use_static
+  def f = dynamic(fun (x, ~y: y): x) :: (Int, ~y: Int) -> Int
+  f(1, 2)
+  ~throws values("wrong number of arguments",
+                 "(based on static information)")
+
+check:
+  ~eval
+  use_static
+  def f = dynamic(fun (x, ~y: y): x) :: (Int, ~y: Int) -> Int
+  f(1)
+  ~throws values("missing keyword argument",
+                 "~y")
+
+check:
+  ~eval
+  use_static
+  def f = dynamic(fun (x, ~y: y): x) :: (Int, ~y: Int) -> Int
+  f(1, ~y: 2)
+  ~is 1
+
+// Keyword rest arguments
+
+check: ((fun (x, ~& kws): kws) :: (Int, ~& Map) -> Map)(1, ~y: 2)
+       ~is { #'~y: 2 }
+
+check: (fun (x): #false) :: (Int, ~& Map) -> Map
+       ~throws error.annot_msg()
+
+check: (fun (x, ~y: y): #false) :: (Int, ~& Map) -> Map
+       ~throws error.annot_msg()
+
+check: (fun (x, ~y: y = 10): #false) :: (Int, ~& Map) -> Map
+       ~throws error.annot_msg()
+
+check: ((fun (x, ~y: y = 10, ~& kws): kws) :: (Int, ~& Map) -> Map)(1, ~y: 2)
+       ~completes
+
+check: ((fun (x, ~y: y, ~& kws): kws) :: (Int, ~y: Int) -> Map)(1, ~y: 2)
+       ~is {}
+
+check: ((fun (x, ~y: y, ~& kws): kws) :: (Int, ~y: Int, ~& Map) -> Map)(1, ~y: 2, ~z: 3)
+       ~is { #'~z: 3 }
+
+check: ((fun (x, ~y: y, ~& kws): kws) :: (Int, ~y: Int, ~& Map.of(Keyword, Int -> Int)) -> Map)(1, ~y: 2, ~z: 3)
+       ~throws error.annot_msg("keyword rest-argument map")
+
+check: ((fun (x, ~y: y = "ok", ~& kws, z, ...): [kws, z, ...]) :: (Int, ~& Map, & List.of(Int)) -> Any)(1, ~y: 2, ~z: 3)
+       ~is [{ #'~z: 3 }]
+
+check: ((fun (x, ~y: y = "ok", ~& kws, z, ...): [kws, z, ...]) :: (Int, ~& Map, & List.of(Int)) -> Any)(1, ~y: 2, ~z: 3, 4, 5)
+       ~is [{ #'~z: 3 }, 4, 5]
+
+check:
+  use_static
+  let f = (fun (x, ~y: y, ~& kws, z, ...): [[z, ...], kws]) :: (Int, ~y: Int, ~& Map, Int, ...) -> matching([[_, ...], _ :: Map])
+  f(1, ~y: 2, ~z: 3, 4, 5, 6)
+  ~is [[4, 5, 6], { #'~z: 3 }]
+
+check:
+  use_static
+  let f = ((fun (x, ~y: y, ~& kws): kws) :: (Int, ~y: Int, ~& Map.of(Keyword, Int -> Int)) -> Map)
+  f(1, ~y: 2, ~z: fun (x): x)[#'~z](10)
+  ~is 10
+
+check:
+  use_static
+  let f = ((fun (x, ~y: y, ~& kws): kws) :: (Int, ~y: Int, ~& Map.of(Keyword, Int -> Int)) -> Map)
+  f(1, ~y: 2, ~z: fun (x): x)[#'~z]("no")
+  ~throws error.annot_msg("argument")
+
+check:
+  ~eval
+  1 :: (~& Map, ~& Map) -> Int
+  ~throws "second keyword-rest argument not allowed"
+
+check:
+  ~eval
+  1 :: (~& Map, Int) -> Int
+  ~throws "non-rest argument not allowed after rest argument"
+
+// Dependent annotations
+
+block:
+  let f :: (x :: Any, satisfying(fun (y): y == x)) -> List:
+    fun (x, y): [x, y]
+  check f(1, 1) ~is [1, 1]
+  check f("a", "a") ~is ["a", "a"]
+  check f(1, "a") ~throws error.annot_msg("argument")
+
+block:
+  let f :: (arg :: Any) -> satisfying(if arg is_a String
+                                      | fun (x): x is_a Int
+                                      | fun (x): x is_a String):
+    fun (x):
+      cond
+      | x == 0: #'symbol
+      | x == "": #'empty
+      | x is_a Int:
+          "int"
+      | ~else:
+          100
+  check f("x") ~is 100
+  check f(1) ~is "int"
+  check f(0) ~throws error.annot_msg("result")
+  check f("") ~throws error.annot_msg("result")
+
+block:
+  let f :: (x :: Any, ~y: satisfying(fun (y): y == x)) -> List:
+    fun (x, ~y: y): [x, y]
+  check f(1, ~y: 1) ~is [1, 1]
+  check f("a", ~y: "a") ~is ["a", "a"]
+  check f(1, ~y: "a") ~throws error.annot_msg("argument")
+
+block:
+  let f :: (~x: x :: Any, satisfying(fun (y): y == x)) -> List:
+    fun (~x: x, y): [x, y]
+  check f(~x: 1, 1) ~is [1, 1]
+  check f(~x: "a", "a") ~is ["a", "a"]
+  check f(~x: 1, "a") ~throws error.annot_msg("argument")
+
+block:
+  use_static
+  let f :: (x :: List, ~y: satisfying(fun (y): y == x.length())) -> List:
+    fun (x, ~y: y): [x, y]
+  check f(["a"], ~y: 1) ~is [["a"], 1]
+  check f([], ~y: 1) ~throws error.annot_msg("argument")
+
+block:
+  use_static
+  let f :: (~x: x :: List, satisfying(fun (y): y == x.length())) -> List:
+    fun (~x: x, y): [x, y]
+  check f(~x: ["a"], 1) ~is [["a"], 1]
+  check f(~x: [], 1) ~throws error.annot_msg("argument")
+
+block:
+  use_static
+  let f :: (& tail :: List, ~& satisfying(fun (m :: Map): m[#'~count] == tail.length())) -> Any:
+    fun (x, ..., ~& kws): "ok"
+  check f(1, 2, 3, ~count: 3) ~is "ok"
+  check f(1, 2, ~count: 3) ~throws error.annot_msg("keyword rest-argument map")
+
+block:
+  use_static
+  let f :: (~& m :: Map, & satisfying(fun (tail :: List): m[#'~count] == tail.length())) -> Any:
+    fun (x, ..., ~& kws): "ok"
+  check f(1, 2, 3, ~count: 3) ~is "ok"
+  check f(1, 2, ~count: 3) ~throws error.annot_msg("rest-argument list")
+
+check:
+  ~eval
+  1 :: (Int, x :: Int = _, y :: Int) -> Int
+  ~throws "non-optional argument follows an optional by-position argument"
+
+block:
+  let f :: (Int, Int) -> (a :: Int, satisfying(fun (b): b == a)):
+    fun (x, y):
+      values(x, y)
+  check f(1, 1) ~is values(1, 1)
+  check f(1, 2) ~throws error.annot_msg("result")
+
+// Rest results
+
+block:
+  let f :: (Int) -> (Int, ...):
+    fun (x):
+      match x
+      | 1: 1
+      | 2: values(2, 2)
+      | 3: values(2, "x")
+      | ~else:  values(3, 3, 3, 3)
+  check f(1) ~is values(1)
+  check f(2) ~is values(2, 2)
+  check f(3) ~throws error.annot_msg("result")
+  check f(4) ~is values(3, 3, 3, 3)
+
+block:
+  let f :: (Int) -> (Int, & List.of(Int)):
+    fun (x):
+      match x
+      | 1: 1
+      | 2: values(2, 2)
+      | 3: values(2, "x")
+      | ~else:  values(3, 3, 3, 3)
+  check f(1) ~is values(1)
+  check f(2) ~is values(2, 2)
+  check f(3) ~throws error.annot_msg("rest-result list")
+  check f(4) ~is values(3, 3, 3, 3)
+
+// `~any` arguments and results
+block:
+  use_static
+  let f :: (~any) -> ~any:
+    fun (x, y): values(x, y)
+  let kf :: (~any) -> ~any:
+    fun (x, y, ~z: z): values(x, y, z)
+  let okf :: (~any) -> ~any:
+    fun (x, y, ~z: z = 0): values(x, y, z)
+  let xf :: (~any) -> ~any:
+    fun (x, y, & z): values(x, y, z)
+  let xkf :: (~any) -> ~any:
+    fun (x, y, & z, ~& kz): values(x, y, z, kz)
+  check f(1, 2) ~is values(1, 2)
+  check kf(1, 2, ~z: 3) ~is values(1, 2, 3)
+  check okf(1, 2) ~is values(1, 2, 0)
+  check okf(1, 2, ~z: 3) ~is values(1, 2, 3)
+  check xf(1, 2, 4, 5) ~is values(1, 2, [4, 5])
+  check xkf(1, 2, 4, 5, ~z: 3) ~is values(1, 2, [4, 5], { #'~z: 3 })
+  check f ~is_a Function.of_arity(2)
+  check (f is_a Function.of_arity(1)) ~is #false
+  check (f is_a Function.of_arity(3)) ~is #false
+  check (f is_a Function.of_arity(~z)) ~is #false
+  check kf ~is_a Function.of_arity(2, ~z)
+  check (kf is_a Function.of_arity(1, ~z)) ~is #false
+  check (kf is_a Function.of_arity(3, ~z)) ~is #false
+  check (kf is_a Function.of_arity(~z)) ~is #true
+  check (kf is_a Function.of_arity(~y)) ~is #false
+  check okf ~is_a Function.of_arity(2, ~z)
+  check (okf is_a Function.of_arity(1, ~z)) ~is #false
+  check (okf is_a Function.of_arity(3, ~z)) ~is #false
+  check (okf is_a Function.of_arity(~z)) ~is #true
+  check (okf is_a Function.of_arity(~y)) ~is #false
+  check xf ~is_a Function.of_arity(2)
+  check xf ~is_a Function.of_arity(30)
+  check (xf is_a Function.of_arity(~z)) ~is #false
+  check xkf ~is_a Function.of_arity(2, ~z)
+  check xkf ~is_a Function.of_arity(3, ~z, ~y)
+  check xkf ~is_a Function.of_arity(30)
+
+block:
+  // Check that `~any` or `values(Any, ...)` produces a tail call
+  let f:
+    fun ():
+      Continuation.call_with_immediate_mark(#'mark, fun (x): x)
+  let f_tail :: () -> (Any, ...) = f
+  let f_nontail :: () -> Any = f
+  let f_also_tail :: () -> (& Any) = f
+  let f_still_tail :: () -> ~any = f
+  let f_also_still_tail :: (~any) -> ~any = f
+  check (Continuation.with_mark #'mark = "yes": f()) ~is "yes"
+  check (Continuation.with_mark #'mark = "yes": f_tail()) ~is "yes"
+  check (Continuation.with_mark #'mark = "yes": f_nontail()) ~is #false
+  check (Continuation.with_mark #'mark = "yes": f_also_tail()) ~is "yes"
+  check (Continuation.with_mark #'mark = "yes": f_still_tail()) ~is "yes"
+  check (Continuation.with_mark #'mark = "yes": f_also_still_tail()) ~is "yes"
+
+// Case annotations
+
+block:
+  let f :: Function.all_of(): math.sum
+  check f() ~throws "arity mismatch"
+  check f(1, 2, 3) ~throws "arity mismatch"
+
+check:
+  ~eval
+  use_static
+  def f :: Function.all_of(): math.sum
+  f()
+  ~throws values("wrong number of arguments",
+                 "(based on static information)")
+
+block:
+  let f :: Function.all_of(Int -> Int,
+                           (Int, Int) -> List):
+    fun
+    | (x):
+        if x == 0 | "zer" | x + 1
+    | (x, y):
+        if x ==y | x | [x, y]
+  check f(1) ~is 2
+  check f(1, 2) ~is [1, 2]
+  check f("x") ~throws error.annot_msg("argument")
+  check f(0) ~throws error.annot_msg("result")
+  check f(0, 0) ~throws error.annot_msg("result")
+  check f() ~throws "arity mismatch"
+  check f(1, 2, 3) ~throws "arity mismatch"
+  check f(~x: 1) ~throws "does not accept keyword arguments"
+
+check:
+  ~eval
+  use_static
+  block:
+    let f :: Function.all_of(Int -> Int,
+                             (Int, Int) -> List):
+      #false
+    f()
+  ~throws values("wrong number of arguments",
+                 "(based on static information)")
+
+check:
+  ~eval
+  use_static
+  block:
+    let f :: Function.all_of(Int -> Int,
+                             (Int, Int) -> List):
+      #false
+    f(1, 2, 3)
+  ~throws values("wrong number of arguments",
+                 "(based on static information)")
+
+block:
+  let f :: Function.all_of(Int -> Int,
+                           String -> String,
+                           Boolean -> Boolean):
+    fun (x): if x | x | "no"
+  check f(1) ~is 1
+  check f("two") ~is "two"
+  check f(#true) ~is #true
+  check f([]) ~throws "no matching case"
+  check f(#false) ~throws error.annot_msg("result")
+
+block:
+  let f :: Function.all_of((Int, Real, ...) -> Real,
+                           (Real) -> Real):
+    math.sum
+  check f(1) ~is 1
+  check f(1, 2.0) ~is 3.0
+  check f(1.0) ~is 1.0
+  check f("a") ~throws "no matching case"
+
+block:
+  // distinct arities
+  let f :: Function.all_of((Real) -> Real,
+                           (Int, Real, Real, ...) -> Int):
+    math.sum
+  check f(1.0) ~is 1.0
+  check f(1, 2) ~is 3
+  check f(1.0, 2) ~throws error.annot_msg("argument")
+  check f(1, 2.0) ~throws error.annot_msg("result")
+
+block:
+  // overlapping arities
+  let f :: Function.all_of((Real) -> Real,
+                           (Int, Real, ...) -> Int):
+    math.sum
+  check f(1.0) ~is 1.0
+  check f(1, 2) ~is 3
+  check f(1.0, 2) ~throws "no matching case"
+  check f(1, 2.0) ~throws error.annot_msg("result")
+
+block:
+  let f :: Function.all_of((Int, Real = _, ~x: Any) -> Real,
+                           (Real, ~x: Any) -> Real):
+    fun (~x: x, n, ...):
+      math.sum(n, ...)
+  check f(1, ~x: #false) ~is 1
+  check f(1, 2.0, ~x: #false) ~is 3.0
+  check f(1.0, ~x: #false) ~is 1.0
+
+block:
+  let f :: Function.all_of((Int, Real = _) -> Real,
+                           (Real, ~x: Any) -> Real):
+    fun (~x: x = 0, n, ...):
+      math.sum(n, ...)
+  check f(1, ~x: #false) ~is 1
+  check f(1, 2.0) ~is 3.0
+  check f(1.0, ~x: #false) ~is 1.0
+  check f(1, 2.0, ~x: #false) ~throws "no matching case for arguments"
+
+block:
+  let f :: Function.all_of((Int, Real = _) -> Real,
+                           (Real, ~& Map) -> Real):
+    fun (~& kws, n, ...):
+      math.sum(n, ...)
+  check f(1, ~x: #false) ~is 1
+  check f(1, 2.0) ~is 3.0
+  check f(1.0, ~x: #false) ~is 1.0
+  check f(1, 2.0, ~x: #false) ~throws "no matching case for arguments"
+
+block:
+  use_static
+  let f :: Function.all_of((Int, ~x: Int) -> Map,
+                           (String, String, ~y: String) -> Map):
+    fun (a, b = #false, ~& kws):
+      kws ++ { #'~val: a, #'~opt: b }
+  check f(1, ~x: 2) ~is { #'~x: 2, #'~val: 1, #'~opt: #false }
+  check f("a", "b", ~y: "b") ~is { #'~y: "b", #'~val: "a", #'~opt: "b" }
+  check f("a", ~x: 2) ~throws "no matching case"
+  check f(1, ~y: "b") ~throws "no matching case"
+  // note that static mode can't rule this out, due to the way
+  // that multi-case keyword information is represented
+  check f(#false, ~x: 2, ~y: "b") ~throws "no matching case"
+
+block:
+  use_static
+  let f :: Function.all_of((Int, ~x: Int) -> Map,
+                           (String, ~y: String) -> Map):
+    fun (a, ~& kws):
+      kws ++ { #'~val: a }
+  check f(1, ~x: 2) ~is { #'~val: 1, #'~x: 2 }
+  check f("a", ~y: "b") ~is { #'~val: "a", #'~y: "b" }
+  check f("a", ~x: 2) ~throws "no matching case"
+  check f(1, ~y: "b") ~throws "no matching case"
+  // note that static mode can't rule this out, due to the way
+  // that multi-case keyword information is represented
+  check f(#false, ~x: 2, ~y: "b") ~throws "no matching case"
+
+check:
+  ~eval
+  use_static
+  def f :: Function.all_of((Int, ~x: Int) -> Map,
+                           (String, ~y: String) -> Map):
+    fun (a, ~& kws):
+      kws ++ { #'~val: a }
+  f(1, ~z: 2)
+  ~throws values("keyword argument not recognized",
+                 "(based on static information)")
+
+block:
+  let f :: Function.all_of((x :: Any) -> satisfying(fun (y): y == x),
+                           (x :: Any, y :: satisfying(fun (y): y == x)) -> List):
+    fun | (x):
+            if x | x | #true
+        | (x, y):
+            [x, y]
+  check f(1) ~is 1
+  check f(1, 1) ~is [1, 1]
+  check f(1, 2) ~throws error.annot_msg("argument")
+  check f(#false) ~throws error.annot_msg("result")
+
+block:
+  use_static
+  def f :: Function.all_of(() -> List,
+                           Int -> Map):
+    fun | (): [0]
+        | (v): { #'val: v }
+  check f()[0] ~is 0
+  check f(1)[#'val] ~is 1
+
+block:
+  use_static
+  def f :: Function.all_of((~x: Any) -> List,
+                           (~y: Any) -> Map):
+    fun | (~x: x): [x]
+        | (~y: y): { #'val: y }
+  check f(~x: 10)[0] ~is 10
+  check f(~y: 11)[#'val] ~is 11
+
+block:
+  use_static
+  def f :: Function.all_of(Real -> Int,
+                           (~any) -> ~any):
+    fun | (x): x
+        | (x, y): values(x, y)
+  check f(1) ~is 1
+  check f("a") ~is "a"
+  check f(1.0) ~throws error.annot_msg("result")
+  check f(1, 2) ~is values(1, 2)
+  check f(1, 2, 3) ~throws "arity mismatch"

--- a/shrubbery-lib/shrubbery/print.rkt
+++ b/shrubbery-lib/shrubbery/print.rkt
@@ -310,9 +310,26 @@
   (cond
     [(syntax? s)
      (or (syntax-column s)
-         (let ([e (syntax-e s)])
-           (and (pair? e)
-                (extract-starting-column (car e))))
+         (let loop ([s s])
+           (let ([l (syntax->list s)])
+             (and l
+                  (case (syntax-e (car l))
+                    [(multi)
+                     (and (pair? (cdr l))
+                          (loop (cadr l)))]
+                    [(group)
+                     (and (pair? (cdr l))
+                          (loop (cadr l)))]
+                    [(op)
+                     (and (pair? (cdr l))
+                          (null? (cddr l))
+                          (loop (cadr l)))]
+                    [(parens brackets braces quotes block alts)
+                     (extract-starting-column (car l))]
+                    [(parsed)
+                     (and (= 3 (length l))
+                          (extract-starting-column (caddr l)))]
+                    [else #f]))))
          0)]
     [else 0]))
 


### PR DESCRIPTION
The `->` annotation operator constructs a converting annotation that expects a function of suitable arity and wraps it to check argument and result annotations. The `Function.all_of` annotation form takes any number of annotations constructed by `->` and creates a annotation that is satified by a function that handles all of `->` cases, similar to `case->` in Racket's contract system.

The expressiveness of `->` itself is similar to `->i` in Racket's contract system: it supports optional and keyword arguments, and arguments can be named to create dependent checks.

Unlike `case->`, which selects a case based only on the arity of a call, `Function.all_of` selects a case based on the first clause that matches the arguments of a given call. This makes `Function.all_of` more analogous to a multi-case `fun`, and it means that `Function.all_of` can express some dependencies even with simple `->` forms, as in

```
  Function.all_of(Int -> Int,
                  String -> String)
```

To get error reprting to work well overall, this commit makes a general change to the annotation-macro layer. Each annotation form is now responsible for attaching its rendered form to its expansion, like expression macros. So, there are more internal uses of `relocate+reraw`, and there's more need for `Syntax.relocate_span`s at the Rhombus level.

The `Any` annotation is like `any/c` in Racket, which means that `() -> Any` will wrap a function with a non-tail call to ensure that it produces a single result. Use `() -> (Any, ...)` or `() -> (& Any)` to avoid constraining the number of results and produce a tail-calling wrapper.

The `->` operator cannot by itself handle multiple arguments in parentheses on the left of the operator, since an infix operator takes a parsed left-hand side, and a parenthesized sequence of annotation is not an annotation. As a workaround, the `#%parens` form exported by `rhombus` cooperates with the `->` form.