### PR TITLE
Initial Path integration

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation.rkt
@@ -442,11 +442,12 @@
    (lambda (form tail)
      (syntax-parse tail
        [(op::name . (~var t (:annotation-seq #'::)))
+        (define op-name (string->symbol (shrubbery-syntax->string #'op.name)))
         (values
          (build-annotated-expression #'op.name #'t
                                      checked? form #'t.parsed
                                      (lambda (tmp-id)
-                                       #`(raise-::-annotation-failure 'op.name #,tmp-id '#,(shrubbery-syntax->string #'t.parsed)))
+                                       #`(raise-::-annotation-failure '#,op-name #,tmp-id '#,(shrubbery-syntax->string #'t.parsed)))
                                      wrap-static-info*)
          #'t.tail)]))
    'none))

--- a/rhombus-lib/rhombus/private/amalgam/closeable.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/closeable.rhm
@@ -8,30 +8,33 @@ export:
   Closeable
 
 namespace Closeable:
-  export rename cdef as def
+  export:
+    close
+    rename cdef as def  
+
+  fun close(v :: Closeable):
+    v.close()
 
   defn.sequence_macro 'cdef $(bind :: Identifier) = $(rhs :: expr_meta.Parsed)
                        $body
                        ...':
+    ~op_stx: self
     def rhs_statinfo = statinfo_meta.gather(rhs)
-    def resource = Syntax.make_temp_id()
+    def resource = Syntax.make_temp_id("resource")
     def resource_with_statinfo = statinfo_meta.wrap(resource, rhs_statinfo)
-    def close_stmt:
-      '$(if syntax_meta.is_static(bind) | 'use_static' | 'use_dynamic')
-       $(resource_with_statinfo) . $('close'.relocate(rhs))()'
     values(
       '
         block:
           def mutable $resource = #false
           try:
             ~initially:
-              $resource := ($rhs :: Closeable)
+              $resource := ($rhs $('::'.relocate(self)) Closeable)
             block:
               let $bind = $resource_with_statinfo
               #void
               $body
               ...
             ~finally:
-              $close_stmt
+              ($resource :~ Closeable).close()
       ',
       '')

--- a/rhombus-lib/rhombus/private/amalgam/closeable.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/closeable.rhm
@@ -1,0 +1,37 @@
+#lang rhombus/private/amalgam/core
+
+import:
+  "core-meta.rkt" open
+  "closeable.rkt" open
+
+export:
+  Closeable
+
+namespace Closeable:
+  export rename cdef as def
+
+  defn.sequence_macro 'cdef $(bind :: Identifier) = $(rhs :: expr_meta.Parsed)
+                       $body
+                       ...':
+    def rhs_statinfo = statinfo_meta.gather(rhs)
+    def resource = Syntax.make_temp_id()
+    def resource_with_statinfo = statinfo_meta.wrap(resource, rhs_statinfo)
+    def close_stmt:
+      '$(if syntax_meta.is_static(bind) | 'use_static' | 'use_dynamic')
+       $(resource_with_statinfo) . $('close'.relocate(rhs))()'
+    values(
+      '
+        block:
+          def mutable $resource = #false
+          try:
+            ~initially:
+              $resource := ($rhs :: Closeable)
+            block:
+              let $bind = $resource_with_statinfo
+              #void
+              $body
+              ...
+            ~finally:
+              $close_stmt
+      ',
+      '')

--- a/rhombus-lib/rhombus/private/amalgam/closeable.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/closeable.rhm
@@ -10,12 +10,12 @@ export:
 namespace Closeable:
   export:
     close
-    rename cdef as def  
+    rename clet as let
 
   fun close(v :: Closeable):
     v.close()
 
-  defn.sequence_macro 'cdef $(bind :: Identifier) = $(rhs :: expr_meta.Parsed)
+  defn.sequence_macro 'clet $(bind :: Identifier) = $(rhs :: expr_meta.Parsed)
                        $body
                        ...':
     ~op_stx: self
@@ -31,7 +31,6 @@ namespace Closeable:
               $resource := ($rhs $('::'.relocate(self)) Closeable)
             block:
               let $bind = $resource_with_statinfo
-              #void
               $body
               ...
             ~finally:

--- a/rhombus-lib/rhombus/private/amalgam/closeable.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/closeable.rhm
@@ -14,8 +14,10 @@ namespace Closeable:
 
   fun close(v :: Closeable):
     v.close()
+    #void
 
-  defn.sequence_macro 'clet $(bind :: Identifier) = $(rhs :: expr_meta.Parsed)
+  defn.sequence_macro 'clet $bind ... = $(rhs :: expr_meta.Parsed)
+                       $body0
                        $body
                        ...':
     ~op_stx: self
@@ -29,10 +31,12 @@ namespace Closeable:
           try:
             ~initially:
               $resource := ($rhs $('::'.relocate(self)) Closeable)
-            block:
-              let $bind = $resource_with_statinfo
-              $body
-              ...
+            Continuation.barrier:
+              let $bind ... = $resource_with_statinfo
+              block:
+                $body0
+                $body
+                ...
             ~finally:
               ($resource :~ Closeable).close()
       ',

--- a/rhombus-lib/rhombus/private/amalgam/closeable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/closeable.rkt
@@ -1,10 +1,16 @@
 #lang racket/base
 
 (require (for-syntax racket/base
-                     "interface-parse.rkt")
+                     "interface-parse.rkt"
+                     "class-method-result.rkt")
+         "define-arity.rkt"
          (submod "annotation.rkt" for-class)
          "class-desc.rkt"
-         "provide.rkt")
+         "provide.rkt"
+         (submod "dot.rkt" for-dot-provider)
+         "dot-provider-key.rkt"
+         "annotation-failure.rkt"
+         "dot-parse.rkt")
 
 (provide (for-spaces (rhombus/annot
                       rhombus/class)
@@ -14,7 +20,7 @@
   (make-struct-type-property 'Closeable #f '()))
 
 (define-annotation-syntax Closeable
-  (identifier-annotation closeable? ()))
+  (identifier-annotation closeable? ((#%dot-provider closeable-instance))))
 (define (closeable? v)
   (or (port? v)
       (Closeable? v)))
@@ -25,8 +31,8 @@
      (interface-desc #'()
                      '#(#&close)
                      #'#(#:abstract)
-                     (hasheq 'describe 0)
-                     (hasheq 'describe #f)
+                     (hasheq 'close 0)
+                     (hasheq 'close #'close-result)
                      '()
                      #f
                      #'()
@@ -41,3 +47,23 @@
                      #t
                      #f
                      null))))
+
+(define-syntax close-result
+  (method-result-maker
+   (lambda ()
+     (method-result #f #t 0 "Any" #'() 1))))
+
+(define-dot-provider-syntax closeable-instance
+  (dot-provider
+   (dot-parse-dispatch
+    (lambda (field-sym field-proc ary nary repetition? fail-k)
+      (case field-sym
+        [(close) (nary 1 #'Closeable.close #'Closeable.close/method)]
+        [else (fail-k)])))))
+
+(define/method (Closeable.close v)
+  (cond
+    [(input-port? v) (close-input-port v)]
+    [(output-port? v) (close-output-port v)]
+    [(Closeable? v) ((vector-ref (Closeable-ref v) 0) v)]
+    [else (raise-annotation-failure 'Closeable.close v "Closeable")]))

--- a/rhombus-lib/rhombus/private/amalgam/closeable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/closeable.rkt
@@ -1,0 +1,43 @@
+#lang racket/base
+
+(require (for-syntax racket/base
+                     "interface-parse.rkt")
+         (submod "annotation.rkt" for-class)
+         "class-desc.rkt"
+         "provide.rkt")
+
+(provide (for-spaces (rhombus/annot
+                      rhombus/class)
+                     Closeable))
+
+(define-values (prop:Closeable Closeable? Closeable-ref)
+  (make-struct-type-property 'Closeable #f '()))
+
+(define-annotation-syntax Closeable
+  (identifier-annotation closeable? ()))
+(define (closeable? v)
+  (or (port? v)
+      (Closeable? v)))
+
+(define-class-desc-syntax Closeable
+  (interface-desc-maker
+   (lambda ()
+     (interface-desc #'()
+                     '#(#&close)
+                     #'#(#:abstract)
+                     (hasheq 'describe 0)
+                     (hasheq 'describe #f)
+                     '()
+                     #f
+                     #'()
+                     '()
+                     ;; --------------------
+                     #'Closeable
+                     #'Closeable
+                     #'prop:Closeable
+                     #'prop:Closeable
+                     #'Closeable-ref
+                     #'Closeable-ref
+                     #t
+                     #f
+                     null))))

--- a/rhombus-lib/rhombus/private/amalgam/control.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/control.rkt
@@ -15,7 +15,8 @@
          (submod "annotation.rkt" for-class)
          (submod "function-parse.rkt" for-build)
          (submod "equal.rkt" for-parse)
-         "if-blocked.rkt")
+         "if-blocked.rkt"
+         "rhombus-primitive.rkt")
 
 (provide (for-spaces (rhombus/annot
                       rhombus/namespace)
@@ -31,6 +32,7 @@
    [current_marks Continuation.Marks.current]
    capture
    prompt
+   barrier
    [escape Continuation.escape]
    ;; TEMP see `PromptTag`
    [default_prompt_tag Continuation.PromptTag.default]
@@ -160,6 +162,8 @@
                    (rhombus-expression (#,group-tag tag-expr ...)))
                 #'())]))))
 
+(set-primitive-who! 'call-with-composable-continuation 'Continuation.capture)
+
 (define-syntax prompt
   (expression-transformer
    (lambda (stx)
@@ -248,6 +252,15 @@
                         (if handler
                             (list handler)
                             null)))
+                #'())]))))
+
+(define-syntax barrier
+  (expression-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       [(_ (tag::block g ...))
+        (values #`(call-with-continuation-barrier
+                   (lambda () (rhombus-body-at tag g ...)))
                 #'())]))))
 
 (define/arity (Continuation.escape

--- a/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
@@ -14,4 +14,5 @@
         "class_together.rhm"
         "enum.rhm"
         "pipeline.rhm"
-        "str.rhm")
+        "str.rhm"
+        "closeable.rhm")

--- a/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
@@ -6,6 +6,7 @@
         "check.rhm"
         "maybe.rhm"
         "string.rhm"
+        "path-object.rhm"
         "when_unless.rhm"
         "where.rhm"
         "described_as.rhm"

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rhm
@@ -1,0 +1,19 @@
+#lang rhombus/private/amalgam/core
+
+import:
+  "core-meta.rkt" open
+
+use_static
+
+export:
+  PathString
+
+namespace PathString:
+  export:
+    to_path
+
+  fun to_path(p :: PathString) :~ Path:
+    Path(p)
+
+  annot.macro 'to_path':
+    'converting(fun (p :: PathString) :~ Path: to_path(p))'

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rhm
@@ -11,9 +11,23 @@ export:
 namespace PathString:
   export:
     to_path
+    to_complete_path
 
   fun to_path(p :: PathString) :~ Path:
     Path(p)
 
+  fun
+  | to_complete_path(p :: PathString):
+      Path.to_complete_path(p)
+  | to_complete_path(p :: PathString, ~relative_to: base_path :: PathString):
+      Path.to_complete_path(p, ~relative_to: base_path)
+
   annot.macro 'to_path':
     'converting(fun (p :: PathString) :~ Path: to_path(p))'
+
+  annot.macro
+  | 'to_complete_path(~relative_to: $base_path)':
+      'converting(fun (p :: PathString) :~ Path:
+                    to_complete_path(p, ~relative_to: $base_path))'
+  | 'to_complete_path':
+      'converting(fun (p :: PathString) :~ Path: to_complete_path(p))'

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rhm
@@ -11,23 +11,23 @@ export:
 namespace PathString:
   export:
     to_path
-    to_complete_path
+    to_absolute_path
 
   fun to_path(p :: PathString) :~ Path:
     Path(p)
 
   fun
-  | to_complete_path(p :: PathString):
-      Path.to_complete_path(p)
-  | to_complete_path(p :: PathString, ~relative_to: base_path :: PathString):
-      Path.to_complete_path(p, ~relative_to: base_path)
+  | to_absolute_path(p :: PathString):
+      Path.to_absolute_path(p)
+  | to_absolute_path(p :: PathString, ~relative_to: base_path :: PathString):
+      Path.to_absolute_path(p, ~relative_to: base_path)
 
   annot.macro 'to_path':
     'converting(fun (p :: PathString) :~ Path: to_path(p))'
 
   annot.macro
-  | 'to_complete_path(~relative_to: $base_path)':
+  | 'to_absolute_path(~relative_to: $base_path)':
       'converting(fun (p :: PathString) :~ Path:
-                    to_complete_path(p, ~relative_to: $base_path))'
-  | 'to_complete_path':
-      'converting(fun (p :: PathString) :~ Path: to_complete_path(p))'
+                    to_absolute_path(p, ~relative_to: $base_path))'
+  | 'to_absolute_path':
+      'converting(fun (p :: PathString) :~ Path: to_absolute_path(p))'

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rhm
@@ -7,6 +7,7 @@ use_static
 
 export:
   PathString
+  +/
 
 namespace PathString:
   export:
@@ -31,3 +32,9 @@ namespace PathString:
                     to_absolute_path(p, ~relative_to: $base_path))'
   | 'to_absolute_path':
       'converting(fun (p :: PathString) :~ Path: to_absolute_path(p))'
+
+operator ((l_path :: PathString)
+            +/ (r_path :: PathString || matching(#'up) || matching(#'same)))
+  :~ Path:
+    ~weaker_than ++
+    Path.extend(l_path, r_path)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rhm
@@ -37,4 +37,4 @@ operator ((l_path :: PathString)
             +/ (r_path :: PathString || matching(#'up) || matching(#'same)))
   :~ Path:
     ~weaker_than ++
-    Path.extend(l_path, r_path)
+    Path.add(l_path, r_path)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -6,6 +6,7 @@
          "call-result-key.rkt"
          "define-arity.rkt"
          "compare-key.rkt"
+         (submod "annotation.rkt" for-class)
          (submod "string.rkt" static-infos)
          (submod "bytes.rkt" static-infos))
 
@@ -13,7 +14,9 @@
                       #f
                       rhombus/bind
                       rhombus/annot)
-                     Path))
+                     Path)
+         (for-space rhombus/annot
+                    PathString))
 
 (module+ for-builtin
   (provide path-method-table))
@@ -70,3 +73,5 @@
   #:primitive (path->string)
   #:static-infos ((#%call-result #,(get-string-static-infos)))
   (string->immutable-string (path->string s)))
+
+(define-annotation-syntax PathString (identifier-annotation path-string? ()))

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -64,7 +64,8 @@
    extend
    is_absolute
    parts
-   string))
+   string
+   to_complete_path))
 
 (define/arity #:name Path (path c)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
@@ -102,5 +103,10 @@
   #:primitive (path->string)
   #:static-infos ((#%call-result #,(get-string-static-infos)))
   (string->immutable-string (path->string s)))
+
+(define/method (Path.to_complete_path p #:relative_to [base-path (current-directory)])
+  #:primitive (path->complete-path)
+  #:static-infos ((#%call-result #,(get-path-static-infos)))
+  (path->complete-path p base-path))
 
 (define-annotation-syntax PathString (identifier-annotation path-string? ()))

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -64,8 +64,10 @@
    extend
    is_absolute
    parts
+   read_with
    string
-   to_complete_path))
+   to_complete_path
+   write_with))
 
 (define/arity #:name Path (path c)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
@@ -99,6 +101,10 @@
   #:static-infos ((#%call-result #,(get-treelist-static-infos)))
   (to-treelist #f (explode-path p)))
 
+(define/method (Path.read_with p f)
+  #:primitive (call-with-input-file)
+  (call-with-input-file p f))
+
 (define/method (Path.string s)
   #:primitive (path->string)
   #:static-infos ((#%call-result #,(get-string-static-infos)))
@@ -108,5 +114,9 @@
   #:primitive (path->complete-path)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
   (path->complete-path p base-path))
+
+(define/method (Path.write_with p f #:exists [exists 'error])
+  #:primitive (call-with-output-file)
+  (call-with-output-file p f #:exists exists))
 
 (define-annotation-syntax PathString (identifier-annotation path-string? ()))

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
 (require (for-syntax racket/base)
+	 racket/path
          "provide.rkt"
          "class-primitive.rkt"
          "annotation-failure.rkt"
@@ -67,7 +68,8 @@
    read_with
    string
    to_complete_path
-   write_with))
+   write_with
+   only))
 
 (define/arity #:name Path (path c)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
@@ -100,6 +102,10 @@
   #:primitive (explode-path)
   #:static-infos ((#%call-result #,(get-treelist-static-infos)))
   (to-treelist #f (explode-path p)))
+
+(define/method (Path.only p)
+  #:primitive (path-only)
+  (path-only p))
 
 (define/method (Path.read_with p f)
   #:primitive (call-with-input-file)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -6,9 +6,12 @@
          "call-result-key.rkt"
          "define-arity.rkt"
          "compare-key.rkt"
+         "index-result-key.rkt"
+         "static-info.rkt"
          (submod "annotation.rkt" for-class)
-         (submod "string.rkt" static-infos)
-         (submod "bytes.rkt" static-infos))
+         (submod "bytes.rkt" static-infos)
+         (submod "list.rkt" for-listable)
+         (submod "string.rkt" static-infos))
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -53,8 +56,8 @@
   ()
   #:methods
   (bytes
-   string
-   ))
+   parts
+   string))
 
 (define/arity #:name Path (path c)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
@@ -68,6 +71,11 @@
   #:primitive (path->bytes)
   #:static-infos ((#%call-result #,(get-bytes-static-infos)))
   (bytes->immutable-bytes (path->bytes s)))
+
+(define/method (Path.parts p)
+  #:primitive (explode-path)
+  #:static-infos ((#%call-result #,(get-treelist-static-infos)))
+  (to-treelist #f (explode-path p)))
 
 (define/method (Path.string s)
   #:primitive (path->string)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -5,6 +5,7 @@
          "annotation-failure.rkt"
          "call-result-key.rkt"
          "define-arity.rkt"
+         "append-key.rkt"
          "compare-key.rkt"
          "index-result-key.rkt"
          "static-info.rkt"
@@ -42,7 +43,8 @@
 (define-primitive-class Path path
   #:lift-declaration
   #:no-constructor-static-info
-  #:instance-static-info ((#%compare ((< path<?)
+  #:instance-static-info ((#%append Path.extend)
+                          (#%compare ((< path<?)
                                       (<= path<=?)
                                       (> path>?)
                                       (>= path>=?)
@@ -56,6 +58,7 @@
   ()
   #:methods
   (bytes
+   extend
    parts
    string))
 
@@ -71,6 +74,11 @@
   #:primitive (path->bytes)
   #:static-infos ((#%call-result #,(get-bytes-static-infos)))
   (bytes->immutable-bytes (path->bytes s)))
+
+(define/method (Path.extend p . ss)
+  #:primitive (build-path)
+  #:static-infos ((#%call-result #,(get-path-static-infos)))
+  (apply build-path p ss))
 
 (define/method (Path.parts p)
   #:primitive (explode-path)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -59,6 +59,7 @@
   #:methods
   (bytes
    extend
+   is_absolute
    parts
    string))
 
@@ -79,6 +80,10 @@
   #:primitive (build-path)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
   (apply build-path p ss))
+
+(define/method (Path.is_absolute p)
+  #:primitive (absolute-path?)
+  (absolute-path? p))
 
 (define/method (Path.parts p)
   #:primitive (explode-path)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -11,6 +11,7 @@
          "static-info.rkt"
          (submod "annotation.rkt" for-class)
          (submod "bytes.rkt" static-infos)
+         (submod "function.rkt" for-info)
          (submod "list.rkt" for-listable)
          (submod "string.rkt" static-infos))
 
@@ -54,6 +55,8 @@
   #:translucent
   #:fields
   ([bytes Path.bytes #,(get-bytes-static-infos)])
+  #:namespace-fields
+  ([current_directory current-directory])
   #:properties
   ()
   #:methods
@@ -70,6 +73,11 @@
     [(bytes? c) (bytes->path c)]
     [(string? c) (string->path c)]
     [else (raise-annotation-failure who c "String || Bytes || Path")]))
+
+(define-static-info-syntax current-directory
+  (#%function-arity 3)
+  (#%call-result #,(get-path-static-infos))
+  . #,(get-function-static-infos))
 
 (define/method (Path.bytes s)
   #:primitive (path->bytes)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -62,7 +62,7 @@
   ()
   #:methods
   (bytes
-   extend
+   add
    parts
    string
    to_absolute_path
@@ -101,7 +101,7 @@
   #:static-infos ((#%call-result #,(get-bytes-static-infos)))
   (bytes->immutable-bytes (path->bytes s)))
 
-(define/method (Path.extend p . ss)
+(define/method (Path.add p . ss)
   #:primitive (build-path)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
   (apply build-path p ss))

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -67,7 +67,7 @@
    extend
    parts
    string
-   to_complete_path
+   to_absolute_path
    only
    add_suffix))
 
@@ -127,7 +127,7 @@
   #:static-infos ((#%call-result #,(get-string-static-infos)))
   (string->immutable-string (path->string s)))
 
-(define/method (Path.to_complete_path p #:relative_to [base-path (current-directory)])
+(define/method (Path.to_absolute_path p #:relative_to [base-path (current-directory)])
   #:primitive (path->complete-path)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
   (path->complete-path p base-path))

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -69,7 +69,8 @@
    string
    to_complete_path
    write_with
-   only))
+   only
+   add_suffix))
 
 (define/arity #:name Path (path c)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
@@ -106,6 +107,11 @@
 (define/method (Path.only p)
   #:primitive (path-only)
   (path-only p))
+
+(define/method (Path.add_suffix p sfx)
+  #:primitive (path-add-suffix)
+  #:static-infos ((#%call-result #,(get-path-static-infos)))
+  (path-add-suffix p sfx))
 
 (define/method (Path.read_with p f)
   #:primitive (call-with-input-file)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -63,7 +63,7 @@
   #:methods
   (bytes
    add
-   parts
+   split
    string
    to_absolute_path
    directory_only
@@ -106,7 +106,7 @@
   #:static-infos ((#%call-result #,(get-path-static-infos)))
   (apply build-path p ss))
 
-(define/method (Path.parts p)
+(define/method (Path.split p)
   #:primitive (explode-path)
   #:static-infos ((#%call-result #,(get-treelist-static-infos)))
   (to-treelist #f (explode-path p)))

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -66,7 +66,7 @@
    parts
    string
    to_absolute_path
-   only
+   directory_only
    add_suffix))
 
 (define/arity #:name Path (path c)
@@ -111,7 +111,7 @@
   #:static-infos ((#%call-result #,(get-treelist-static-infos)))
   (to-treelist #f (explode-path p)))
 
-(define/method (Path.only p)
+(define/method (Path.directory_only p)
   #:primitive (path-only)
   (path-only p))
 

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -57,13 +57,14 @@
   #:fields
   ([bytes Path.bytes #,(get-bytes-static-infos)])
   #:namespace-fields
-  ([current_directory current-directory])
+  ([Absolute Path.Absolute]
+   [Relative Path.Relative]
+   [current_directory current-directory])
   #:properties
   ()
   #:methods
   (bytes
    extend
-   is_absolute
    parts
    string
    to_complete_path
@@ -77,6 +78,20 @@
     [(bytes? c) (bytes->path c)]
     [(string? c) (string->path c)]
     [else (raise-annotation-failure who c "String || Bytes || Path")]))
+
+(define (path-is-absolute? v)
+  (and (path? v)
+       (absolute-path? v)))
+
+(define (path-is-relative? v)
+  (and (path? v)
+       (not (absolute-path? v))))
+
+(define-annotation-syntax Path.Absolute
+  (identifier-annotation path-is-absolute? #,(get-path-static-infos)))
+
+(define-annotation-syntax Path.Relative
+  (identifier-annotation path-is-relative? #,(get-path-static-infos)))
 
 (define-static-info-syntax current-directory
   (#%function-arity 3)
@@ -92,10 +107,6 @@
   #:primitive (build-path)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
   (apply build-path p ss))
-
-(define/method (Path.is_absolute p)
-  #:primitive (absolute-path?)
-  (absolute-path? p))
 
 (define/method (Path.parts p)
   #:primitive (explode-path)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -65,10 +65,8 @@
    extend
    is_absolute
    parts
-   read_with
    string
    to_complete_path
-   write_with
    only
    add_suffix))
 
@@ -113,10 +111,6 @@
   #:static-infos ((#%call-result #,(get-path-static-infos)))
   (path-add-suffix p sfx))
 
-(define/method (Path.read_with p f)
-  #:primitive (call-with-input-file)
-  (call-with-input-file p f))
-
 (define/method (Path.string s)
   #:primitive (path->string)
   #:static-infos ((#%call-result #,(get-string-static-infos)))
@@ -126,9 +120,5 @@
   #:primitive (path->complete-path)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
   (path->complete-path p base-path))
-
-(define/method (Path.write_with p f #:exists [exists 'error])
-  #:primitive (call-with-output-file)
-  (call-with-output-file p f #:exists exists))
 
 (define-annotation-syntax PathString (identifier-annotation path-string? ()))

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -6,7 +6,6 @@
          "annotation-failure.rkt"
          "call-result-key.rkt"
          "define-arity.rkt"
-         "append-key.rkt"
          "compare-key.rkt"
          "index-result-key.rkt"
          "static-info.rkt"
@@ -45,8 +44,7 @@
 (define-primitive-class Path path
   #:lift-declaration
   #:no-constructor-static-info
-  #:instance-static-info ((#%append Path.extend)
-                          (#%compare ((< path<?)
+  #:instance-static-info ((#%compare ((< path<?)
                                       (<= path<=?)
                                       (> path>?)
                                       (>= path>=?)

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -50,7 +50,8 @@
    [open_string Port.Input.open_string])
   #:properties ()
   #:methods
-  ([peek_byte Port.Input.peek_byte]
+  ([close Port.Input.close]
+   [peek_byte Port.Input.peek_byte]
    [peek_bytes Port.Input.peek_bytes]
    [peek_char Port.Input.peek_char]
    [peek_string Port.Input.peek_string]
@@ -77,7 +78,8 @@
    ExistsFlag)
   #:properties ()
   #:methods
-  ([flush Port.Output.flush]
+  ([close Port.Output.close]
+   [flush Port.Output.flush]
    [print Port.Output.print]
    [println Port.Output.println]
    [show Port.Output.show]
@@ -188,6 +190,10 @@
     [(string? v) (string->immutable-string v)]
     [else v]))
 
+(define/method (Port.Input.close port)
+  #:primitive (close-input-port)
+  (close-input-port port))
+
 (define/method (Port.Input.peek_byte port #:skip_bytes [skip 0])
   #:primitive (peek-byte)
   (peek-byte port skip))
@@ -230,6 +236,10 @@
 (define/method (Port.Input.read_string port amt)
   #:primitive (read-string)
   (coerce-read-result (read-string amt port)))
+
+(define/method (Port.Output.close port)
+  #:primitive (close-output-port)
+  (close-output-port port))
 
 (define/method (Port.Output.get_bytes port)
   #:primitive (get-output-bytes)

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -71,7 +71,8 @@
    [open_bytes Port.Output.open_bytes]
    [open_string Port.Output.open_string]
    [get_bytes Port.Output.get_bytes]
-   [get_string Port.Output.get_string])
+   [get_string Port.Output.get_string]
+   ExistsFlag)
   #:properties ()
   #:methods
   ([flush Port.Output.flush]
@@ -124,6 +125,16 @@
   any
   [any_one any-one])
 
+(define-simple-symbol-enum ExistsFlag
+  error
+  replace
+  truncate
+  [must_truncate must-truncate]
+  [truncate_replace truncate/replace]
+  update
+  [can_update can-update]
+  append)
+
 (define (check-input-port who ip)
   (unless (input-port? ip)
     (raise-annotation-failure who ip "Port.Input")))
@@ -139,6 +150,11 @@
     [(bstr) (open-input-bytes bstr)]
     [(bstr name) (open-input-bytes bstr name)]))
 
+(define/arity (Port.Input.open_file path)
+  #:primitive (open-input-file)
+  #:static-infos ((#%call-result #,(get-input-port-static-infos)))
+  (open-input-file path))
+
 (define/arity Port.Input.open_string
   #:primitive (open-input-string)
   #:static-infos ((#%call-result #,(get-input-port-static-infos)))
@@ -152,6 +168,11 @@
   (case-lambda
     [() (open-output-bytes)]
     [(name) (open-output-bytes name)]))
+
+(define/arity (Port.Output.open_file path #:exists [exists 'error])
+  #:primitive (open-output-file)
+  #:static-infos ((#%call-result #,(get-output-port-static-infos)))
+  (open-output-file path #:exists (->ExistsFlag exists)))
 
 (define/arity Port.Output.open_string
   #:primitive (open-output-string)

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -46,6 +46,7 @@
   ([String Port.Input.String]
    [current current-input-port]
    [open_bytes Port.Input.open_bytes]
+   [open_file Port.Input.open_file]
    [open_string Port.Input.open_string])
   #:properties ()
   #:methods
@@ -69,6 +70,7 @@
    [current current-output-port]
    [current_error current-error-port]
    [open_bytes Port.Output.open_bytes]
+   [open_file Port.Output.open_file]
    [open_string Port.Output.open_string]
    [get_bytes Port.Output.get_bytes]
    [get_string Port.Output.get_string]

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -173,10 +173,13 @@
     [() (open-output-bytes)]
     [(name) (open-output-bytes name)]))
 
-(define/arity (Port.Output.open_file path #:exists [exists 'error])
+(define/arity (Port.Output.open_file path #:exists [exists-in 'error])
   #:primitive (open-output-file)
   #:static-infos ((#%call-result #,(get-output-port-static-infos)))
-  (open-output-file path #:exists (->ExistsFlag exists)))
+  (define exists (->ExistsFlag exists-in))
+  (unless exists
+    (raise-annotation-failure who exists-in "Port.Output.ExistsFlag"))
+  (open-output-file path #:exists exists))
 
 (define/arity Port.Output.open_string
   #:primitive (open-output-string)

--- a/rhombus-lib/rhombus/private/amalgam/print.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/print.rkt
@@ -155,7 +155,10 @@
        [(display?)
         (display v op)]
        [else
-        (write v op)])]
+        (concat
+         (display "Path(" op)
+         (write (path->string v) op)
+         (display ")" op))])]
     [(and (procedure? v)
           (not (printer-ref v #f)))
      (define name (object-name v))

--- a/rhombus-scribble-lib/rhombus/scribble/private/rhombus-doc.rkt
+++ b/rhombus-scribble-lib/rhombus/scribble/private/rhombus-doc.rkt
@@ -221,7 +221,7 @@
 (define-for-syntax (identifier-macro-extract-name stx space-name)
   (syntax-parse stx
     #:datum-literals (group op quotes)
-    [(group _::doc-form (quotes (group (~var id (identifier-target space-name)) . _))) #'id.name]
+    [(group _::doc-form (quotes (group (~var id (identifier-target space-name)) . _) . _)) #'id.name]
     [(group _::doc-form (quotes (~var id (identifier-target space-name)))) #'id.name]))
 
 (define-for-syntax (operator-macro-extract-name stx space-name)
@@ -242,8 +242,10 @@
 (define-for-syntax (identifier-macro-extract-metavariables stx space-name vars)
   (syntax-parse stx
     #:datum-literals (group op quotes)
-    [(group _::doc-form (quotes (group (~var _ (identifier-target space-name)) t ...)))
-     (extract-pattern-metavariables #'(group t ...) vars)]
+    [(group _::doc-form (quotes (group (~var _ (identifier-target space-name)) t ...)
+                                (group t2 ...)
+                                ...))
+     (extract-pattern-metavariables #'(group t ... t2 ... ...) vars)]
     [(group _::doc-form (quotes (~var _ (identifier-target space-name))))
      vars]))
 
@@ -276,10 +278,13 @@
 (define-for-syntax (identifier-macro-extract-typeset stx space-name subst)
   (syntax-parse stx
     #:datum-literals ($ group op quotes)
-    [(group _::doc-form (quotes (~and g (group (~var id (identifier-target space-name)) e ...))))
+    [(group _::doc-form (quotes (~and g (group (~var id (identifier-target space-name)) e ...)) g2 ...))
      (rb #:at #'g
          #:pattern? #t
-         #`(group #,@(subst #'id.name) e ...))]
+         #`(multi
+            (group #,@(subst #'id.name) e ...)
+            g2
+            ...))]
     [(group _::doc-form (quotes (~var id (identifier-target space-name))))
      #`(paragraph plain #,(subst #'id.name))]))
 
@@ -325,6 +330,13 @@
   identifier-macro-extract-typeset)
 
 (define-doc defn.macro defn
+  "definition"
+  rhombus/defn
+  identifier-macro-extract-name
+  identifier-macro-extract-metavariables
+  identifier-macro-extract-typeset)
+
+(define-doc defn.sequence_macro defn
   "definition"
   rhombus/defn
   identifier-macro-extract-name

--- a/rhombus-scribble-lib/rhombus/scribble/private/typeset-doc.rkt
+++ b/rhombus-scribble-lib/rhombus/scribble/private/typeset-doc.rkt
@@ -883,11 +883,17 @@
                                            [(_ a . _) #'a]))
                           "")]
                 [(option ...) options])
-    #'(rhombus-expression (group rhombusblock_etc option ... (t-block t-form)))))
+    (with-syntax ([body (syntax-parse form
+                          #:datum-literals (multi group)
+                          [(group . _) #'(t-block t-form)]
+                          [(multi g g2 ...) #'(t-block g g2 ...)])])
+      #'(rhombus-expression (group rhombusblock_etc option ... body)))))
 
 (define-for-syntax (drop-pattern-escapes g)
   (syntax-parse g
-    #:datum-literals (group)
+    #:datum-literals (group multi)
+    [((~and m multi) g ...)
+     #`(m ,@(map drop-pattern-escapes (syntax->list #'(g ...))))]
     [((~and g group) t ...)
      (define new-ts
        (let loop ([ts (syntax->list #'(t ...))])

--- a/rhombus/rhombus/scribblings/reference/appendable.scrbl
+++ b/rhombus/rhombus/scribblings/reference/appendable.scrbl
@@ -29,6 +29,7 @@ An @deftech{appendable} value is one that supports @rhombus(++). Maps,
   operator ((v1 :: ReadableString) ++ (v2 :: ReadableString))
     :: String
   operator ((v1 :: Bytes) ++ (v2 :: Bytes)) :: MutableBytes
+  operator ((v1 :: Path) ++ (v2 :: PathString)) :: Path
   operator ((v1 :: Appendable) ++ (v2 :: Appendable)) :: Any
 ){
 

--- a/rhombus/rhombus/scribblings/reference/appendable.scrbl
+++ b/rhombus/rhombus/scribblings/reference/appendable.scrbl
@@ -29,7 +29,6 @@ An @deftech{appendable} value is one that supports @rhombus(++). Maps,
   operator ((v1 :: ReadableString) ++ (v2 :: ReadableString))
     :: String
   operator ((v1 :: Bytes) ++ (v2 :: Bytes)) :: MutableBytes
-  operator ((v1 :: Path) ++ (v2 :: PathString)) :: Path
   operator ((v1 :: Appendable) ++ (v2 :: Appendable)) :: Any
 ){
 

--- a/rhombus/rhombus/scribblings/reference/closeable.scrbl
+++ b/rhombus/rhombus/scribblings/reference/closeable.scrbl
@@ -1,0 +1,73 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open)
+
+@title{Closeables}
+
+The @rhombus(Closeable.let) definition form binds a name to a closeable
+object and injects a call to @rhombus(Closeable.close) to close the
+object after subsequent definitions and expressions. Implementing the
+@rhombus(Closeable) interface allows an object to cooperate with
+@rhombus(Closeable.let).
+
+@doc(
+  defn.sequence_macro 'Closeable.let $bind = $rhs
+                       $body
+                       ...'
+){
+
+ Evaluates @rhombus(rhs) to get a @rhombus(Closeable) object and defines
+ @rhombus(bind) as the result for use in the @rhombus(body) sequence
+ (which must be non-empty). After the @rhombus(body) sequence completes,
+ the object is closed with @rhombus(Closeable.close) before returning the
+ results of the @rhombus(body) sequence.
+
+ The @rhombus(rhs) is evaluated with breaks disabled like the
+ @rhombus(~initially) part of @rhombus(try). If control escapes from the
+ @rhombus(body) sequence (e.g., because an exception is raised), then the
+ object produced by @rhombus(rhs) is closed before escaping, and breaks
+ are disabled during that close as in the @rhombus(~finally) part of
+ @rhombus(try). Consequently, in the case of a break exception, the
+ object is reliably closed or not yet opened by @rhombus(rhs). A
+ continuation jump back into the @rhombus(body) sequence is disallowed
+ via @rhombus(Continuation.barrier).
+
+@examples(
+  ~fake:
+    block:
+      Closeable.let i = Port.Input.open_file("data.txt")
+      i.read_line()
+      // `i` is closed after this point
+    "file content"
+)
+
+}
+
+@doc(
+  interface Closeable
+){
+
+ An interface that a class can implement (publicly or privately) to
+ customize the way its objects close, especially with @rhombus(Closeable.let).
+
+ The @rhombus(Closeable) interface has one method:
+
+@itemlist(
+
+ @item{@rhombus(#,(@rhombus(close, ~datum))()) --- closes the object.
+  Closing an already-closed object should succeed without any effect. The
+  result should normally be @rhombus(#void), but the result is not
+  specifically constrained by the @rhombus(Closeable) interface.}
+
+)
+
+}
+
+@doc(
+  fun Closeable.close(c :: Closeable) :: Void
+){
+
+ Calls the @rhombus(close, ~datum) method of @rhombus(c), then returns
+ @rhombus(#void).
+
+}

--- a/rhombus/rhombus/scribblings/reference/continuation.scrbl
+++ b/rhombus/rhombus/scribblings/reference/continuation.scrbl
@@ -127,6 +127,31 @@
 }
 
 @doc(
+  expr.macro 'Continuation.barrier:
+                $body
+                ...'
+){
+
+ Like @rhombus(block), but disallowing a continuation capture during the
+ @rhombus(body) that extends to the context of the
+ @rhombus(Continuation.barrier) form.
+
+@examples(
+  ~error:
+    Continuation.barrier:
+      Continuation.capture k:
+        "done"
+  Continuation.barrier:
+    Continuation.prompt:
+      Continuation.capture k:
+        k
+)
+
+}
+
+
+
+@doc(
   annot.macro 'Continuation.Marks'
 ){
 

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -14,7 +14,9 @@ A @deftech{path} value represents a filesystem path.
   path.extend(part, ...)
   path.is_absolute()
   path.parts()
+  path.read_with(proc)
   path.string()
+  path.write_with(proc, ...)
 )
 
 Paths are @tech{comparable}, which means that generic operations like
@@ -140,6 +142,29 @@ Paths are @tech{comparable}, which means that generic operations like
   Path.parts(p)
   p.parts()
 )
+
+}
+
+@doc(
+  fun Path.read_with(path :: Path, read_proc :: Function.of_arity(1))
+){
+
+ Opens @rhombus(path) for reading and calls @rhombus(read_proc) with the
+ @tech{input port}.  The result of @rhombus(read_proc) is the result of
+ @rhombus(Path.read_with).
+
+}
+
+@doc(
+  fun Path.write_with(path :: Path,
+                      proc :: Function.of_arity(1),
+                      ~exists: exists_flag
+                                 :: Port.Output.ExistsFlag = #'error)
+){
+
+ Opens @rhombus(path) for writing and calls @rhombus(write_proc) with the
+ @tech{output port}.  The result of @rhombus(write_proc) is the result of
+ @rhombus(Path.write_with).
 
 }
 

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -11,6 +11,7 @@ A @deftech{path} value represents a filesystem path.
   "path"
   Path
   path.bytes()
+  path.extend(part, ...)
   path.parts()
   path.string()
 )
@@ -77,6 +78,46 @@ Paths are @tech{comparable}, which means that generic operations like
 
 }
 
+@doc(
+  fun Path.extend(path :: Path,
+                  part :: PathString | #'up | #'same, ...) :: Path
+){
+
+  Creates a path given a base path and any number of sub-path
+  extensions. See also @rhombus(++).  If @rhombus(path) is an absolute path,
+  the result is an absolute path, otherwise the result is a relative path.
+
+  The @rhombus(path) and each @rhombus(part) must be either a relative
+  path, the symbol @rhombus(#'up) (indicating the relative parent
+  directory), or the symbol @rhombus(#'same) (indicating the
+  relative current directory).  For Windows paths, if @rhombus(path) is a
+  drive specification (with or without a trailing slash) the first
+  @rhombus(part) can be an absolute (driveless) path. For all platforms,
+  the last @rhombus(part) can be a filename.
+
+  The @rhombus(path) and @rhombus(part) arguments can be paths for
+  any platform. The platform for the resulting path is inferred from the
+  @rhombus(path) and @rhombus(part) arguments, where string arguments imply
+  a path for the current platform. If different arguments are for
+  different platforms, the @rhombus(Exn.Fail.Contract, ~class) exception
+  is thrown.  If no argument implies a platform (i.e., all are @rhombus(#'up)
+  or @rhombus(#'same)), the generated path is for the current platform.
+
+  Each @rhombus(part) and @rhombus(path) can optionally end in a directory
+  separator. If the last @rhombus(part) ends in a separator, it is
+  included in the resulting path.
+
+  The @rhombus(build-path) procedure builds a path @italic{without}
+  checking the validity of the path or accessing the filesystem.
+
+@examples(
+  def p = Path("/home/rhombus")
+  Path.extend(p, "shape.txt")
+  p.extend("shape.txt")
+  p ++ "shape.txt"
+)
+
+}
 @doc(
   fun Path.parts(path :: Path) :: List.of(Path || #'up || #'same)
 ){

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -11,6 +11,7 @@ A @deftech{path} value represents a filesystem path.
   "path"
   Path
   path.bytes()
+  path.parts()
   path.string()
 )
 
@@ -72,6 +73,23 @@ Paths are @tech{comparable}, which means that generic operations like
   def p = Path("/home/rhombus/shape.txt")
   Path.bytes(p)
   p.bytes()
+)
+
+}
+
+@doc(
+  fun Path.parts(path :: Path) :: List.of(Path || #'up || #'same)
+){
+
+  Returns a list of path elements that constitute @rhombus(path).
+
+  The @rhombus(Path.parts) function computes its result in time
+  proportional to the length of @rhombus(path).
+
+@examples(
+  def p = Path("/home/rhombus/shape.txt")
+  Path.parts(p)
+  p.parts()
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -19,13 +19,20 @@ Paths are @tech{comparable}, which means that generic operations like
 
 @doc(
   annot.macro 'Path'
+  annot.macro 'PathString'
+  annot.macro 'PathString.to_path'
 ){
 
- Matches a path value.
+ Matches a path value.  The @rhombus(PathString, ~annot) annotation allows
+ @rhombus(ReadableString, ~annot) as well as @rhombus(Path, ~annot) values.
+ The @rhombus(PathString.to_path, ~annot)
+ @tech(~doc: guide_doc){converter annotation} allows
+ @rhombus(PathString, ~annot) values, but converts
+ @rhombus(ReadableString, ~annot) values to @rhombus(Path) values.
 }
 
 @doc(
-  fun Path(path :: Bytes || String || Path) :: Path
+  fun Path(path :: Bytes || ReadableString || Path) :: Path
 ){
 
  Constructs a path given a byte string, string, or existing path. When a

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -184,6 +184,19 @@ Paths are @tech{comparable}, which means that generic operations like
 
 }
 
+@doc(
+  fun Path.only(path :: PathString) :: Path
+){
+
+ Returns @rhombus(path) without its final path element in the case
+ that @rhombus(path) is not syntactically a directory; if
+ @rhombus(path) has only a single, non-directory path element, #f is
+ returned. If @rhombus(path) is syntactically a directory, then
+ @rhombus(path) is returned unchanged (but as a path, if it was a
+ string).
+
+}
+
 @// ------------------------------------------------------------
 
 @include_section("runtime-path.scrbl")

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -12,6 +12,7 @@ A @deftech{path} value represents a filesystem path.
   Path
   path.bytes()
   path.extend(part, ...)
+  path.is_absolute()
   path.parts()
   path.string()
 )
@@ -118,6 +119,13 @@ Paths are @tech{comparable}, which means that generic operations like
 )
 
 }
+
+@doc(fun Path.is_absolute(path :: Path)){
+
+ Returns @rhombus(#true) if @rhombus(path) is an absolute path, @rhombus(#false)
+ otherwise.  This procedure does not access the filesystem.
+}
+
 @doc(
   fun Path.parts(path :: Path) :: List.of(Path || #'up || #'same)
 ){

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -145,7 +145,7 @@ Paths are @tech{comparable}, which means that generic operations like
 }
 
 @doc(
-  fun Path.split(path :: Path) :: List.of(Path || #'up || #'same)
+  fun Path.split(path :: PathString) :: List.of(Path || #'up || #'same)
 ){
 
   Returns a list of path elements that constitute @rhombus(path).

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -12,7 +12,7 @@ A @deftech{path} value represents a filesystem path.
   Path
   path.bytes()
   path.add(part, ...)
-  path.parts()
+  path.split()
   path.string()
   path.to_absolute_path(...)
 )
@@ -139,18 +139,18 @@ Paths are @tech{comparable}, which means that generic operations like
 }
 
 @doc(
-  fun Path.parts(path :: Path) :: List.of(Path || #'up || #'same)
+  fun Path.split(path :: Path) :: List.of(Path || #'up || #'same)
 ){
 
   Returns a list of path elements that constitute @rhombus(path).
 
-  The @rhombus(Path.parts) function computes its result in time
+  The @rhombus(Path.split) function computes its result in time
   proportional to the length of @rhombus(path).
 
 @examples(
   def p = Path("/home/rhombus/shape.txt")
-  Path.parts(p)
-  p.parts()
+  Path.split(p)
+  p.split()
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -172,7 +172,7 @@ Paths are @tech{comparable}, which means that generic operations like
 }
 
 @doc(
-  fun Path.only(path :: PathString) :: Path
+  fun Path.directory_only(path :: PathString) :: Path
 ){
 
  Returns @rhombus(path) without its final path element in the case

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -93,12 +93,17 @@ Paths are @tech{comparable}, which means that generic operations like
 }
 
 @doc(
-  fun Path.extend(path :: Path,
-                  part :: PathString | #'up | #'same, ...) :: Path
+  fun Path.extend(path :: PathString,
+                  part :: PathString
+                    || matching(#'up)
+                    || matching(#'same), ...) :: Path
+  operator ((base :: PathString) +/ (part :: PathString
+                                       || matching(#'up)
+                                       || matching(#'same))) :: Path
 ){
 
   Creates a path given a base path and any number of sub-path
-  extensions. See also @rhombus(++).  If @rhombus(path) is an absolute path,
+  extensions. If @rhombus(path) is an absolute path,
   the result is an absolute path, otherwise the result is a relative path.
 
   The @rhombus(path) and each @rhombus(part) must be either a relative
@@ -121,14 +126,14 @@ Paths are @tech{comparable}, which means that generic operations like
   separator. If the last @rhombus(part) ends in a separator, it is
   included in the resulting path.
 
-  The @rhombus(build-path) procedure builds a path @italic{without}
+  The @rhombus(Path.extend) procedure builds a path @italic{without}
   checking the validity of the path or accessing the filesystem.
 
 @examples(
   def p = Path("/home/rhombus")
   Path.extend(p, "shape.txt")
   p.extend("shape.txt")
-  p ++ "shape.txt"
+  p +/ "shape.txt"
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -14,9 +14,7 @@ A @deftech{path} value represents a filesystem path.
   path.extend(part, ...)
   path.is_absolute()
   path.parts()
-  path.read_with(proc)
   path.string()
-  path.write_with(proc, ...)
 )
 
 Paths are @tech{comparable}, which means that generic operations like
@@ -142,29 +140,6 @@ Paths are @tech{comparable}, which means that generic operations like
   Path.parts(p)
   p.parts()
 )
-
-}
-
-@doc(
-  fun Path.read_with(path :: Path, read_proc :: Function.of_arity(1))
-){
-
- Opens @rhombus(path) for reading and calls @rhombus(read_proc) with the
- @tech{input port}.  The result of @rhombus(read_proc) is the result of
- @rhombus(Path.read_with).
-
-}
-
-@doc(
-  fun Path.write_with(path :: Path,
-                      proc :: Function.of_arity(1),
-                      ~exists: exists_flag
-                                 :: Port.Output.ExistsFlag = #'error)
-){
-
- Opens @rhombus(path) for writing and calls @rhombus(write_proc) with the
- @tech{output port}.  The result of @rhombus(write_proc) is the result of
- @rhombus(Path.write_with).
 
 }
 

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -12,7 +12,6 @@ A @deftech{path} value represents a filesystem path.
   Path
   path.bytes()
   path.extend(part, ...)
-  path.is_absolute()
   path.parts()
   path.string()
 )
@@ -24,6 +23,8 @@ Paths are @tech{comparable}, which means that generic operations like
   annot.macro 'Path'
   annot.macro 'PathString'
   annot.macro 'PathString.to_path'
+  annot.macro 'Path.Absolute'
+  annot.macro 'Path.Relative'
 ){
 
  Matches a path value.  The @rhombus(PathString, ~annot) annotation allows
@@ -32,6 +33,11 @@ Paths are @tech{comparable}, which means that generic operations like
  @tech(~doc: guide_doc){converter annotation} allows
  @rhombus(PathString, ~annot) values, but converts
  @rhombus(ReadableString, ~annot) values to @rhombus(Path) values.
+
+ The @rhombus(Path.Absolute, ~annot) annotation only matches
+ @rhombus(Path, ~annot)s that begin with the root directory of the filesystem
+ or drive.  The @rhombus(Path.Relative, ~annot) annotation only matches
+ @rhombus(Path, ~annot)s that are relative to some base directory.
 }
 
 @doc(
@@ -118,12 +124,6 @@ Paths are @tech{comparable}, which means that generic operations like
   p ++ "shape.txt"
 )
 
-}
-
-@doc(fun Path.is_absolute(path :: Path)){
-
- Returns @rhombus(#true) if @rhombus(path) is an absolute path, @rhombus(#false)
- otherwise.  This procedure does not access the filesystem.
 }
 
 @doc(

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -78,6 +78,12 @@ Paths are @tech{comparable}, which means that generic operations like
 }
 
 @doc(
+  Parameter.def Path.current_directory :: Path
+){
+  A @tech{context parameter} for the current directory.
+}
+
+@doc(
   fun Path.bytes(path :: Path) :: Bytes
 ){
 

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -14,6 +14,7 @@ A @deftech{path} value represents a filesystem path.
   path.extend(part, ...)
   path.parts()
   path.string()
+  path.to_absolute_path(...)
 )
 
 Paths are @tech{comparable}, which means that generic operations like
@@ -22,6 +23,8 @@ Paths are @tech{comparable}, which means that generic operations like
 @doc(
   annot.macro 'Path'
   annot.macro 'PathString'
+  annot.macro 'PathString.to_absolute_path'
+  annot.macro 'PathString.to_absolute_path(~relative_to: base :: PathString)'
   annot.macro 'PathString.to_path'
   annot.macro 'Path.Absolute'
   annot.macro 'Path.Relative'
@@ -32,7 +35,11 @@ Paths are @tech{comparable}, which means that generic operations like
  The @rhombus(PathString.to_path, ~annot)
  @tech(~doc: guide_doc){converter annotation} allows
  @rhombus(PathString, ~annot) values, but converts
- @rhombus(ReadableString, ~annot) values to @rhombus(Path) values.
+ @rhombus(ReadableString, ~annot) values to @rhombus(Path) values.  Similarly
+ @rhombus(PathString.to_absolute_path, ~annot) is a converter annotation that
+ converts a @rhombus(PathString, ~annot) into an absolute path relative to
+ @rhombus(Path.current_directory()) or to the specified @rhombus(base)
+ directory.
 
  The @rhombus(Path.Absolute, ~annot) annotation only matches
  @rhombus(Path, ~annot)s that begin with the root directory of the filesystem
@@ -170,6 +177,20 @@ Paths are @tech{comparable}, which means that generic operations like
  @rhombus(path) is returned unchanged (but as a path, if it was a
  string).
 
+}
+
+@doc(
+  fun Path.to_absolute_path(path :: PathString,
+                            ~relative_to: base
+                                          :: PathString
+                                            = Path.current_directory())
+    :: Path
+){
+ Returns @rhombus(path) as an absolute path. If @rhombus(path) is already an
+ absolute path, it is returned as the result. Otherwise, @rhombus(path) is
+ resolved with respect to the absolute path @rhombus(base). If @rhombus(base) is
+ not an absolute path, the @rhombus(Exn.Fail.Contract, ~class) exception is
+ thrown.
 }
 
 @// ------------------------------------------------------------

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -11,7 +11,7 @@ A @deftech{path} value represents a filesystem path.
   "path"
   Path
   path.bytes()
-  path.extend(part, ...)
+  path.add(part, ...)
   path.parts()
   path.string()
   path.to_absolute_path(...)
@@ -93,10 +93,10 @@ Paths are @tech{comparable}, which means that generic operations like
 }
 
 @doc(
-  fun Path.extend(path :: PathString,
-                  part :: PathString
-                    || matching(#'up)
-                    || matching(#'same), ...) :: Path
+  fun Path.add(path :: PathString,
+               part :: PathString
+                 || matching(#'up)
+                 || matching(#'same), ...) :: Path
   operator ((base :: PathString) +/ (part :: PathString
                                        || matching(#'up)
                                        || matching(#'same))) :: Path
@@ -126,13 +126,13 @@ Paths are @tech{comparable}, which means that generic operations like
   separator. If the last @rhombus(part) ends in a separator, it is
   included in the resulting path.
 
-  The @rhombus(Path.extend) procedure builds a path @italic{without}
+  The @rhombus(Path.add) procedure builds a path @italic{without}
   checking the validity of the path or accessing the filesystem.
 
 @examples(
   def p = Path("/home/rhombus")
-  Path.extend(p, "shape.txt")
-  p.extend("shape.txt")
+  Path.add(p, "shape.txt")
+  p.add("shape.txt")
   p +/ "shape.txt"
 )
 

--- a/rhombus/rhombus/scribblings/reference/port.scrbl
+++ b/rhombus/rhombus/scribblings/reference/port.scrbl
@@ -113,6 +113,14 @@ output. Moreover, an @deftech{input string port} or an
 }
 
 @doc(
+  fun Port.Input.open_file(file :: PathString) :: Port.Input
+){
+
+ Creates an @tech{input port} that reads from the @tech{path} @rhombus(file).
+
+}
+
+@doc(
   fun Port.Input.open_string(str :: ReadableString,
                              name :: Symbol = #'string)
     :: Port.Input.String
@@ -315,6 +323,51 @@ output. Moreover, an @deftech{input string port} or an
 }
 
 @doc(
+  fun Port.Output.open_file(path :: PathString,
+                            ~exists: exists_flag
+                                       :: Port.Output.ExistsFlag = #'error)
+    :: Port.Output
+){
+
+ Creates an @tech{output port} that writes to the @tech{path} @rhombus(file).
+ The @rhombus(exists_flag) argument specifies how to handle/require
+ files that already exist:
+
+ @itemlist(
+
+  @item{@rhombus(#'error) --- throws @rhombus(Exn.Fail.Filesystem.Exists)
+        if the file exists.}
+
+  @item{@rhombus(#'replace) --- remove the old file, if it
+        exists, and write a new one.}
+
+  @item{@rhombus(#'truncate) --- remove all old data, if the file
+        exists.}
+
+  @item{@rhombus(#'must_truncate) --- remove all old data in an
+        existing file; if the file does not exist, the
+        @rhombus(Exn.Fail.Filesystem) exception is thrown.}
+
+  @item{@rhombus(#'truncate_replace) --- try @rhombus(#'truncate);
+        if it fails (perhaps due to file permissions), try
+        @rhombus(#'replace).}
+
+  @item{@rhombus(#'update) --- open an existing file without
+        truncating it; if the file does not exist, the
+        @rhombus(Exn.Fail.Filesystem) exception is thrown.}
+
+  @item{@rhombus(#'can_update) --- open an existing file without
+        truncating it, or create the file if it does not exist.}
+
+  @item{@rhombus(#'append) --- append to the end of the file,
+        whether it already exists or not; on Windows,
+        @rhombus(#'append) is equivalent to @rhombus(#'update), except that
+        the file is not required to exist, and the file position is
+        immediately set to the end of the file after opening it.}
+
+)}
+
+@doc(
   fun Port.Output.open_bytes(name :: Symbol = #'string)
     :: Port.Output.String
   fun Port.Output.open_string(name :: Symbol = #'string)
@@ -355,5 +408,21 @@ output. Moreover, an @deftech{input string port} or an
 ){
 
  Flushes the content of @rhombus(out)'s buffer.
+
+}
+
+@doc(
+  enum Port.Output.ExistsFlag:
+    error
+    append
+    update
+    can_update
+    replace
+    truncate
+    must_truncate
+    truncate_replace
+){
+
+  Flags for handling existing files when opening @tech{output ports}.
 
 }

--- a/rhombus/rhombus/scribblings/reference/protocol.scrbl
+++ b/rhombus/rhombus/scribblings/reference/protocol.scrbl
@@ -12,3 +12,4 @@
 @include_section("appendable.scrbl")
 @include_section("comparable.scrbl")
 @include_section("printable.scrbl")
+@include_section("closeable.scrbl")

--- a/rhombus/rhombus/tests/closeable.rhm
+++ b/rhombus/rhombus/tests/closeable.rhm
@@ -1,0 +1,65 @@
+#lang rhombus
+
+check:
+  "x" is_a Closeable ~is #false
+  Port.Input.open_string("x") is_a Closeable ~is #true
+  Port.Output.open_string() is_a Closeable ~is #true
+
+check:
+  ~eval
+  class Thing():
+    implements Closeable
+  ~throws "final class cannot have abstract methods"
+
+check:
+  ~eval
+  interface Closeable2:
+    method close(): #void
+  class Thing():
+    implements:
+      Closeable
+      Closeable2
+  ~throws "method supplied by multiple superinterfaces and not overridden"
+
+check:
+  ~eval
+  use_static
+  class Thing():
+    implements Closeable
+    override close(x = 1): #void
+  (Thing() :: Closeable).close(1)
+  ~throws values("wrong number of arguments in method call",
+                 "based on static information")
+
+block:
+  use_static
+  class Thing():
+    implements Closeable
+    override method close(): println("bye")
+
+  check: Thing() ~is_a Closeable
+
+  check:
+    (Thing() :: Closeable).close()
+    ~prints "bye\n"
+
+  check:
+    Thing().close()
+    ~prints "bye\n"
+
+  check:
+    Closeable.def c = Thing()
+    println("go")
+    ~prints "go\nbye\n"
+
+  check:
+    Closeable.def c = Thing()
+    c.close()
+    println("go")
+    ~prints "bye\ngo\nbye\n"
+
+check:
+  Closeable.def c = 5
+  #void
+  ~throws values(error.annot_msg(),
+                 error.annot("Closeable").msg)

--- a/rhombus/rhombus/tests/closeable.rhm
+++ b/rhombus/rhombus/tests/closeable.rhm
@@ -48,18 +48,18 @@ block:
     ~prints "bye\n"
 
   check:
-    Closeable.def c = Thing()
+    Closeable.let c = Thing()
     println("go")
     ~prints "go\nbye\n"
 
   check:
-    Closeable.def c = Thing()
+    Closeable.let c = Thing()
     c.close()
     println("go")
     ~prints "bye\ngo\nbye\n"
 
 check:
-  Closeable.def c = 5
+  Closeable.let c = 5
   #void
   ~throws values(error.annot_msg(),
                  error.annot("Closeable").msg)

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -59,3 +59,11 @@ block:
     check p == q ~is #false
     check p != Path("/") ~is #false
     check p != q ~is #true
+
+block:
+  def s = "/etc"
+  def p1 = Path("/etc")
+  def p2 = (s :: PathString.to_path)
+  check p1 compares_equal p2 ~is #true
+  version_guard.at_least "8.13.0.1":
+    check p1 == p2 ~is #true

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -75,3 +75,9 @@ block:
   check p2.parts() ~is [Path("C:"), Path("windows")]
   def p3 = Path("../a/b/./c")
   check p3.parts() ~is [#'up, Path("a"), Path("b"), #'same, Path("c")]
+
+block:
+  check Path("/").extend("etc", Path("passwd")) ~is Path("/etc/passwd")
+  check Path.extend("C:", "win32", "sys") ~is Path("C:/win32/sys")
+  check Path("/") ++ Path("etc") ++ "passwd" ~is Path("/etc/passwd")
+  check Path("..") ++ "a" ++ "b" ++ #'same ++ "c" ~is Path("../a/b/./c")

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -81,3 +81,13 @@ block:
   check Path.extend("C:", "win32", "sys") ~is Path("C:/win32/sys")
   check Path("/") ++ Path("etc") ++ "passwd" ~is Path("/etc/passwd")
   check Path("..") ++ "a" ++ "b" ++ #'same ++ "c" ~is Path("../a/b/./c")
+
+block:
+  def p1 = Path("/etc")
+  def p2 = Path("etc")
+  check Path.is_absolute(p1) ~is #true
+  check Path.is_absolute("/etc") ~is #true
+  check p1.is_absolute() ~is #true
+  check Path.is_absolute(p2) ~is #false
+  check Path.is_absolute("etc") ~is #false
+  check p2.is_absolute() ~is #false

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -67,3 +67,11 @@ block:
   check p1 compares_equal p2 ~is #true
   version_guard.at_least "8.13.0.1":
     check p1 == p2 ~is #true
+
+block:
+  def p1 = Path("/etc/passwd")
+  check p1.parts() ~is [Path("/"), Path("etc"), Path("passwd")]
+  def p2 = Path("C:/windows")
+  check p2.parts() ~is [Path("C:"), Path("windows")]
+  def p3 = Path("../a/b/./c")
+  check p3.parts() ~is [#'up, Path("a"), Path("b"), #'same, Path("c")]

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -77,8 +77,8 @@ block:
   check p3.parts() ~is [#'up, Path("a"), Path("b"), #'same, Path("c")]
 
 block:
-  check Path("/").extend("etc", Path("passwd")) ~is Path("/etc/passwd")
-  check Path.extend("C:", "win32", "sys") ~is Path("C:/win32/sys")
+  check Path("/").add("etc", Path("passwd")) ~is Path("/etc/passwd")
+  check Path.add("C:", "win32", "sys") ~is Path("C:/win32/sys")
   check Path("/") +/ Path("etc") +/ "passwd" ~is Path("/etc/passwd")
   check Path("..") +/ "a" +/ "b" +/ #'same +/ "c" ~is Path("../a/b/./c")
   check "/" +/ "App" ++ "lications" +/ "Racket v10.04" \
@@ -96,7 +96,7 @@ block:
 
 block:
   def p1 = Path("shadow")
-  check p1.to_absolute_path() ~is Path.current_directory().extend("shadow")
+  check p1.to_absolute_path() ~is Path.current_directory().add("shadow")
   check p1.to_absolute_path(~relative_to: "/etc") ~is Path("/etc/shadow")
 
   def p2 :: PathString.to_absolute_path(~relative_to: "/etc") = "shadow"

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -79,8 +79,10 @@ block:
 block:
   check Path("/").extend("etc", Path("passwd")) ~is Path("/etc/passwd")
   check Path.extend("C:", "win32", "sys") ~is Path("C:/win32/sys")
-  check Path("/") ++ Path("etc") ++ "passwd" ~is Path("/etc/passwd")
-  check Path("..") ++ "a" ++ "b" ++ #'same ++ "c" ~is Path("../a/b/./c")
+  check Path("/") +/ Path("etc") +/ "passwd" ~is Path("/etc/passwd")
+  check Path("..") +/ "a" +/ "b" +/ #'same +/ "c" ~is Path("../a/b/./c")
+  check "/" +/ "App" ++ "lications" +/ "Racket v10.04" \
+  ~is Path ("/Applications/Racket v10.04")
 
 block:
   def p1 = Path("/etc")

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -91,3 +91,15 @@ block:
   check p1 is_a Path.Relative ~is #false
   check p2 is_a Path.Absolute ~is #false
   check p2 is_a Path.Relative ~is #true
+
+block:
+  def p1 = Path("shadow")
+  check p1.to_absolute_path() ~is Path.current_directory().extend("shadow")
+  check p1.to_absolute_path(~relative_to: "/etc") ~is Path("/etc/shadow")
+
+  def p2 :: PathString.to_absolute_path(~relative_to: "/etc") = "shadow"
+  check p2 ~is Path("/etc/shadow")
+  check p2.to_absolute_path() ~is Path("/etc/shadow")
+
+  def p3 = Path.to_absolute_path("shadow", ~relative_to: "/etc")
+  check p3 ~is Path("/etc/shadow")

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -85,9 +85,9 @@ block:
 block:
   def p1 = Path("/etc")
   def p2 = Path("etc")
-  check Path.is_absolute(p1) ~is #true
-  check Path.is_absolute("/etc") ~is #true
-  check p1.is_absolute() ~is #true
-  check Path.is_absolute(p2) ~is #false
-  check Path.is_absolute("etc") ~is #false
-  check p2.is_absolute() ~is #false
+  check "/etc" is_a Path.Absolute ~is #false
+  check "etc" is_a Path.Relative ~is #false
+  check p1 is_a Path.Absolute ~is #true
+  check p1 is_a Path.Relative ~is #false
+  check p2 is_a Path.Absolute ~is #false
+  check p2 is_a Path.Relative ~is #true

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -70,11 +70,11 @@ block:
 
 block:
   def p1 = Path("/etc/passwd")
-  check p1.parts() ~is [Path("/"), Path("etc"), Path("passwd")]
+  check p1.split() ~is [Path("/"), Path("etc"), Path("passwd")]
   def p2 = Path("C:/windows")
-  check p2.parts() ~is [Path("C:"), Path("windows")]
+  check p2.split() ~is [Path("C:"), Path("windows")]
   def p3 = Path("../a/b/./c")
-  check p3.parts() ~is [#'up, Path("a"), Path("b"), #'same, Path("c")]
+  check p3.split() ~is [#'up, Path("a"), Path("b"), #'same, Path("c")]
 
 block:
   check Path("/").add("etc", Path("passwd")) ~is Path("/etc/passwd")


### PR DESCRIPTION
Some initial Path integration that I've been poking at for a couple of weeks now.

Initially, I used a veneer for `Path.read_with` and `Path.write_with` that were syntax and would take a block that would become the read (write) procedure.  Once I started thinking about adding the other flags for reading and writing the syntax seemed too messy so I went back to a simple wrapper around `call-with-input-file`/`call-with-output-file`.