### PR TITLE
use "does not satisfy annotation" error consistently

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annot-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annot-macro.rkt
@@ -10,6 +10,7 @@
                      "tail-returner.rkt"
                      "macro-result.rkt"
                      "realm.rkt"
+                     "annotation-failure.rkt"
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
@@ -126,7 +127,7 @@
 
 (define-for-syntax (check-syntax who s)
   (unless (syntax? s)
-    (raise-argument-error* who rhombus-realm "Syntax" s)))
+    (raise-annotation-failure who s "Syntax")))
 
 (define-for-syntax (annotation-kind stx who)
   (check-syntax who stx)
@@ -203,7 +204,7 @@
     #:static-infos ((#%call-result #,(get-syntax-static-infos)))
     (define group (unpack-group stx #f #f))
     (unless group
-      (raise-argument-error* who rhombus-realm "Group" stx))
+      (raise-annotation-failure who stx "Group"))
     (syntax-parse group
       [a::annotation
        #:with ab::annotation-binding-form #'a.parsed

--- a/rhombus-lib/rhombus/private/amalgam/annotation-failure.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation-failure.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+(require "binding-failure.rkt")
+
+(provide raise-annotation-failure)
+
+(define (raise-annotation-failure who val ctc)
+  (raise-binding-failure who "value" val ctc))

--- a/rhombus-lib/rhombus/private/amalgam/annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation.rkt
@@ -22,12 +22,12 @@
          "dotted-sequence-parse.rkt"
          "static-info.rkt"
          "parse.rkt"
-         "realm.rkt"
          "parens.rkt"
          "if-blocked.rkt"
          "number.rkt"
          "is-static.rkt"
-         "rhombus-primitive.rkt")
+         "rhombus-primitive.rkt"
+         "annotation-failure.rkt")
 
 (provide is_a
          (for-spaces (#f
@@ -881,9 +881,6 @@
 (define (raise-::-annotation-failure who val ctc)
   (raise-annotation-failure who val ctc))
 
-(define (raise-annotation-failure who val ctc)
-  (raise-binding-failure who "value" val ctc))
-
 (define-annotation-syntax matching
   (annotation-prefix-operator
    '((default . stronger))
@@ -930,8 +927,7 @@
          #'tail)]))))
 
 (define (raise-predicate-error who val)
-  (raise-argument-error* who rhombus-realm
-                         "Function.of_arity(1)" val))
+  (raise-annotation-failure who val "Function.of_arity(1)"))
 
 ;; `#%parens` is defined in "arrow-annotation.rkt"
 
@@ -960,7 +956,7 @@
         (values (annotation-predicate-form
                  #`(let ([n (rhombus-expression n-g)])
                      (unless (real? n)
-                       (raise-argument-error* '#,id rhombus-realm "Real" n))
+                       (raise-annotation-failure '#,id n "Real"))
                      (lambda (v)
                        (and (real? v)
                             (#,comp-stx v n))))
@@ -998,9 +994,9 @@
                  #`(let ([lo-v (rhombus-expression lo.g)]
                          [hi-v (rhombus-expression hi.g)])
                      (unless (#,pred-stx lo-v)
-                       (raise-argument-error* 'form-id rhombus-realm '#,annot-str lo-v))
+                       (raise-annotation-failure 'form-id lo-v '#,annot-str))
                      (unless (#,pred-stx hi-v)
-                       (raise-argument-error* 'form-id rhombus-realm '#,annot-str hi-v))
+                       (raise-annotation-failure 'form-id hi-v '#,annot-str))
                      (lambda (v)
                        (and (#,pred-stx v)
                             (lo.comp lo-v v)

--- a/rhombus-lib/rhombus/private/amalgam/appendable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/appendable.rkt
@@ -215,7 +215,7 @@
     [else
      (define app1 (appendable-ref v1 #f))
      (unless app1
-       (raise-argument-error* append-who/method rhombus-realm "Appendable" v1))
+       (raise-annotation-failure append-who/method v1 "Appendable"))
      (define app2 (appendable-ref v2 #f))
      (unless (and app2 (same-append? app1 app2))
        (raise-mismatch "appendable object" v1 v2

--- a/rhombus-lib/rhombus/private/amalgam/arithmetic.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/arithmetic.rkt
@@ -5,7 +5,7 @@
          "expression.rkt"
          "repetition.rkt"
          "define-operator.rkt"
-         "realm.rkt"
+         "annotation-failure.rkt"
          "compare-key.rkt"
          "static-info.rkt")
 
@@ -155,7 +155,7 @@
 (define (number!=? a b)
   (define (check n)
     (unless (number? n)
-      (raise-argument-error* '.!= rhombus-realm "Number" n)))
+      (raise-annotation-failure '.!= n "Number")))
   (check a)
   (check b)
   (not (= a b)))

--- a/rhombus-lib/rhombus/private/amalgam/array.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/array.rkt
@@ -20,7 +20,6 @@
          "reducer.rkt"
          "parens.rkt"
          "parse.rkt"
-         "realm.rkt"
          "mutability.rkt"
          "class-primitive.rkt"
          "rhombus-primitive.rkt"
@@ -133,7 +132,7 @@
 
 (define (check-nonneg-int who v)
   (unless (exact-nonnegative-integer? v)
-    (raise-argument-error* who rhombus-realm "NonnegInt" v)))
+    (raise-annotation-failure who v "NonnegInt")))
 
 (define-syntax (array-build-convert arg-id build-convert-stxs kws data)
   (with-syntax ([[(annot-str . _) _] data])
@@ -225,7 +224,7 @@
 
 (define (check-array who v)
   (unless (vector? v)
-    (raise-argument-error* who rhombus-realm "Array" v)))
+    (raise-annotation-failure who v "Array")))
 
 (define/method Array.append
   #:primitive (vector-append)

--- a/rhombus-lib/rhombus/private/amalgam/assign-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/assign-macro.rkt
@@ -9,7 +9,7 @@
                      (submod "syntax-class-primitive.rkt" for-syntax-class)
                      (submod "syntax-class-primitive.rkt" for-syntax-class-syntax)
                      "macro-result.rkt"
-                     "realm.rkt"
+                     "annotation-failure.rkt"
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
@@ -99,7 +99,7 @@
 
 (define-for-syntax (check-syntax who s)
   (unless (syntax? s)
-    (raise-argument-error* who rhombus-realm "Syntax" s)))
+    (raise-annotation-failure who s "Syntax")))
 
 (begin-for-syntax
   (define/arity (assign_meta.unpack_left stx)
@@ -135,9 +135,9 @@
                       #`(rhombus-expression #,(unpack-group set 'assign_meta.AssignParsed #f))
                       (if (identifier? rhs-name)
                           rhs-name
-                          (raise-argument-error 'assign_meta.AssignParsed
-                                                "Identifier"
-                                                rhs-name))
+                          (raise-annotation-failure 'assign_meta.AssignParsed
+                                                    rhs-name
+                                                    "Identifier"))
                       #'assign.tail))]
              #:with parsed assign-expr
              #:with tail tail))

--- a/rhombus-lib/rhombus/private/amalgam/bind-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/bind-macro.rkt
@@ -18,6 +18,7 @@
                      "tail-returner.rkt"
                      "macro-result.rkt"
                      "realm.rkt"
+                     "annotation-failure.rkt"
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
@@ -103,7 +104,7 @@
 
 (define-for-syntax (check-syntax who s)
   (unless (syntax? s)
-    (raise-argument-error* who rhombus-realm "Syntax" s)))
+    (raise-annotation-failure who s "Syntax")))
 
 (begin-for-syntax
   (define/arity (bind_meta.unpack stx)

--- a/rhombus-lib/rhombus/private/amalgam/binding-failure.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/binding-failure.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+(require "realm.rkt")
+
+(provide raise-binding-failure)
+
+(define (raise-binding-failure who what val annotation-str . extra)
+  (apply raise-arguments-error*
+         who rhombus-realm
+         (string-append what " does not satisfy annotation")
+         what val
+         (append extra
+                 (list "annotation" (unquoted-printing-string
+                                     (regexp-replace*
+                                      #rx"\n"
+                                      (error-contract->adjusted-string
+                                       annotation-str
+                                       rhombus-realm)
+                                      ;; number of spaces here depends on "annotation:"
+                                      "\n              "))))))

--- a/rhombus-lib/rhombus/private/amalgam/binding.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/binding.rkt
@@ -12,7 +12,8 @@
                      "macro-result.rkt")
          "realm.rkt"
          "dotted-sequence-parse.rkt"
-         "realm.rkt")
+         "realm.rkt"
+         "binding-failure.rkt")
 
 (begin-for-syntax
   (provide (property-out binding-prefix-operator)
@@ -169,18 +170,3 @@
     [(_ name:id rhs)
      (quasisyntax/loc stx
        (define-syntax #,(in-binding-space #'name) rhs))]))
-
-(define (raise-binding-failure who what val annotation-str . extra)
-  (apply raise-arguments-error*
-         who rhombus-realm
-         (string-append what " does not satisfy annotation")
-         what val
-         (append extra
-                 (list "annotation" (unquoted-printing-string
-                                     (regexp-replace*
-                                      #rx"\n"
-                                      (error-contract->adjusted-string
-                                       annotation-str
-                                       rhombus-realm)
-                                      ;; number of spaces here depends on "annotation:"
-                                      "\n              "))))))

--- a/rhombus-lib/rhombus/private/amalgam/bits.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/bits.rkt
@@ -2,10 +2,10 @@
 (require (for-syntax racket/base)
          "name-root.rkt"
          "define-operator.rkt"
-         "realm.rkt"
          "define-arity.rkt"
          (submod "arithmetic.rkt" static-infos)
-         "call-result-key.rkt")
+         "call-result-key.rkt"
+         "annotation-failure.rkt")
 
 (provide (for-space rhombus/namespace
                     bits))
@@ -37,11 +37,11 @@
 
 (define (check-int who n)
   (unless (exact-integer? n)
-    (raise-argument-error* who rhombus-realm "Int" n)))
+    (raise-annotation-failure who n "Int")))
 
 (define (check-nonneg-int who n)
   (unless (exact-nonnegative-integer? n)
-    (raise-argument-error* who rhombus-realm "NonnegInt" n)))
+    (raise-annotation-failure who n "NonnegInt")))
 
 (define (arithmetic-shift-left a b)
   (define who '|bits.(<<)|)

--- a/rhombus-lib/rhombus/private/amalgam/box.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/box.rkt
@@ -120,7 +120,7 @@
 
 (define (check-box who bx)
   (unless (box? bx)
-    (raise-argument-error* who rhombus-realm "Box" bx)))
+    (raise-annotation-failure who bx "Box")))
 
 (define/method (Box.copy bx)
   #:static-infos ((#%call-result #,(get-box-static-infos)))

--- a/rhombus-lib/rhombus/private/amalgam/bytes.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/bytes.rkt
@@ -16,7 +16,6 @@
          "class-primitive.rkt"
          "rhombus-primitive.rkt"
          "number.rkt"
-         "realm.rkt"
          "static-info.rkt")
 
 (provide (for-spaces (rhombus/annot
@@ -161,17 +160,17 @@
 (define (bytes!=? a b)
   (if (and (bytes? a) (bytes? b))
       (not (bytes=? a b))
-      (raise-argument-error* '!= rhombus-realm "Bytes" (if (bytes? a) b a))))
+      (raise-annotation-failure '!= (if (bytes? a) b a) "Bytes")))
 
 (define (bytes<=? a b)
   (if (and (bytes? a) (bytes? b))
       (not (bytes>? a b))
-      (raise-argument-error* '<= rhombus-realm "Bytes" (if (bytes? a) b a))))
+      (raise-annotation-failure '<= (if (bytes? a) b a) "Bytes")))
 
 (define (bytes>=? a b)
   (if (and (bytes? a) (bytes? b))
       (not (bytes<? a b))
-      (raise-argument-error* '>= rhombus-realm "Bytes" (if (bytes? a) b a))))
+      (raise-annotation-failure '>= (if (bytes? a) b a) "Bytes")))
 
 (begin-for-syntax
   (install-get-literal-static-infos! 'bytes get-bytes-static-infos))

--- a/rhombus-lib/rhombus/private/amalgam/char.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/char.rkt
@@ -17,7 +17,6 @@
          (submod "annotation.rkt" for-class)
          (submod "literal.rkt" for-info)
          (submod "symbol.rkt" for-static-info)
-         "realm.rkt"
          "class-primitive.rkt"
          "literal.rkt")
 
@@ -228,12 +227,12 @@
 (define (char!=? a b)
   (if (and (char? a) (char? b))
       (not (char=? a b))
-      (raise-argument-error* '!= rhombus-realm "Char" (if (char? a) b a))))
+      (raise-annotation-failure '!= (if (char? a) b a) "Char")))
 
 (define (char-ci!=? a b)
   (if (and (char? a) (char? b))
       (not (char-ci=? a b))
-      (raise-argument-error* '!= rhombus-realm "Char" (if (char? a) b a))))
+      (raise-annotation-failure '!= (if (char? a) b a) "Char")))
 
 (begin-for-syntax
   (install-get-literal-static-infos! 'char get-char-static-infos))

--- a/rhombus-lib/rhombus/private/amalgam/class-clause-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-clause-primitive.rkt
@@ -526,7 +526,7 @@
 
 (define (check-primitive-property who v)
   (unless (struct-type-property? v)
-    (raise-argument-error* who rhombus-realm "PrimitiveProperty" v))
+    (raise-annotation-failure who v "PrimitiveProperty"))
   v)
 
 (define-class-clause-syntax primitive_property

--- a/rhombus-lib/rhombus/private/amalgam/class-meta.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-meta.rkt
@@ -74,9 +74,9 @@
 
 (define (lookup who info key)
   (unless (class-data? info)
-    (raise-argument-error* who rhombus-realm "class_meta.Info" info))
+    (raise-annotation-failure who info "class_meta.Info"))
   (unless (symbol? key)
-    (raise-argument-error* who rhombus-realm "Symbol" key))
+    (raise-annotation-failure who key "Symbol"))
   (case key
     [(name)
      (cond
@@ -260,7 +260,7 @@
 (define (unpack-identifier who id-in)
   (define id (unpack-term/maybe id-in))
   (unless (identifier? id)
-    (raise-argument-error* who rhombus-realm "Identifier" id-in))
+    (raise-annotation-failure who id-in "Identifier"))
   id)
 
 (define (describe who id-in)

--- a/rhombus-lib/rhombus/private/amalgam/comparable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/comparable.rkt
@@ -359,7 +359,7 @@
     (define (method-op v1 v2)
       (define vt1 (Comparable-ref v1 #f))
       (unless vt1
-        (raise-argument-error* compare-who/method rhombus-realm "Comparable" v1))
+        (raise-annotation-failure compare-who/method v1 "Comparable"))
       (define app1 (vector-ref vt1 vtable-index))
       (define vt2 (Comparable-ref v2 #f))
       (unless (and vt2

--- a/rhombus-lib/rhombus/private/amalgam/context-stx.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/context-stx.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 (require syntax/parse/pre
          "pack.rkt"
-         "realm.rkt")
+         "annotation-failure.rkt")
 
 (provide extract-ctx
          extract-group-ctx)
@@ -17,7 +17,7 @@
        (let ([t (and (syntax? ctx-stx)
                      (unpack-term ctx-stx #f #f))])
          (unless t
-           (raise-argument-error* who rhombus-realm (or annot (if false-ok? "maybe(Term)" "Term")) ctx-stx))
+           (raise-annotation-failure who ctx-stx (or annot (if false-ok? "maybe(Term)" "Term"))))
          (define (result v container?)
            (if report-container?
                (values v container?)
@@ -57,7 +57,7 @@
        (let ([t (and (syntax? ctx-stx)
                      (unpack-group ctx-stx #f #f))])
          (unless t
-           (raise-argument-error* who rhombus-realm (or annot (if false-ok? "maybe(Group)" "Group")) ctx-stx))
+           (raise-annotation-failure who ctx-stx (or annot (if false-ok? "maybe(Group)" "Group"))))
          (syntax-parse t
            #:datum-literals (group)
            [((~and tag group) . tail)

--- a/rhombus-lib/rhombus/private/amalgam/control.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/control.rkt
@@ -11,7 +11,6 @@
          "binding.rkt"
          "entry-point.rkt"
          "parse.rkt"
-         "realm.rkt"
          "define-arity.rkt"
          (submod "annotation.rkt" for-class)
          (submod "function-parse.rkt" for-build)
@@ -265,26 +264,23 @@
       [(not name-in) #f]
       [(symbol? name-in) name-in]
       [(string? name-in) (string->symbol name-in)]
-      [else (raise-argument-error* who
-                                   rhombus-realm
-                                   "maybe(ReadableString || Symbol)"
-                                   name-in)]))
+      [else (raise-annotation-failure who
+                                      name-in
+                                      "maybe(ReadableString || Symbol)")]))
   (if name
       (make-continuation-prompt-tag name)
       (make-continuation-prompt-tag)))
 
 (define/arity (Continuation.call_in k proc)
   (unless (continuation? k)
-    (raise-argument-error* who
-                           rhombus-realm
-                           "Continuation"
-                           k))
+    (raise-annotation-failure who
+                              k
+                              "Continuation"))
   (unless (and (procedure? proc)
                (procedure-arity-includes? proc 0))
-    (raise-argument-error* who
-                           rhombus-realm
-                           "Function.of_arity(0)"
-                           proc))
+    (raise-annotation-failure who
+                              proc
+                              "Function.of_arity(0)"))
   (call-in-continuation k proc))
 
 (define-for-syntax (build-try-handler b-parseds rhss)

--- a/rhombus-lib/rhombus/private/amalgam/entry-point-adjustment.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/entry-point-adjustment.rkt
@@ -2,7 +2,7 @@
 (require "treelist.rkt"
          "to-list.rkt"
          "dot-property.rkt"
-         "realm.rkt")
+         "annotation-failure.rkt")
 
 (provide (struct-out entry-point-adjustment)
          no-adjustments)
@@ -22,9 +22,9 @@
             (define who 'entry_point_meta.Adjustment)
             (define args (to-treelist #f args-in))
             (unless (and args (for/and ([e (in-treelist args)]) (identifier? e)))
-              (raise-argument-error* who rhombus-realm "Listable.to_list && List.of(Identifier)" args-in))
+              (raise-annotation-failure who args-in "Listable.to_list && List.of(Identifier)"))
             (unless (and (procedure? wrap) (procedure-arity-includes? wrap 2))
-              (raise-argument-error* who rhombus-realm "Function.of_arity(2)" wrap))
+              (raise-annotation-failure who wrap "Function.of_arity(2)"))
             (values args wrap (and is-method? #t))))
 
 (define no-adjustments

--- a/rhombus-lib/rhombus/private/amalgam/entry-point-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/entry-point-macro.rkt
@@ -9,6 +9,7 @@
                      "entry-point-adjustment-meta.rkt"
                      "macro-result.rkt"
                      "realm.rkt"
+                     "annotation-failure.rkt"
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      (submod "symbol.rkt" for-static-info)
@@ -75,7 +76,7 @@
 
 (define-for-syntax (check-syntax who s)
   (unless (syntax? s)
-    (raise-argument-error* who rhombus-realm "Syntax" s)))
+    (raise-annotation-failure who s "Syntax")))
 
 (begin-for-syntax
   (define/arity (entry_point_meta.pack stx)

--- a/rhombus-lib/rhombus/private/amalgam/equatable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/equatable.rkt
@@ -5,7 +5,7 @@
          racket/hash-code
          "provide.rkt"
          "name-root.rkt"
-         "realm.rkt"
+         "annotation-failure.rkt"
          (only-in "class-desc.rkt" define-class-desc-syntax)
          "define-arity.rkt"
          "call-result-key.rkt"
@@ -87,7 +87,7 @@
 
 (define (check-int who i)
   (unless (exact-integer? i)
-    (raise-argument-error* who rhombus-realm "Int" i)))
+    (raise-annotation-failure who i "Int")))
 
 (define/arity hash_code_combine
   (case-lambda

--- a/rhombus-lib/rhombus/private/amalgam/error.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/error.rhm
@@ -103,7 +103,7 @@ fun annot_msg(what :: String = "value") :~ String:
 fun text(~label: label :: String,
          v) :~ Clause:
   Clause(
-    label ++ ": " ++ reindent(to_string(v), ~label: label)
+    label ++ ":" ++ reindent(to_string(v), ~label: label)
   )
 
 fun val(~label: label :: String = "value", v) :~ Clause:

--- a/rhombus-lib/rhombus/private/amalgam/eval.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/eval.rkt
@@ -8,7 +8,6 @@
          "static-info.rkt"
          (submod "annotation.rkt" for-class)
          "name-root.rkt"
-         "realm.rkt"
          (submod "module-path-object.rkt" for-primitive)
          (submod "function.rkt" for-info))
 
@@ -46,7 +45,7 @@
 (define/arity #:name eval (rhombus-eval e
                                         #:as_interaction [as_interaction #f])
   (unless (syntax? e)
-    (raise-argument-error* who rhombus-realm "Syntax" e))
+    (raise-annotation-failure who e "Syntax"))
   (if as_interaction
       (eval `(#%top-interaction . ,#`(multi #,@(unpack-multi e 'eval #f))))
       (eval #`(rhombus-top #,@(unpack-multi e 'eval #f)))))
@@ -57,5 +56,5 @@
 
 (define/arity (import mod-path)
   (unless (module-path? mod-path)
-    (raise-argument-error* who rhombus-realm "ModulePath" mod-path))
+    (raise-annotation-failure who mod-path "ModulePath"))
   (namespace-require (module-path-raw mod-path)))

--- a/rhombus-lib/rhombus/private/amalgam/exn-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/exn-object.rkt
@@ -10,7 +10,7 @@
          (submod "list.rkt" for-compound-repetition)
          (submod "syntax-object.rkt" for-quasiquote)
          (submod "srcloc-object.rkt" for-static-info)
-         "realm.rkt")
+         "annotation-failure.rkt")
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -79,8 +79,8 @@
 
 (define/arity (Exn.Fail.Annot message marks)
   #:static-infos ((#%call-result #,(get-exn:fail:contract-static-infos)))
-  (unless (string? message) (raise-argument-error* who rhombus-realm "ReadableString" message))
-  (unless (continuation-mark-set? marks) (raise-argument-error* who rhombus-realm "Continuation.Marks" marks))
+  (unless (string? message) (raise-annotation-failure who message "ReadableString"))
+  (unless (continuation-mark-set? marks) (raise-annotation-failure who marks "Continuation.Marks"))
   (exn:fail:contract message marks))
 
 (define-exn Arity exn:fail:contract:arity

--- a/rhombus-lib/rhombus/private/amalgam/expr-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/expr-macro.rkt
@@ -9,7 +9,7 @@
                      (submod "syntax-class-primitive.rkt" for-syntax-class)
                      "tail-returner.rkt"
                      "name-root.rkt"
-                     "realm.rkt"
+                     "annotation-failure.rkt"
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
@@ -117,7 +117,7 @@
 
 (define-for-syntax (check-syntax who s)
   (unless (syntax? s)
-    (raise-argument-error* who rhombus-realm "Syntax" s)))
+    (raise-annotation-failure who s "Syntax")))
 
 (begin-for-syntax
   (define/arity (expr_meta.pack_s_exp orig-s)

--- a/rhombus-lib/rhombus/private/amalgam/function.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/function.rkt
@@ -73,11 +73,11 @@
 
 (define (check-proc who proc)
   (unless (procedure? proc)
-    (raise-argument-error* who rhombus-realm "Function" proc)))
+    (raise-annotation-failure who proc "Function")))
 
 (define (check-list who l)
   (unless (treelist? l)
-    (raise-argument-error* who rhombus-realm "List" l)))
+    (raise-annotation-failure who l "List")))
 
 (define (check-proc-arity who fn n)
   (define (make-msg why)
@@ -252,7 +252,7 @@
 
 (define (check-nonneg-int who v)
   (unless (exact-nonnegative-integer? v)
-    (raise-argument-error* who rhombus-realm "NonnegInt" v)))
+    (raise-annotation-failure who v "NonnegInt")))
 
 (define (accepts-keywords? proc kws)
   (define-values (req allow) (procedure-keywords proc))

--- a/rhombus-lib/rhombus/private/amalgam/immediate-callee-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/immediate-callee-macro.rkt
@@ -9,7 +9,7 @@
                      (submod "syntax-class-primitive.rkt" for-syntax-class)
                      (submod "syntax-class-primitive.rkt" for-syntax-class-syntax)
                      "macro-result.rkt"
-                     "realm.rkt"
+                     "annotation-failure.rkt"
                      "tail-returner.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      (submod "symbol.rkt" for-static-info)
@@ -46,18 +46,16 @@
     (pattern (~var callee (:immediate-callee (to-list 'immediate_callee_meta.Parsed static-infoss)
                                              (case op-mode
                                                [(infix prefix) op-mode]
-                                               [else (raise-argument-error* 'immediate_callee_meta.Parsed
-                                                                            rhombus-realm
-                                                                            "matching(#'prefix || #'infix)"
-                                                                            op-mode)])
+                                               [else (raise-annotation-failure 'immediate_callee_meta.Parsed
+                                                                               op-mode
+                                                                               "matching(#'prefix || #'infix)")])
                                              (or (and (syntax? op-stx)
                                                       (syntax-parse op-stx
                                                         [op::name #'op.name]
                                                         [_ #f]))
-                                                 (raise-argument-error* 'immediate_callee_meta.Parsed
-                                                                        rhombus-realm
-                                                                        "Name"
-                                                                        op-stx))))
+                                                 (raise-annotation-failure 'immediate_callee_meta.Parsed
+                                                                           op-stx
+                                                                           "Name"))))
              #:with (parsed . tail) #'callee.parsed))
 
   (define-syntax-class-syntax Parsed

--- a/rhombus-lib/rhombus/private/amalgam/indexable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/indexable.rkt
@@ -19,7 +19,6 @@
          (submod "set.rkt" for-index)
          "repetition.rkt"
          "compound-repetition.rkt"
-         "realm.rkt"
          "index-property.rkt"
          "mutability.rkt"
          (only-in "class-desc.rkt" define-class-desc-syntax)
@@ -216,7 +215,7 @@
     [else
      (define ref (indexable-ref indexable #f))
      (unless ref
-       (raise-argument-error* indexable-get-who rhombus-realm "Indexable" indexable))
+       (raise-annotation-failure indexable-get-who indexable "Indexable"))
      (ref indexable index)]))
 
 (define (indexable-set! indexable index val)
@@ -229,5 +228,5 @@
     [else
      (define set (setable-ref indexable #f))
      (unless set
-       (raise-argument-error* indexable-set!-who rhombus-realm "MutableIndexable" indexable))
+       (raise-annotation-failure indexable-set!-who indexable "MutableIndexable"))
      (set indexable index val)]))

--- a/rhombus-lib/rhombus/private/amalgam/interface-meta.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/interface-meta.rkt
@@ -16,6 +16,7 @@
                    method-shape-extract))
          "call-result-key.rkt"
          "realm.rkt"
+         "annotation-failure.rkt"
          "pack.rkt")
 
 (provide (for-space rhombus/namespace
@@ -61,9 +62,9 @@
 
 (define (lookup who info key)
   (unless (interface-data? info)
-    (raise-argument-error* who rhombus-realm "interface_meta.Info" info))
+    (raise-annotation-failure who info "interface_meta.Info"))
   (unless (symbol? key)
-    (raise-argument-error* who rhombus-realm "Symbol" key))
+    (raise-annotation-failure who key "Symbol"))
   (case key
     [(name)
      (cond
@@ -104,7 +105,7 @@
 (define (unpack-identifier who id-in)
   (define id (unpack-term/maybe id-in))
   (unless (identifier? id)
-    (raise-argument-error* who rhombus-realm "Identifier" id-in))
+    (raise-annotation-failure who id-in "Identifier"))
   id)
 
 (define (describe who id-in)

--- a/rhombus-lib/rhombus/private/amalgam/key-comp-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/key-comp-macro.rkt
@@ -10,7 +10,7 @@
          "to-list.rkt"
          (submod "map.rkt" for-key-comp-macro)
          (submod "set.rkt" for-key-comp-macro)
-         "realm.rkt"
+         "annotation-failure.rkt"
          "parse.rkt"
          "key-comp-property.rkt"
          "../version-case.rkt")
@@ -164,9 +164,9 @@
 
 (define (hash-procedures #:equals equals #:hash_code hash_code)
   (unless (and (procedure? equals) (procedure-arity-includes? equals 3))
-    (raise-argument-error* 'key_comp.def rhombus-realm "Function.of_arity(3)" equals))
+    (raise-annotation-failure 'key_comp.def equals "Function.of_arity(3)"))
   (unless (and (procedure? hash_code) (procedure-arity-includes? hash_code 2))
-    (raise-argument-error* 'key_comp.def rhombus-realm "Function.of_arity(2)" hash_code))
+    (raise-annotation-failure 'key_comp.def hash_code "Function.of_arity(2)"))
   (values equals hash_code))
 
 (define (x-map-set-build elems ht)

--- a/rhombus-lib/rhombus/private/amalgam/keyword.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/keyword.rkt
@@ -7,7 +7,6 @@
          "call-result-key.rkt"
          "compare-key.rkt"
          (submod "annotation.rkt" for-class)
-         "realm.rkt"
          "static-info.rkt")
 
 (provide (for-spaces (rhombus/annot
@@ -43,7 +42,7 @@
 
 (define (check-keywords who a b)
   (unless (and (keyword? a) (keyword? b))
-    (raise-argument-error* who rhombus-realm "Keyword" (if (keyword? a) b a))))
+    (raise-annotation-failure who (if (keyword? a) b a) "Keyword")))
 
 (define (keyword<=? a b)
   (check-keywords '<= a b)

--- a/rhombus-lib/rhombus/private/amalgam/list.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/list.rkt
@@ -261,15 +261,15 @@
 
 (define (check-treelist who l)
   (unless (treelist? l)
-    (raise-argument-error* who rhombus-realm "List" l)))
+    (raise-annotation-failure who l "List")))
 
 (define (check-list who l)
   (unless (list? l)
-    (raise-argument-error* who rhombus-realm "PairList" l)))
+    (raise-annotation-failure who l "PairList")))
 
 (define (check-mutable-treelist who l)
   (unless (mutable-treelist? l)
-    (raise-argument-error* who rhombus-realm "MutableList" l)))
+    (raise-annotation-failure who l "MutableList")))
 
 (define/arity (List.cons a d)
   #:primitive (treelist-cons)
@@ -314,11 +314,11 @@
 
 (define (check-nonempty-list who l)
   (unless (nonempty-list? l)
-    (raise-argument-error* who rhombus-realm "NonemptyPairList" l)))
+    (raise-annotation-failure who l "NonemptyPairList")))
 
 (define (check-nonempty-treelist who l)
   (unless (nonempty-treelist? l)
-    (raise-argument-error* who rhombus-realm "NonemptyList" l)))
+    (raise-annotation-failure who l "NonemptyList")))
 
 (define/arity (List.first l)
   #:primitive (treelist-first)
@@ -351,7 +351,7 @@
 
 (define (check-nonneg-int who n)
   (unless (exact-nonnegative-integer? n)
-    (raise-argument-error* who rhombus-realm "NonnegInt" n)))
+    (raise-annotation-failure who n "NonnegInt")))
 
 (define/arity (List.iota n)
   #:static-infos ((#%call-result #,(get-treelist-static-infos)))
@@ -776,11 +776,11 @@
 (define (check-function-of-arity n who proc)
   (unless (and (procedure? proc)
                (procedure-arity-includes? proc n))
-    (raise-argument-error* who rhombus-realm
-                           (string-append "Function.of_arity("
-                                          (number->string n)
-                                          ")")
-                           proc)))
+    (raise-annotation-failure who
+                              proc
+                              (string-append "Function.of_arity("
+                                             (number->string n)
+                                             ")"))))
 
 (define/method (List.map lst proc)
   #:static-infos ((#%call-result #,(get-treelist-static-infos)))
@@ -932,14 +932,14 @@
     [(a b)
      (unless (list? b)
        (check-list who a)
-       (raise-argument-error* who rhombus-realm "PairList" b))
+       (raise-annotation-failure who b "PairList"))
      (append a b)]
     [ls
      (let ([ln (list-last ls)])
        (unless (list? ln)
          (for ([l (in-list ls)])
            (check-list who l))
-         (raise-argument-error* who rhombus-realm "PairList" ln)))
+         (raise-annotation-failure who ln "PairList")))
      (apply append ls)]))
 
 (define/method (MutableList.append a b)

--- a/rhombus-lib/rhombus/private/amalgam/map.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/map.rkt
@@ -278,7 +278,7 @@
       [else
        (define lst (to-list #f arg))
        (unless (and (pair? lst) (pair? (cdr lst)) (null? (cddr lst)))
-         (raise-argument-error* who rhombus-realm "Listable.to_list && matching([_, _])" arg))
+         (raise-annotation-failure who arg "Listable.to_list && matching([_, _])"))
        (hash-set ht (car lst) (cadr lst))])))
 
 (define (list->map key+vals)
@@ -1043,7 +1043,7 @@
 
 (define (check-readable-map who ht)
   (unless (hash? ht)
-    (raise-argument-error* who rhombus-realm "ReadableMap" ht)))
+    (raise-annotation-failure who ht "ReadableMap")))
 
 (define/method (Map.length ht)
   #:primitive (hash-count)
@@ -1081,7 +1081,7 @@
 
 (define (check-map who ht)
   (unless (immutable-hash? ht)
-    (raise-argument-error* who rhombus-realm "Map" ht)))
+    (raise-annotation-failure who ht "Map")))
 
 (define (hash-append a b)
   (let-values ([(a b)

--- a/rhombus-lib/rhombus/private/amalgam/math.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/math.rkt
@@ -4,6 +4,7 @@
          "name-root.rkt"
          "static-info.rkt"
          "realm.rkt"
+         "annotation-failure.rkt"
          "define-arity.rkt"
          (submod "define-arity.rkt" for-info)
          "function-arity-key.rkt"
@@ -76,11 +77,11 @@
 
 (define (check-posint who n)
   (unless (exact-positive-integer? n)
-    (raise-argument-error* who rhombus-realm "PosInt" n)))
+    (raise-annotation-failure who n "PosInt")))
 
 (define (check-int who n)
   (unless (exact-integer? n)
-    (raise-argument-error* who rhombus-realm "Int" n)))
+    (raise-annotation-failure who n "Int")))
 
 (define/arity #:name random rhombus-random
   #:static-infos ((#%call-result #,(get-number-static-infos)))
@@ -123,15 +124,15 @@
            (case-lambda
              [() (0-value op)]
              [(a)
-              (unless (ok? a) (raise-argument-error* who rhombus-realm ok-str a))
+              (unless (ok? a) (raise-annotation-failure who a ok-str))
               (op a)]
              [(a b)
-              (unless (ok? a) (raise-argument-error* who rhombus-realm ok-str a))
-              (unless (ok? b) (raise-argument-error* who rhombus-realm ok-str b))
+              (unless (ok? a) (raise-annotation-failure who a ok-str))
+              (unless (ok? b) (raise-annotation-failure who b ok-str))
               (op a b)]
              [ns
               (for ([a (in-list ns)])
-                (unless (ok? a) (raise-argument-error* who rhombus-realm ok-str a)))
+                (unless (ok? a) (raise-annotation-failure who a ok-str)))
               (apply op ns)]))
          ...)]))
 

--- a/rhombus-lib/rhombus/private/amalgam/module-path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/module-path-object.rkt
@@ -17,6 +17,7 @@
          "static-info.rkt"
          "call-result-key.rkt"
          "realm.rkt"
+         "annotation-failure.rkt"
          "module-path-parse.rkt"
          "parens.rkt"
          "pack.rkt"
@@ -139,13 +140,13 @@
 
 (define (module-path-s-exp who mp)
   (unless (module-path? mp)
-    (raise-argument-error* who rhombus-realm "ModulePath" mp))
+    (raise-annotation-failure who mp "ModulePath"))
   (module-path-raw mp))
 
 (define/arity (ModulePath stx)
   #:static-infos ((#%call-result #,(get-module-path-static-infos)))
   (define g (and (syntax? stx) (unpack-group stx #f #f)))
-  (unless g (raise-argument-error* who rhombus-realm "Group" stx))
+  (unless g (raise-annotation-failure who stx "Group"))
   (define (bad)
     (raise-arguments-error* who rhombus-realm "syntax object does not contain a valid module path"
                             "syntax object" stx))

--- a/rhombus-lib/rhombus/private/amalgam/operator-compare.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/operator-compare.rkt
@@ -5,7 +5,7 @@
                      enforest/operator
                      enforest/hier-name-parse
                      "pack.rkt"
-                     "realm.rkt"
+                     "annotation-failure.rkt"
                      "name-path-op.rkt"
                      "dotted-sequence.rkt")
          "name-root-space.rkt"
@@ -48,11 +48,11 @@
                      [else
                       (datum->syntax #f 'none)])]
                   [_ #f]))])
-        (raise-argument-error* who rhombus-realm "Name" stx)))
+        (raise-annotation-failure who stx "Name")))
 
   (define (check-mode who mode)
     (unless (or (eq? mode 'prefix) (eq? mode 'infix))
-      (raise-argument-error* who rhombus-realm "matching(#'prefix || #'infix)" mode)))
+      (raise-annotation-failure who mode "matching(#'prefix || #'infix)")))
   
   (define (get-relative-precedence who left-mode left-stx right-stx
                                    space-sym relative-precedence)
@@ -69,7 +69,7 @@
     (check-mode who left-mode)
     (define left-id (extract-name who left-stx space-sym))
     (define g (or (unpack-tail tail #f #f)
-                  (raise-argument-error* who rhombus-realm "Sequence" tail)))
+                  (raise-annotation-failure who tail "Sequence")))
     (define in-space (if space-sym
                          (make-interned-syntax-introducer space-sym)
                          (lambda (x) x)))

--- a/rhombus-lib/rhombus/private/amalgam/pack.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/pack.rkt
@@ -5,6 +5,7 @@
          "treelist.rkt"
          "to-list.rkt"
          "realm.rkt"
+         "annotation-failure.rkt"
          "srcloc.rkt")
 
 ;; We represent Rhombus syntax objects as a syntax object with one of
@@ -355,7 +356,7 @@
        (for/list ([r (in-list r)])
          (unpack* r (sub1 depth)))]
       [else
-       (raise-argument-error* (syntax-e qs) rhombus-realm "Listable" r)])))
+       (raise-annotation-failure (syntax-e qs) r "Listable")])))
 
 (define (pack-term* stx depth)
   (pack* stx depth pack-term))

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -2,7 +2,7 @@
 (require (for-syntax racket/base)
          "provide.rkt"
          "class-primitive.rkt"
-         "realm.rkt"
+         "annotation-failure.rkt"
          "call-result-key.rkt"
          "define-arity.rkt"
          "compare-key.rkt"
@@ -59,8 +59,7 @@
     [(path? c) c]
     [(bytes? c) (bytes->path c)]
     [(string? c) (string->path c)]
-    [else (raise-argument-error* who rhombus-realm
-                                 "String || Bytes || Path" c)]))
+    [else (raise-annotation-failure who c "String || Bytes || Path")]))
 
 (define/method (Path.bytes s)
   #:primitive (path->bytes)

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -126,11 +126,11 @@
 
 (define (check-input-port who ip)
   (unless (input-port? ip)
-    (raise-argument-error* who rhombus-realm "Port.Input" ip)))
+    (raise-annotation-failure who ip "Port.Input")))
 
 (define (check-output-port who op)
   (unless (output-port? op)
-    (raise-argument-error* who rhombus-realm "Port.Output" op)))
+    (raise-annotation-failure who op "Port.Output")))
 
 (define/arity Port.Input.open_bytes
   #:primitive (open-input-bytes)
@@ -200,7 +200,7 @@
   (define mode (->ReadLineMode mode-in))
   (unless mode
     (check-input-port who port)
-    (raise-argument-error* who rhombus-realm "Port.Input.ReadLineMode" mode-in))
+    (raise-annotation-failure who mode-in "Port.Input.ReadLineMode"))
   (coerce-read-result
    (read-line port mode)))
 

--- a/rhombus-lib/rhombus/private/amalgam/print-desc.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/print-desc.rkt
@@ -1,5 +1,5 @@
 #lang racket/base
-(require "realm.rkt"
+(require "annotation-failure.rkt"
          (prefix-in pe: pretty-expressive)
          (prefix-in sp: shrubbery/private/simple-pretty))
 
@@ -42,7 +42,7 @@
   (make-parameter 80
                   (lambda (v)
                     (unless (exact-nonnegative-integer? v)
-                      (raise-argument-error* 'Printable.current_page_width rhombus-realm "NonnegInt" v))
+                      (raise-annotation-failure 'Printable.current_page_width v "NonnegInt"))
                     v)
                   'Printable.current_page_width))
 

--- a/rhombus-lib/rhombus/private/amalgam/print.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/print.rkt
@@ -11,7 +11,7 @@
          "printer-property.rkt"
          "define-arity.rkt"
          "mutability.rkt"
-         "realm.rkt"
+         "annotation-failure.rkt"
          "print-desc.rkt"
          "key-comp-property.rkt"
          "enum.rkt")
@@ -59,7 +59,7 @@
 
 (define (check-output-port who op)
   (unless (output-port? op)
-    (raise-argument-error* who rhombus-realm "Port.Output" op)))
+    (raise-annotation-failure who op "Port.Output")))
 
 (define-simple-symbol-enum PrintMode
   text
@@ -67,7 +67,7 @@
 
 (define (check-mode who mode)
   (unless (PrintMode? mode)
-    (raise-argument-error* who rhombus-realm "PrintMode" mode)))
+    (raise-annotation-failure who mode "PrintMode")))
 
 (define (do-print* who vs op mode pretty?)
   (check-output-port who op)

--- a/rhombus-lib/rhombus/private/amalgam/printable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/printable.rkt
@@ -7,7 +7,6 @@
          "printer-property.rkt"
          "name-root.rkt"
          (submod "annotation.rkt" for-class)
-         "realm.rkt"
          (only-in "class-desc.rkt" define-class-desc-syntax)
          "define-arity.rkt"
          (submod "function.rkt" for-info)
@@ -100,15 +99,15 @@
     [(string? pd) (pretty-text pd)]
     [(bytes? pd) (pretty-text pd)]
     [else (and who
-               (raise-argument-error* who rhombus-realm "PrintDesc" pd))]))
+               (raise-annotation-failure who pd "PrintDesc"))]))
 
 (define (check-int who n)
   (unless (exact-integer? n)
-    (raise-argument-error* who rhombus-realm "Int" n)))
+    (raise-annotation-failure who n "Int")))
 
 (define (check-nonneg-int who n)
   (unless (exact-nonnegative-integer? n)
-    (raise-argument-error* who rhombus-realm "NonnegInt" n)))
+    (raise-annotation-failure who n "NonnegInt")))
 
 (define/arity (PrintDesc.concat . pds)
   (PrintDesc
@@ -140,9 +139,7 @@
 (define/arity (PrintDesc.list pre elems post)
   (define pre-pd (print-description-unwrap who pre))
   (define (bad-elems)
-    (raise-argument-error* who rhombus-realm
-                           "Listable.to_list && List.of(PrintDesc)"
-                           elems))
+    (raise-annotation-failure who elems "Listable.to_list && List.of(PrintDesc)"))
   (define elem-pds (cond
                      [(to-list #f elems)
                       => (lambda (elems)
@@ -172,7 +169,7 @@
   (define alt (print-description-unwrap who alt-pd))
   (define mode (->SpecialMode mode-in))
   (unless mode
-    (raise-argument-error* who rhombus-realm "PrintDesc.SpecialMode" mode-in))
+    (raise-annotation-failure who mode-in "PrintDesc.SpecialMode"))
   (check-nonneg-int who len)
   (PrintDesc (pretty-special v len mode alt)))
 

--- a/rhombus-lib/rhombus/private/amalgam/range.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/range.rkt
@@ -19,6 +19,7 @@
          "treelist.rkt"
          (submod "list.rkt" for-listable)
          "realm.rkt"
+         "annotation-failure.rkt"
          "number.rkt"
          "provide.rkt"
          "printer-property.rkt"
@@ -310,11 +311,11 @@
 
 (define (check-int who i)
   (unless (exact-integer? i)
-    (raise-argument-error* who rhombus-realm "Int" i)))
+    (raise-annotation-failure who i "Int")))
 
 (define (check-pos-int who i)
   (unless (exact-positive-integer? i)
-    (raise-argument-error* who rhombus-realm "PosInt" i)))
+    (raise-annotation-failure who i "PosInt")))
 
 (define (check-start-end who start end)
   (unless (start . <= . end)
@@ -492,15 +493,15 @@
 
 (define (check-range who r)
   (unless (range? r)
-    (raise-argument-error* who rhombus-realm "Range" r)))
+    (raise-annotation-failure who r "Range")))
 
 (define (check-sequence-range who r)
   (unless (sequence-range? r)
-    (raise-argument-error* who rhombus-realm "SequenceRange" r)))
+    (raise-annotation-failure who r "SequenceRange")))
 
 (define (check-list-range who r)
   (unless (list-range? r)
-    (raise-argument-error* who rhombus-realm "ListRange" r)))
+    (raise-annotation-failure who r "ListRange")))
 
 (define/method (Range.start r)
   #:static-infos ((#%call-result #,(get-int-static-infos)))

--- a/rhombus-lib/rhombus/private/amalgam/reducer-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/reducer-macro.rkt
@@ -6,11 +6,11 @@
                      "pack.rkt"
                      "tail-returner.rkt"
                      "macro-result.rkt"
-                     "realm.rkt"
                      "static-info-pack.rkt"
                      "name-root.rkt"
                      (submod "syntax-class-primitive.rkt" for-syntax-class)
                      "realm.rkt"
+                     "annotation-failure.rkt"
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
@@ -108,12 +108,12 @@
 
 (define-for-syntax (check-syntax who s)
   (unless (syntax? s)
-    (raise-argument-error* who rhombus-realm "Syntax" s)))
+    (raise-annotation-failure who s "Syntax")))
 
 (define-for-syntax (unpack-identifier who id-in [annot-str "Identifier"])
   (define id (unpack-term/maybe id-in))
   (unless (identifier? id)
-    (raise-argument-error* who rhombus-realm annot-str id-in))
+    (raise-annotation-failure who id-in annot-str))
   id)
 
 (define-for-syntax (unpack-maybe-identifier who maybe-id-in)

--- a/rhombus-lib/rhombus/private/amalgam/repet-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/repet-macro.rkt
@@ -10,6 +10,7 @@
                      "name-root.rkt"
                      (submod "syntax-class-primitive.rkt" for-syntax-class)
                      "realm.rkt"
+                     "annotation-failure.rkt"
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
@@ -111,7 +112,7 @@
 
 (define-for-syntax (check-syntax who s)
   (unless (syntax? s)
-    (raise-argument-error* who rhombus-realm "Syntax" s)))
+    (raise-annotation-failure who s "Syntax")))
 
 (begin-for-syntax
   (define/arity (repet_meta.pack_list stx)

--- a/rhombus-lib/rhombus/private/amalgam/runtime-config.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/runtime-config.rkt
@@ -108,6 +108,13 @@
               [(racket/primitive)
                (define (rhombus s) (values s 'rhombus/primitive))
                (cond
+                 [(regexp-match-positions #rx"^contract violation\n  expected: (.*)\n  given: (.*)" msg)
+                  => (lambda (m)
+                       (define expected (cadr m))
+                       (define value (caddr m))
+                       (rhombus (string-append "value does not satisfy annotation\n"
+                                               "  annotation: " (substring msg (car expected) (cdr expected)) "\n"
+                                               "  value: " (substring msg (car value) (cdr value)))))]
                  [(regexp-match-positions #rx"^not a procedure;\n expected a procedure that can be applied to arguments" msg)
                   => (lambda (m)
                        (rhombus (string-append "not a function" (substring msg (cdar m)))))]

--- a/rhombus-lib/rhombus/private/amalgam/set.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/set.rkt
@@ -263,7 +263,7 @@
 
 (define (check-readable-set who s)
   (unless (set? s)
-    (raise-argument-error* who rhombus-realm "ReadableSet" s)))
+    (raise-annotation-failure who s "ReadableSet")))
 
 (define/method (Set.length s)
   #:static-infos ((#%call-result #,(get-int-static-infos)))
@@ -972,7 +972,7 @@
 
 (define (check-set who s)
   (unless (immutable-set? s)
-    (raise-argument-error* who rhombus-realm "Set" s)))
+    (raise-annotation-failure who s "Set")))
 
 (define (set-append/hash a b)
   (let-values ([(a b)
@@ -1059,7 +1059,7 @@
 
 (define (check-mutable-set who s)
   (unless (mutable-set? s)
-    (raise-argument-error* who rhombus-realm "MutableSet" s)))
+    (raise-annotation-failure who s "MutableSet")))
 
 (define (set-set! s v in?)
   (if in?

--- a/rhombus-lib/rhombus/private/amalgam/static-info-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/static-info-macro.rkt
@@ -13,6 +13,7 @@
                      "srcloc.rkt"
                      "static-info.rkt"
                      "realm.rkt"
+                     "annotation-failure.rkt"
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
@@ -125,7 +126,7 @@
 
 (define-for-syntax (convert-static-info-key who val)
   (unless (static-info-key? val)
-    (raise-argument-error* 'statinfo.key rhombus-realm "static info key" val))
+    (raise-annotation-failure 'statinfo.key val "static info key"))
   val)
 
 (define-for-syntax (pack who stx)
@@ -133,19 +134,19 @@
 
 (define-for-syntax (check-syntax who s)
   (unless (syntax? s)
-    (raise-argument-error* who rhombus-realm "Syntax" s)))
+    (raise-annotation-failure who s "Syntax")))
 
 (define-for-syntax (unpack-identifier who id-in)
   (define id (unpack-term/maybe id-in))
   (unless (identifier? id)
-    (raise-argument-error* who rhombus-realm "Identifier" id-in))
+    (raise-annotation-failure who id-in "Identifier"))
   id)
 
 (define-for-syntax (make-key #:union union #:intersect intersect)
   (define (check-proc union)
     (unless (and (procedure? union)
                  (procedure-arity-includes? union 2))
-      (raise-argument-error* 'statinfo.key rhombus-realm "Function.of_arity(2)" union)))
+      (raise-annotation-failure 'statinfo.key union "Function.of_arity(2)")))
   (check-proc union)
   (check-proc intersect)
   (static-info-key union intersect))
@@ -209,9 +210,9 @@
                         (= 2 (treelist-length r))
                         (exact-integer? (treelist-ref r 0))
                         (syntax? (treelist-ref r 1)))))
-      (raise-argument-error* who rhombus-realm
-                             "matching([[_ :: Int, _ :: Syntax], ...])"
-                             infos))
+      (raise-annotation-failure who
+                                infos
+                                "matching([[_ :: Int, _ :: Syntax], ...])"))
     (cond
       [(and (= 1 (treelist-length infos))
             (eqv? -1 (treelist-ref (treelist-ref infos 0) 0)))

--- a/rhombus-lib/rhombus/private/amalgam/string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/string.rkt
@@ -13,7 +13,6 @@
          (only-in (submod "print.rkt" for-string)
                   [display rhombus:display]
                   [print rhombus:print])
-         "realm.rkt"
          "call-result-key.rkt"
          "index-key.rkt"
          "index-result-key.rkt"
@@ -196,7 +195,7 @@
     [(expr)
      (print-to-string a rhombus:print)]
     [else
-     (raise-argument-error* who rhombus-realm "PrintMode" mode)]))
+     (raise-annotation-failure who mode "PrintMode")]))
 
 (define/arity (repr a)
   #:static-infos ((#%call-result #,(get-string-static-infos)))
@@ -204,7 +203,7 @@
 
 (define (check-readable-string who s)
   (unless (string? s)
-    (raise-argument-error* who rhombus-realm "ReadableString" s)))
+    (raise-annotation-failure who s "ReadableString")))
 
 (define/method (String.get s i)
   #:primitive (string-ref)
@@ -355,12 +354,12 @@
 (define (string!=? a b)
   (if (and (string? a) (string? b))
       (not (string=? a b))
-      (raise-argument-error* '!= rhombus-realm "String" (if (string? a) b a))))
+      (raise-annotation-failure '!= (if (string? a) b a) "String")))
 
 (define (string-ci!=? a b)
   (if (and (string? a) (string? b))
       (not (string-ci=? a b))
-      (raise-argument-error* '!= rhombus-realm "String" (if (string? a) b a))))
+      (raise-annotation-failure '!= (if (string? a) b a) "String")))
 
 (begin-for-syntax
   (install-get-literal-static-infos! 'string get-string-static-infos))

--- a/rhombus-lib/rhombus/private/amalgam/symbol.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/symbol.rkt
@@ -6,7 +6,6 @@
          (submod "annotation.rkt" for-class)
          "compare-key.rkt"
          "call-result-key.rkt"
-         "realm.rkt"
          "static-info.rkt")
 
 (provide (for-spaces (rhombus/annot
@@ -53,7 +52,7 @@
 
 (define (check-symbols who a b)
   (unless (and (symbol? a) (symbol? b))
-    (raise-argument-error* who rhombus-realm "Symbol" (if (symbol? a) b a))))
+    (raise-annotation-failure who (if (symbol? a) b a) "Symbol")))
 
 (define (symbol<=? a b)
   (check-symbols '<= a b)

--- a/rhombus-lib/rhombus/private/amalgam/syntax-meta.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/syntax-meta.rkt
@@ -6,10 +6,9 @@
                      enforest/hier-name-parse
                      shrubbery/print
                      racket/phase+space
-                     "realm.rkt"
+                     "annotation-failure.rkt"
                      "pack.rkt"
                      "dotted-sequence.rkt"
-                     "realm.rkt"
                      "define-arity.rkt"
                      "call-result-key.rkt"
                      "name-root.rkt"
@@ -81,7 +80,7 @@
     (define l1 (extract-name-components who id1))
     (define l2 (extract-name-components who id2))
     (unless (phase? phase)
-      (raise-argument-error* who rhombus-realm "SyntaxPhase" phase))
+      (raise-annotation-failure who phase "SyntaxPhase"))
     (and (= (length l1) (length l2))
          (for/and ([n1 (in-list l1)]
                    [n2 (in-list l2)])
@@ -98,7 +97,7 @@
 
   (define (extract-name/sp who stx sp
                            #:build-dotted? [build-dotted? #f])
-    (unless (space-name? sp) (raise-argument-error* who rhombus-realm "SpaceMeta" sp))
+    (unless (space-name? sp) (raise-annotation-failure who sp "SpaceMeta"))
     (extract-name who stx (space-name-symbol sp)
                   #:build-dotted? build-dotted?))
 
@@ -122,7 +121,7 @@
                        [(null? (cdr l)) l]
                        [else (cons (car l) (loop (cddr l)))]))]
                   [_ #f]))])
-        (raise-argument-error* who rhombus-realm "Name" stx)))
+        (raise-annotation-failure who stx "Name")))
 
   (define/arity (syntax_meta.expanding_phase)
     (syntax-local-phase-level))
@@ -142,23 +141,23 @@
            [(group _::dotted-operator-or-identifier-sequence) #t]
            [(multi (group _::dotted-operator-or-identifier-sequence)) #t]
            [_
-            (raise-argument-error who "error.Who" m-who)])
+            (raise-annotation-failure who m-who "error.Who")])
          (string->symbol (shrubbery-syntax->string #:use-raw? #t m-who))]))
     (cond
       [(eq? form unsafe-undefined)
        (define form form/msg)
-       (unless (syntax? form) (raise-argument-error who "Syntax" form))
+       (unless (syntax? form) (raise-annotation-failure who form "Syntax"))
        (raise-syntax-error who-in "bad syntax" (maybe-respan form))]
       [(eq? detail unsafe-undefined)
        (define msg form/msg)
-       (unless (string? msg) (raise-argument-error who "ReadableString" msg))
-       (unless (syntax? form) (raise-argument-error who "Syntax" form))
+       (unless (string? msg) (raise-annotation-failure who msg "ReadableString"))
+       (unless (syntax? form) (raise-annotation-failure who form "Syntax"))
        (raise-syntax-error who-in msg (maybe-respan form))]
       [else
        (define msg form/msg)
-       (unless (string? msg) (raise-argument-error who "ReadableString" msg))
+       (unless (string? msg) (raise-annotation-failure who msg "ReadableString"))
        (define (bad-detail)
-         (raise-argument-error who "Syntax || List.of(Syntax)" detail))
+         (raise-annotation-failure who detail "Syntax || List.of(Syntax)"))
        (define details (map maybe-respan (cond
                                            [(treelist? detail)
                                             (define l (treelist->list detail))
@@ -191,9 +190,7 @@
                  [_ #f])]
         [else #f]))
     (unless id
-      (raise-argument-error* who rhombus-realm
-                             "Identifier || Operator"
-                             id/op-in))
+      (raise-annotation-failure who id/op-in "Identifier || Operator"))
     id)
 
   (define/arity (syntax_meta.is_static id/op-in)

--- a/rhombus-lib/rhombus/private/amalgam/syntax-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/syntax-object.rkt
@@ -322,7 +322,7 @@
 
 (define (check-symbol who v)
   (unless (symbol? v)
-    (raise-argument-error* who rhombus-realm "Symbol" v)))
+    (raise-annotation-failure who v "Symbol")))
 
 (define/arity (Syntax.make_op v [ctx-stx #f])
   #:static-infos ((#%call-result #,(get-syntax-static-infos)))
@@ -332,7 +332,7 @@
 (define (to-nonempty-list who v-in)
   (define l (to-list #f v-in))
   (unless (pair? l)
-    (raise-argument-error* who rhombus-realm "Listable.to_list && NonemptyList" v-in))
+    (raise-annotation-failure who v-in "Listable.to_list && NonemptyList"))
   l)
 
 (define/arity (Syntax.make_group v-in [ctx-stx #f])
@@ -357,7 +357,7 @@
 
 (define (check-readable-string who s)
   (unless (string? s)
-    (raise-argument-error* who rhombus-realm "ReadableString" s)))
+    (raise-annotation-failure who s "ReadableString")))
 
 (define/arity (Syntax.make_id str [ctx #f])
   #:static-infos ((#%call-result #,(get-syntax-static-infos)))
@@ -390,7 +390,7 @@
 
 (define (check-syntax who v)
   (unless (syntax? v)
-    (raise-argument-error* who rhombus-realm "Syntax" v)))
+    (raise-annotation-failure who v "Syntax")))
 
 (define/method (Syntax.unwrap v)
   (check-syntax who v)
@@ -411,7 +411,7 @@
                      (unpack-term v who #f))
     #:datum-literals (op)
     [(op o) (syntax-e #'o)]
-    [_ (raise-argument-error* who rhombus-realm "Operator" v)]))
+    [_ (raise-annotation-failure who v "Operator")]))
 
 (define/method (Syntax.unwrap_group v)
   #:static-infos ((#%call-result #,(get-treelist-of-syntax-static-infos)))
@@ -475,7 +475,7 @@
                    (loop #'tail))]
            [((parens (group (op o)))) (list "(" (symbol->immutable-string (syntax-e #'o)) ")")]
            [(x) (list (symbol->immutable-string (syntax-e #'x)))]))))]
-    [_ (raise-argument-error* who rhombus-realm "Name" v)]))
+    [_ (raise-annotation-failure who v "Name")]))
 
 (define (do-relocate who stx-in ctx-stx-in
                      extract-ctx annot)
@@ -571,11 +571,11 @@
   (case-lambda
     [(stx-in)
      (define stx (unpack-term/maybe stx-in))
-     (unless stx (raise-argument-error* who rhombus-realm "Term" stx-in))
+     (unless stx (raise-annotation-failure who stx-in "Term"))
      (get-source-properties stx extract-ctx)]
     [(stx-in prefix raw tail suffix)
      (define stx (unpack-term/maybe stx-in))
-     (unless stx (raise-argument-error* who rhombus-realm "Term" stx-in))
+     (unless stx (raise-annotation-failure who stx-in "Term"))
      (set-source-properties stx extract-ctx prefix raw tail suffix)]))
 
 (define/method Syntax.group_source_properties
@@ -586,11 +586,11 @@
   (case-lambda
     [(stx-in)
      (define stx (unpack-group stx-in #f #f))
-     (unless stx (raise-argument-error* who rhombus-realm "Group" stx-in))
+     (unless stx (raise-annotation-failure who stx-in "Group"))
      (get-source-properties stx extract-group-ctx)]
     [(stx-in prefix raw tail suffix)
      (define stx (unpack-group stx-in #f #f))
-     (unless stx (raise-argument-error* who rhombus-realm "Group" stx-in))
+     (unless stx (raise-annotation-failure who stx-in "Group"))
      (set-source-properties stx extract-group-ctx prefix raw tail suffix)]))
 
 (define (get-source-properties stx extract-ctx)
@@ -642,21 +642,19 @@
 (define/method (Syntax.relocate_span stx-in ctx-stxes-in)
   #:static-infos ((#%call-result #,(get-syntax-static-infos)))
   (define stx (unpack-term/maybe stx-in))
-  (unless stx (raise-argument-error* who rhombus-realm "Term" stx-in))
+  (unless stx (raise-annotation-failure who stx-in "Term"))
   (relocate-span who stx ctx-stxes-in))
 
 (define/method (Syntax.relocate_group_span stx-in ctx-stxes-in)
   #:static-infos ((#%call-result #,(get-syntax-static-infos)))
   (define stx (unpack-group stx-in #f #f))
-  (unless stx (raise-argument-error* who rhombus-realm "Group" stx-in))
+  (unless stx (raise-annotation-failure who stx-in "Group"))
   (relocate-span who stx ctx-stxes-in))
 
 (define (to-list-of-stx who v-in)
   (define stxs (to-list #f v-in))
   (unless (and stxs (andmap syntax? stxs))
-    (raise-argument-error* who rhombus-realm
-                           "Listable.to_list && List.of(Syntax)"
-                           v-in))
+    (raise-annotation-failure who v-in "Listable.to_list && List.of(Syntax)"))
   stxs)
 
 (define (relocate-span who stx ctx-stxes-in)
@@ -686,16 +684,14 @@
                                '(oops)))])
     (define term-stx (unpack-term/maybe stx))
     (unless term-stx
-      (raise-argument-error* who rhombus-realm
-                             "Listable.to_list && NonemptyList.of(Term)"
-                             v-in))
+      (raise-annotation-failure who v-in "Listable.to_list && NonemptyList.of(Term)"))
     term-stx))
 
 (define/arity (Syntax.relocate_split stxes-in ctx-stx)
   #:static-infos ((#%call-result #,(get-treelist-of-syntax-static-infos)))
   (define stxes (to-list-of-term-stx who stxes-in))
   (unless (syntax? ctx-stx)
-    (raise-argument-error* who rhombus-realm "Syntax" ctx-stx))
+    (raise-annotation-failure who ctx-stx "Syntax"))
   (cond
     [(null? (cdr stxes))
      ;; copying from 1 to 1

--- a/rhombus-lib/rhombus/private/amalgam/syntax-parameter-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/syntax-parameter-macro.rkt
@@ -9,6 +9,7 @@
                      "name-root.rkt"
                      "define-arity.rkt"
                      "realm.rkt"
+                     "annotation-failure.rkt"
                      "pack.rkt")
          "provide.rkt"
          "definition.rkt"
@@ -73,7 +74,7 @@
     (define id (or (unpack-term id-in #f #f)
                    id-in))
     (unless (identifier? id)
-      (raise-argument-error* who rhombus-realm "Identifier" id))
+      (raise-annotation-failure who id "Identifier"))
     (define p (syntax-local-value* (in-syntax-parameter-space id) syntax-parameter-ref))
     (unless p
       (raise-arguments-error* who rhombus-realm

--- a/rhombus-lib/rhombus/private/amalgam/to-list.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/to-list.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 (require "treelist.rkt"
          "mutable-treelist.rkt"
-         "realm.rkt")
+         "annotation-failure.rkt")
 
 (provide prop:Listable Listable? Listable-ref
 
@@ -42,7 +42,7 @@
   (cond
     [(not methods)
      (and who
-          (raise-argument-error* who rhombus-realm "Listable" v))]
+          (raise-annotation-failure who v "Listable"))]
     [else
      (define lst ((vector-ref methods 0) v))
      ;; guarded by method result

--- a/rhombus-lib/rhombus/private/amalgam/unquote-binding-primitive-meta.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/unquote-binding-primitive-meta.rkt
@@ -23,7 +23,7 @@
          "dotted-sequence.rkt"
          (for-template (submod "syntax-meta.rkt" for-unquote)
                        "space.rkt")
-         "realm.rkt")
+         "annotation-failure.rkt")
 
 ;; see also "unquote-binding-primitive.rkt"; this one has only forms
 ;; that need meta-time bindings in expansion, so we don't want a
@@ -59,4 +59,4 @@
                                              (cond
                                                [(space-name? space-path) space-path]
                                                [else
-                                                (raise-argument-error* who rhombus-realm "SpaceMeta" space-path)]))))
+                                                (raise-annotation-failure who space-path "SpaceMeta")]))))

--- a/rhombus-lib/rhombus/private/amalgam/veneer-meta.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/veneer-meta.rkt
@@ -15,6 +15,7 @@
                    method-shape-extract))
          "call-result-key.rkt"
          "realm.rkt"
+         "annotation-failure.rkt"
          "pack.rkt")
 
 (provide (for-space rhombus/namespace
@@ -60,9 +61,9 @@
 
 (define (lookup who info key)
   (unless (veneer-data? info)
-    (raise-argument-error* who rhombus-realm "veneer_meta.Info" info))
+    (raise-annotation-failure who info "veneer_meta.Info"))
   (unless (symbol? key)
-    (raise-argument-error* who rhombus-realm "Symbol" key))
+    (raise-annotation-failure who key "Symbol"))
   (case key
     [(name)
      (cond
@@ -97,7 +98,7 @@
 (define (unpack-identifier who id-in)
   (define id (unpack-term/maybe id-in))
   (unless (identifier? id)
-    (raise-argument-error* who rhombus-realm "Identifier" id-in))
+    (raise-annotation-failure who id-in "Identifier"))
   id)
 
 (define (describe who id-in)

--- a/rhombus/rhombus/tests/annot-convert.rhm
+++ b/rhombus/rhombus/tests/annot-convert.rhm
@@ -148,7 +148,7 @@ check:
 
 check:
   [1, "oops"] is_a matching((_ :: List) :: converting(fun ([x, ...]): [x+1, ...]))
-  ~throws "+: contract violation"
+  ~throws "+: " ++ error.annot_msg()
 
 check:
   ~eval

--- a/rhombus/rhombus/tests/annotation.rhm
+++ b/rhombus/rhombus/tests/annotation.rhm
@@ -48,11 +48,11 @@ block:
 
 check:
   #false is_a satisfying("not a function")
-  ~throws values("contract violation", "expected: Function.of_arity(1)")
+  ~throws values(error.annot_msg(), error.annot("Function.of_arity(1)").msg)
 
 check:
   #false is_a satisfying(fun (): #false)
-  ~throws values("contract violation", "expected: Function.of_arity(1)")
+  ~throws values(error.annot_msg(), error.annot("Function.of_arity(1)").msg)
 
 
 block:

--- a/rhombus/rhombus/tests/appendable.rhm
+++ b/rhombus/rhombus/tests/appendable.rhm
@@ -82,15 +82,15 @@ check:
 check:
   (MutableMap{ 1: 2 } :~ Appendable)
     ++ MutableMap{ 3: 4 } ~throws values(
-    "Appendable.append: contract violation",
-    "expected: Appendable",
-    "MutableMap{1: 2}",
+      "Appendable.append: " ++ error.annot_msg(),
+      error.annot("Appendable").msg,
+      error.val(MutableMap{ 1: 2 }).msg,
   )
   (MutableSet{ 1, 2 } :~ Appendable)
-    ++ MutableSet{ 3, 4 } ~throws values(
-    "Appendable.append: contract violation",
-    "expected: Appendable",
-    "MutableSet{1, 2}",
+    ++ MutableSet{ 3, 4 } ~throws values(      
+      "Appendable.append: " ++ error.annot_msg(),
+      error.annot("Appendable").msg,
+      error.val(MutableSet{1, 2}).msg,
   )
 
 block:

--- a/rhombus/rhombus/tests/array.rhm
+++ b/rhombus/rhombus/tests/array.rhm
@@ -38,17 +38,17 @@ check:
 check:
   Array.length([1, 2, 3])
   ~throws values(
-    "Array.length: contract violation",
-    "expected: Array",
-    "given: [1, 2, 3]",
+    "Array.length: " ++ error.annot_msg(),
+    error.annot("Array").msg,
+    error.val([1, 2, 3]).msg,
   )
 
 check:
   ([1, 2, 3] :~ Array).length()
   ~throws values(
-    "Array.length: contract violation",
-    "expected: Array",
-    "given: [1, 2, 3]",
+    "Array.length: " ++ error.annot_msg(),
+    error.annot("Array").msg,
+    error.val([1, 2, 3]).msg,
   )
 
 block:
@@ -72,9 +72,9 @@ block:
   check:
     Array(1, 2, 3) ++ "oops"
     ~throws values(
-      "Array.append: contract violation",
-      "expected: Array",
-      "given: \"oops\"",
+      "Array.append: " ++ error.annot_msg(),
+      error.annot("Array").msg,
+      error.val("oops").msg,
     )
   check:
     Array(1, 2, 3).append(Array(4, 5, 6), Array(7, 8, 9))
@@ -332,41 +332,41 @@ version_guard.at_least "8.13.0.1":
   check:
     Array.to_sequence("oops")
     ~throws values(
-      "Array.to_sequence: contract violation",
-      "expected: Array",
-      "given: \"oops\"",
+      "Array.to_sequence: " ++ error.annot_msg(),
+      error.annot("Array").msg,
+      error.val("oops").msg,
     )
   check:
     ("oops" :~ Array).to_sequence()
     ~throws values(
-      "Array.to_sequence: contract violation",
-      "expected: Array",
-      "given: \"oops\"",
+      "Array.to_sequence: " ++ error.annot_msg(),
+      error.annot("Array").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: "oops" :~ Array):
       x
     ~throws values(
-      "Array.to_sequence: contract violation",
-      "expected: Array",
-      "given: \"oops\"",
+      "Array.to_sequence: " ++ error.annot_msg(),
+      error.annot("Array").msg,
+      error.val("oops").msg,
     )
 
   check:
     for List (x: Array.to_sequence("oops")):
       x
     ~throws values(
-      "Array.to_sequence: contract violation",
-      "expected: Array",
-      "given: \"oops\"",
+      "Array.to_sequence: " ++ error.annot_msg(),
+      error.annot("Array").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: ("oops" :~ Array).to_sequence()):
       x
     ~throws values(
-      "Array.to_sequence: contract violation",
-      "expected: Array",
-      "given: \"oops\"",
+      "Array.to_sequence: " ++ error.annot_msg(),
+      error.annot("Array").msg,
+      error.val("oops").msg,
     )
 
 check:
@@ -382,97 +382,97 @@ check:
 check:
   ("oops" :~ Array)[0]
   ~throws values(
-    "Array.get: contract violation",
-    "expected: Array",
-    "given: \"oops\"",
+    "Array.get: " ++ error.annot_msg(),
+    error.annot("Array").msg,
+    error.val("oops").msg,
   )
 
 check:
   (Array(1, 2, 3) :~ Array)["oops"]
   ~throws values(
-    "Array.get: contract violation",
-    "expected: NonnegInt",
-    "given: \"oops\"",
+    "Array.get: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val("oops").msg,
   )
 
 check:
   (Array(1, 2, 3) :~ Array)[-1]
   ~throws values(
-    "Array.get: contract violation",
-    "expected: NonnegInt",
-    "given: -1",
+    "Array.get: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val(-1).msg,
   )
 
 check:
   ("oops" :~ MutableArray)[0] := 0
   ~throws values(
-    "Array.set: contract violation",
-    "expected: MutableArray",
-    "given: \"oops\"",
+    "Array.set: " ++ error.annot_msg(),
+    error.annot("MutableArray").msg,
+    error.val("oops").msg,
   )
 
 check:
   (Array(1, 2, 3).snapshot() :~ MutableArray)[0] := 0
   ~throws values(
-    "Array.set: contract violation",
-    "expected: MutableArray",
-    "given: Array.snapshot(Array(1, 2, 3))",
+    "Array.set: " ++ error.annot_msg(),
+    error.annot("MutableArray").msg,
+    error.val(Array.snapshot(Array(1, 2, 3))).msg,
   )
 
 check:
   (Array(1, 2, 3) :~ MutableArray)["oops"] := 0
   ~throws values(
-    "Array.set: contract violation",
-    "expected: NonnegInt",
-    "given: \"oops\"",
+    "Array.set: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val("oops").msg,
   )
 
 check:
   (Array(1, 2, 3) :~ MutableArray)[-1] := 0
   ~throws values(
-    "Array.set: contract violation",
-    "expected: NonnegInt",
-    "given: -1",
+    "Array.set: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val(-1).msg,
   )
 
 check:
   Array.append("oops") ~throws values(
-    "Array.append: contract violation",
-    "expected: Array",
-    "given: \"oops\"",
+    "Array.append: " ++ error.annot_msg(),
+    error.annot("Array").msg,
+    error.val("oops").msg,
   )
   ("oops" :~ Array).append() ~throws values(
-    "Array.append: contract violation",
-    "expected: Array",
-    "given: \"oops\"",
+    "Array.append: " ++ error.annot_msg(),
+    error.annot("Array").msg,
+    error.val("oops").msg,
   )
 
 version_guard.at_least "8.14.0.7":
   check:
     Array.make("oops")
     ~throws values(
-      "Array.make: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "Array.make: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
   check:
     Array.make(-1)
     ~throws values(
-      "Array.make: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "Array.make: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )
   check:
     Array.make("oops", 0)
     ~throws values(
-      "Array.make: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "Array.make: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
   check:
     Array.make(-1, 0)
     ~throws values(
-      "Array.make: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "Array.make: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )

--- a/rhombus/rhombus/tests/bits.rhm
+++ b/rhombus/rhombus/tests/bits.rhm
@@ -11,124 +11,124 @@ block:
 // error reporting
 check:
   "oops" bits.and 2 ~throws values(
-    "bits.and: contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.and: " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
   1 bits.and "oops" ~throws values(
-    "bits.and: contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.and: " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
   "oops" bits.or 2 ~throws values(
-    "bits.or: contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.or: " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
   1 bits.or "oops" ~throws values(
-    "bits.or: contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.or: " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
   "oops" bits.xor 2 ~throws values(
-    "bits.xor: contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.xor: " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
   1 bits.xor "oops" ~throws values(
-    "bits.xor: contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.xor: " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
   bits.not "oops" ~throws values(
-    "bits.not: contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.not: " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
 
 check:
   "oops" bits.(<<) 2 ~throws values(
-    "bits.(<<): contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.(<<): " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
   1 bits.(<<) "oops" ~throws values(
-    "bits.(<<): contract violation",
-    "expected: NonnegInt",
-    "given: \"oops\"",
+    "bits.(<<): " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val("oops").msg,
   )
   1 bits.(<<) -1 ~throws values(
-    "bits.(<<): contract violation",
-    "expected: NonnegInt",
-    "given: -1",
+    "bits.(<<): " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val(-1).msg,
   )
   "oops" bits.(>>) 2 ~throws values(
-    "bits.(>>): contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.(>>): " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
   1 bits.(>>) "oops" ~throws values(
-    "bits.(>>): contract violation",
-    "expected: NonnegInt",
-    "given: \"oops\"",
+    "bits.(>>): " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val("oops").msg,
   )
   1 bits.(>>) -1 ~throws values(
-    "bits.(>>): contract violation",
-    "expected: NonnegInt",
-    "given: -1",
+    "bits.(>>): " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val(-1).msg,
   )
   "oops" bits.(?) 2 ~throws values(
-    "bits.(?): contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.(?): " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
 
 version_guard.at_least "8.14.0.2":
   check:
     1 bits.(?) "oops" ~throws values(
-      "bits.(?): contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "bits.(?): " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
     1 bits.(?) -1 ~throws values(
-      "bits.(?): contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "bits.(?): " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )
 
 check:
   bits.length("oops") ~throws values(
-    "bits.length: contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.length: " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
   bits.field("oops", 2, 3) ~throws values(
-    "bits.field: contract violation",
-    "expected: Int",
-    "given: \"oops\"",
+    "bits.field: " ++ error.annot_msg(),
+    error.annot("Int").msg,
+    error.val("oops").msg,
   )
 
 version_guard.at_least "8.14.0.2":
   check:
     bits.field(1, "oops", 3) ~throws values(
-      "bits.field: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "bits.field: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
     bits.field(1, -1, 3) ~throws values(
-      "bits.field: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "bits.field: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )
     bits.field(1, 2, "oops") ~throws values(
-      "bits.field: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "bits.field: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
     bits.field(1, 2, -1) ~throws values(
-      "bits.field: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "bits.field: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )
     // NOTE different messages on CS vs. BC
     bits.field(1, 2, 1) ~throws values(

--- a/rhombus/rhombus/tests/box.rhm
+++ b/rhombus/rhombus/tests/box.rhm
@@ -168,23 +168,23 @@ check:
 check:
   ("oops" :~ Box).value
   ~throws values(
-    "Box.value: contract violation",
-    "expected: Box",
-    "given: \"oops\"",
+    "Box.value: " ++ error.annot_msg(),
+    error.annot("Box").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ MutableBox).value := 0
   ~throws values(
-    "Box.value: contract violation",
-    "expected: MutableBox",
-    "given: \"oops\"",
+    "Box.value: " ++ error.annot_msg(),
+    error.annot("MutableBox").msg,
+    error.val("oops").msg,
   )
 
 check:
   (Box(1).snapshot() :~ MutableBox).value := 0
   ~throws values(
-    "Box.value: contract violation",
-    "expected: MutableBox",
-    "given: Box.snapshot(Box(1))",
+    "Box.value: " ++ error.annot_msg(),
+    error.annot("MutableBox").msg,
+    error.val(Box.snapshot(Box(1))).msg,
   )

--- a/rhombus/rhombus/tests/bytes.rhm
+++ b/rhombus/rhombus/tests/bytes.rhm
@@ -36,9 +36,9 @@ block:
     #"hello".get(0) ~is Byte#"h"
     #"hello" ++ #" " ++ #"world" ~is_now #"hello world"
     #"hello" ++ #" " ++ "world" ~throws values(
-      "Bytes.append: contract violation",
-      "expected: Bytes",
-      "given: \"world\"",
+      "Bytes.append: " ++ error.annot_msg(),
+      error.annot("Bytes").msg,
+      error.val("world").msg,
     )
     #"hello".append(#" world") ~is_now #"hello world"
     #"hello".append(#" world", #" and bye") ~is_now #"hello world and bye"
@@ -138,189 +138,189 @@ version_guard.at_least "8.13.0.1":
   check:
     Bytes.to_sequence("oops")
     ~throws values(
-      "Bytes.to_sequence: contract violation",
-      "expected: Bytes",
-      "given: \"oops\"",
+      "Bytes.to_sequence: " ++ error.annot_msg(),
+      error.annot("Bytes").msg,
+      error.val("oops").msg,
     )
   check:
     ("oops" :~ Bytes).to_sequence()
     ~throws values(
-      "Bytes.to_sequence: contract violation",
-      "expected: Bytes",
-      "given: \"oops\"",
+      "Bytes.to_sequence: " ++ error.annot_msg(),
+      error.annot("Bytes").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: "oops" :~ Bytes):
       x
     ~throws values(
-      "Bytes.to_sequence: contract violation",
-      "expected: Bytes",
-      "given: \"oops\"",
+      "Bytes.to_sequence: " ++ error.annot_msg(),
+      error.annot("Bytes").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: Bytes.to_sequence("oops")):
       x
     ~throws values(
-      "Bytes.to_sequence: contract violation",
-      "expected: Bytes",
-      "given: \"oops\"",
+      "Bytes.to_sequence: " ++ error.annot_msg(),
+      error.annot("Bytes").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: ("oops" :~ Bytes).to_sequence()):
       x
     ~throws values(
-      "Bytes.to_sequence: contract violation",
-      "expected: Bytes",
-      "given: \"oops\"",
+      "Bytes.to_sequence: " ++ error.annot_msg(),
+      error.annot("Bytes").msg,
+      error.val("oops").msg,
     )
 
 check:
   ("oops" :~ Bytes)[0]
   ~throws values(
-    "Bytes.get: contract violation",
-    "expected: Bytes",
-    "given: \"oops\"",
+    "Bytes.get: " ++ error.annot_msg(),
+    error.annot("Bytes").msg,
+    error.val("oops").msg,
   )
 
 check:
   (#"hello" :~ Bytes)["oops"]
   ~throws values(
-    "Bytes.get: contract violation",
-    "expected: NonnegInt",
-    "given: \"oops\"",
+    "Bytes.get: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val("oops").msg,
   )
 
 check:
   (#"hello" :~ Bytes)[-1]
   ~throws values(
-    "Bytes.get: contract violation",
-    "expected: NonnegInt",
-    "given: -1",
+    "Bytes.get: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val(-1).msg,
   )
 
 check:
   ("oops" :~ MutableBytes)[0] := 0
   ~throws values(
-    "Bytes.set: contract violation",
-    "expected: MutableBytes",
-    "given: \"oops\"",
+    "Bytes.set: " ++ error.annot_msg(),
+    error.annot("MutableBytes").msg,
+    error.val("oops").msg,
   )
 
 check:
   (#"hello" :~ MutableBytes)[0] := 0
   ~throws values(
-    "Bytes.set: contract violation",
-    "expected: MutableBytes",
-    "given: #\"hello\"",
+    "Bytes.set: " ++ error.annot_msg(),
+    error.annot("MutableBytes").msg,
+    error.val(#"hello").msg,
   )
 
 check:
   (#"hello".copy() :~ MutableBytes)["oops"] := 0
   ~throws values(
-    "Bytes.set: contract violation",
-    "expected: NonnegInt",
-    "given: \"oops\"",
+    "Bytes.set: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val("oops").msg,
   )
 
 check:
   (#"hello".copy() :~ MutableBytes)[-1] := 0
   ~throws values(
-    "Bytes.set: contract violation",
-    "expected: NonnegInt",
-    "given: -1",
+    "Bytes.set: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val(-1).msg,
   )
 
 version_guard.at_least "8.14.0.2":
   check:
     (#"hello".copy() :~ MutableBytes)[0] := "oops"
     ~throws values(
-      "Bytes.set: contract violation",
-      "expected: Byte",
-      "given: \"oops\"",
+      "Bytes.set: " ++ error.annot_msg(),
+      error.annot("Byte").msg,
+      error.val("oops").msg,
     )
   check:
     (#"hello".copy() :~ MutableBytes)[0] := -1
     ~throws values(
-      "Bytes.set: contract violation",
-      "expected: Byte",
-      "given: -1",
+      "Bytes.set: " ++ error.annot_msg(),
+      error.annot("Byte").msg,
+      error.val(-1).msg,
     )
 
 check:
   Bytes.append("oops") ~throws values(
-    "Bytes.append: contract violation",
-    "expected: Bytes",
-    "given: \"oops\"",
+    "Bytes.append: " ++ error.annot_msg(),
+    error.annot("Bytes").msg,
+    error.val("oops").msg,
   )
   ("oops" :~ Bytes).append() ~throws values(
-    "Bytes.append: contract violation",
-    "expected: Bytes",
-    "given: \"oops\"",
+    "Bytes.append: " ++ error.annot_msg(),
+    error.annot("Bytes").msg,
+    error.val("oops").msg,
   )
 
 version_guard.at_least "8.14.0.7":
   check:
     Bytes.make("oops")
     ~throws values(
-      "Bytes.make: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "Bytes.make: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
   check:
     Bytes.make(-1)
     ~throws values(
-      "Bytes.make: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "Bytes.make: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )
   check:
     Bytes.make("oops", 0)
     ~throws values(
-      "Bytes.make: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "Bytes.make: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
   check:
     Bytes.make(-1, 0)
     ~throws values(
-      "Bytes.make: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "Bytes.make: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )
   check:
     Bytes.make(5, "oops")
     ~throws values(
-      "Bytes.make: contract violation",
-      "expected: Byte",
-      "given: \"oops\"",
+      "Bytes.make: " ++ error.annot_msg(),
+      error.annot("Byte").msg,
+      error.val("oops").msg,
     )
   check:
     Bytes.make(5, "a")
     ~throws values(
-      "Bytes.make: contract violation",
-      "expected: Byte",
-      "given: \"a\"",
+      "Bytes.make: " ++ error.annot_msg(),
+      error.annot("Byte").msg,
+      error.val("a").msg,
     )
   check:
     Bytes.make(5, Char"a")
     ~throws values(
-      "Bytes.make: contract violation",
-      "expected: Byte",
-      "given: Char\"a\"",
+      "Bytes.make: " ++ error.annot_msg(),
+      error.annot("Byte").msg,
+      error.val(Char"a").msg,
     )
   check:
     Bytes.make(5, -1)
     ~throws values(
-      "Bytes.make: contract violation",
-      "expected: Byte",
-      "given: -1",
+      "Bytes.make: " ++ error.annot_msg(),
+      error.annot("Byte").msg,
+      error.val(-1).msg,
     )
   check:
     Bytes.make(5, 256)
     ~throws values(
-      "Bytes.make: contract violation",
-      "expected: Byte",
-      "given: 256",
+      "Bytes.make: " ++ error.annot_msg(),
+      error.annot("Byte").msg,
+      error.val(256).msg,
     )
 
 // checks static infos for elements

--- a/rhombus/rhombus/tests/comparable.rhm
+++ b/rhombus/rhombus/tests/comparable.rhm
@@ -271,9 +271,9 @@ check:
   class NotComparable()
   (NotComparable() :~ Comparable) < NotComparable()
   ~throws values(
-    "Comparable.compare_to: contract violation",
-    "expected: Comparable",
-    "given: NotComparable()",
+    "Comparable.compare_to: " ++ error.annot_msg(),
+    error.annot("Comparable").msg,
+    error.text(~label: "value", "NotComparable()").msg,
   )
 
 block:

--- a/rhombus/rhombus/tests/function.rhm
+++ b/rhombus/rhombus/tests/function.rhm
@@ -74,9 +74,9 @@ check:
 check:
   (fun (x): #void) is_a Function.of_arity(#false, 1)
   ~throws values(
-    "Function.of_arity: contract violation",
-    "expected: NonnegInt",
-    "given: #false",
+    "Function.of_arity: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val(#false).msg,
   )
 
 block:

--- a/rhombus/rhombus/tests/indexable.rhm
+++ b/rhombus/rhombus/tests/indexable.rhm
@@ -131,17 +131,17 @@ check:
 
 check:
   (#'apple :~ Indexable)[0] ~throws values(
-    "Indexable.get: contract violation",
-    "expected: Indexable",
+    "Indexable.get: " ++ error.annot_msg(),
+    error.annot("Indexable").msg,
     "#'apple",
   )
   ("apple" :~ MutableIndexable)[0] := Char"b" ~throws values(
-    "MutableIndexable.set: contract violation",
-    "expected: MutableIndexable",
+    "MutableIndexable.set: " ++ error.annot_msg(),
+    error.annot("MutableIndexable").msg,
     "\"apple\"",
   )
   ("apple".copy() :~ MutableIndexable)[0] := Char"b" ~throws values(
-    "MutableIndexable.set: contract violation",
-    "expected: MutableIndexable",
+    "MutableIndexable.set: " ++ error.annot_msg(),
+    error.annot("MutableIndexable").msg,
     "String.copy(\"apple\")",
   )

--- a/rhombus/rhombus/tests/list.rhm
+++ b/rhombus/rhombus/tests/list.rhm
@@ -40,9 +40,9 @@ check:
 check:
   List.length({1, 2, 3})
   ~throws values(
-    "List.length: contract violation",
-    "expected: List",
-    "given: {1, 2, 3}",
+    "List.length: " ++ error.annot_msg(),
+    error.annot("List").msg,
+    error.val({1, 2, 3}).msg,
   )
 
 check:
@@ -73,16 +73,16 @@ block:
   check:
     [1, 2, 3] ++ PairList[4, 5]
     ~throws values(
-      "List.append: contract violation",
-      "expected: List",
-      "given: PairList[4, 5]",
+      "List.append: " ++ error.annot_msg(),
+      error.annot("List").msg,
+      error.val(PairList[4, 5]).msg,
     )
   check:
     [1, 2, 3] ++ "oops"
     ~throws values(
-      "List.append: contract violation",
-      "expected: List",
-      "given: \"oops\"",
+      "List.append: " ++ error.annot_msg(),
+      error.annot("List").msg,
+      error.val("oops").msg,
     )
   check:
     [1, 2, 3].append([4, 5])
@@ -329,9 +329,9 @@ check:
   [1, 2].append([3]) ~is [1, 2, 3]
   [1, 2].append([3], [4, 5]) ~is [1, 2, 3, 4, 5]
   [1, 2].append(3) ~throws values(
-    "List.append: contract violation",
-    "expected: List",
-    "given: 3"
+    "List.append: " ++ error.annot_msg(),
+    error.annot("List").msg,
+    error.val(3).msg
   )
 
 check:
@@ -434,40 +434,40 @@ version_guard.at_least "8.13.0.1":
   check:
     List.to_sequence("oops")
     ~throws values(
-      "List.to_sequence: contract violation",
-      "expected: List",
-      "given: \"oops\"",
+      "List.to_sequence: " ++ error.annot_msg(),
+      error.annot("List").msg,
+      error.val("oops").msg,
     )
   check:
     ("oops" :~ List).to_sequence()
     ~throws values(
-      "List.to_sequence: contract violation",
-      "expected: List",
-      "given: \"oops\"",
+      "List.to_sequence: " ++ error.annot_msg(),
+      error.annot("List").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: "oops" :~ List):
       x
     ~throws values(
-      "List.to_sequence: contract violation",
-      "expected: List",
-      "given: \"oops\"",
+      "List.to_sequence: " ++ error.annot_msg(),
+      error.annot("List").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: List.to_sequence("oops")):
       x
     ~throws values(
-      "List.to_sequence: contract violation",
-      "expected: List",
-      "given: \"oops\"",
+      "List.to_sequence: " ++ error.annot_msg(),
+      error.annot("List").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: ("oops" :~ List).to_sequence()):
       x
     ~throws values(
-      "List.to_sequence: contract violation",
-      "expected: List",
-      "given: \"oops\"",
+      "List.to_sequence: " ++ error.annot_msg(),
+      error.annot("List").msg,
+      error.val("oops").msg,
     )
 
 check:
@@ -531,67 +531,67 @@ check:
 check:
   [List.repet([1, 2, 3]), ...] ~is [1, 2, 3]
   [List.repet("oops"), ...] ~throws values(
-    "List.repet: contract violation",
-    "expected: List",
-    "given: \"oops\"",
+    "List.repet: " ++ error.annot_msg(),
+    error.annot("List").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ List)[0]
   ~throws values(
-    "List.get: contract violation",
-    "expected: List",
-    "given: \"oops\"",
+    "List.get: " ++ error.annot_msg(),
+    error.annot("List").msg,
+    error.val("oops").msg,
   )
 
 version_guard.at_least "8.14.0.2":
   check:
     ([1, 2, 3] :~ List)["oops"]
     ~throws values(
-      "List.get: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "List.get: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
   check:
     ([1, 2, 3] :~ List)[-1]
     ~throws values(
-      "List.get: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "List.get: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )
 
 check:
   ("oops" :~ List).first
   ~throws values(
-    "List.first: contract violation",
-    "expected: NonemptyList",
-    "given: \"oops\"",
+    "List.first: " ++ error.annot_msg(),
+    error.annot("NonemptyList").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ List).last
   ~throws values(
-    "List.last: contract violation",
-    "expected: NonemptyList",
-    "given: \"oops\"",
+    "List.last: " ++ error.annot_msg(),
+    error.annot("NonemptyList").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ List).rest
   ~throws values(
-    "List.rest: contract violation",
-    "expected: NonemptyList",
-    "given: \"oops\"",
+    "List.rest: " ++ error.annot_msg(),
+    error.annot("NonemptyList").msg,
+    error.val("oops").msg,
   )
 
 check:
   List.append("oops") ~throws values(
-    "List.append: contract violation",
-    "expected: List",
-    "given: \"oops\"",
+    "List.append: " ++ error.annot_msg(),
+    error.annot("List").msg,
+    error.val("oops").msg,
   )
   ("oops" :~ List).append() ~throws values(
-    "List.append: contract violation",
-    "expected: List",
-    "given: \"oops\"",
+    "List.append: " ++ error.annot_msg(),
+    error.annot("List").msg,
+    error.val("oops").msg,
   )

--- a/rhombus/rhombus/tests/map.rhm
+++ b/rhombus/rhombus/tests/map.rhm
@@ -35,9 +35,9 @@ check:
 check:
   Map.length({1, 2, 3})
   ~throws values(
-    "Map.length: contract violation",
-    "expected: ReadableMap",
-    "given: {1, 2, 3}",
+    "Map.length: " ++ error.annot_msg(),
+    error.annot("ReadableMap").msg,
+    error.val({1, 2, 3}).msg,
   )
 
 block:
@@ -54,14 +54,14 @@ block:
     ({"a": 1, "b": 2} ++ {"a": 3})["a"] ~is 3
     ({"a": 1, "b": 2} ++ {"a": 3, "b": 4})["a"] ~is 3
     {"a": 1, "b": 2} ++ "oops" ~throws values(
-      "Map.append: contract violation",
-      "expected: Map",
-      "given: \"oops\"",
+      "Map.append: " ++ error.annot_msg(),
+      error.annot("Map").msg,
+      error.val("oops").msg,
     )
     {"a": 1, "b": 2} ++ MutableMap{"a": 3} ~throws values(
-      "Map.append: contract violation",
-      "expected: Map",
-      "given: MutableMap{\"a\": 3}",
+      "Map.append: " ++ error.annot_msg(),
+      error.annot("Map").msg,
+      error.val(MutableMap{"a": 3}).msg,
     )
     {"a": 1, "b": 2}.append()["a"] ~is 1
     {"a": 1, "b": 2}.append({"a": 2})["a"] ~is 2
@@ -119,57 +119,57 @@ block:
   check:
     Map([1, "1", "oops"])
     ~throws values(
-      "Map: contract violation",
-      "expected: Listable.to_list && matching([_, _])",
+      "Map: " ++ error.annot_msg(),
+      error.annot("Listable.to_list && matching([_, _])").msg,
       "[1, \"1\", \"oops\"]",
     )
   check:
     Map(PairList[1, "1", "oops"])
     ~throws values(
-      "Map: contract violation",
-      "expected: Listable.to_list && matching([_, _])",
+      "Map: " ++ error.annot_msg(),
+      error.annot("Listable.to_list && matching([_, _])").msg,
       "PairList[1, \"1\", \"oops\"]",
     )
   check:
     Map(Array(1, "1", "oops"))
     ~throws values(
-      "Map: contract violation",
-      "expected: Listable.to_list && matching([_, _])",
+      "Map: " ++ error.annot_msg(),
+      error.annot("Listable.to_list && matching([_, _])").msg,
       "Array(1, \"1\", \"oops\")",
     )
   check:
     Map(Broken())
     ~throws values(
-      "Map: contract violation",
-      "expected: Listable.to_list && matching([_, _])",
+      "Map: " ++ error.annot_msg(),
+      error.annot("Listable.to_list && matching([_, _])").msg,
       "Broken()",
     )
   check:
     MutableMap([1, "1", "oops"])
     ~throws values(
-      "MutableMap: contract violation",
-      "expected: Listable.to_list && matching([_, _])",
+      "MutableMap: " ++ error.annot_msg(),
+      error.annot("Listable.to_list && matching([_, _])").msg,
       "[1, \"1\", \"oops\"]",
     )
   check:
     MutableMap(PairList[1, "1", "oops"])
     ~throws values(
-      "MutableMap: contract violation",
-      "expected: Listable.to_list && matching([_, _])",
+      "MutableMap: " ++ error.annot_msg(),
+      error.annot("Listable.to_list && matching([_, _])").msg,
       "PairList[1, \"1\", \"oops\"]",
     )
   check:
     MutableMap(Array(1, "1", "oops"))
     ~throws values(
-      "MutableMap: contract violation",
-      "expected: Listable.to_list && matching([_, _])",
+      "MutableMap: " ++ error.annot_msg(),
+      error.annot("Listable.to_list && matching([_, _])").msg,
       "Array(1, \"1\", \"oops\")",
     )
   check:
     MutableMap(Broken())
     ~throws values(
-      "MutableMap: contract violation",
-      "expected: Listable.to_list && matching([_, _])",
+      "MutableMap: " ++ error.annot_msg(),
+      error.annot("Listable.to_list && matching([_, _])").msg,
       "Broken()",
     )
 
@@ -803,40 +803,40 @@ version_guard.at_least "8.13.0.1":
   check:
     Map.to_sequence("oops")
     ~throws values(
-      "Map.to_sequence: contract violation",
-      "expected: ReadableMap",
-      "given: \"oops\"",
+      "Map.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableMap").msg,
+      error.val("oops").msg,
     )
   check:
     ("oops" :~ Map).to_sequence()
     ~throws values(
-      "Map.to_sequence: contract violation",
-      "expected: ReadableMap",
-      "given: \"oops\"",
+      "Map.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableMap").msg,
+      error.val("oops").msg,
     )
   check:
     for Map ((k, v): "oops" :~ Map):
       values(k, v)
     ~throws values(
-      "Map.to_sequence: contract violation",
-      "expected: ReadableMap",
-      "given: \"oops\"",
+      "Map.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableMap").msg,
+      error.val("oops").msg,
     )
   check:
     for Map ((k, v): Map.to_sequence("oops")):
       values(k, v)
     ~throws values(
-      "Map.to_sequence: contract violation",
-      "expected: ReadableMap",
-      "given: \"oops\"",
+      "Map.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableMap").msg,
+      error.val("oops").msg,
     )
   check:
     for Map ((k, v): ("oops" :~ Map).to_sequence()):
       values(k, v)
     ~throws values(
-      "Map.to_sequence: contract violation",
-      "expected: ReadableMap",
-      "given: \"oops\"",
+      "Map.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableMap").msg,
+      error.val("oops").msg,
     )
 
 check:
@@ -1414,27 +1414,27 @@ block:
 check:
   ("oops" :~ Map)[0]
   ~throws values(
-    "Map.get: contract violation",
-    "expected: ReadableMap",
-    "given: \"oops\"",
+    "Map.get: " ++ error.annot_msg(),
+    error.annot("ReadableMap").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ MutableMap)[0] := 0
   ~throws values(
-    "MutableMap.set: contract violation",
-    "expected: MutableMap",
-    "given: \"oops\"",
+    "MutableMap.set: " ++ error.annot_msg(),
+    error.annot("MutableMap").msg,
+    error.val("oops").msg,
   )
 
 check:
   Map.append("oops") ~throws values(
-    "Map.append: contract violation",
-    "expected: Map",
-    "given: \"oops\"",
+    "Map.append: " ++ error.annot_msg(),
+    error.annot("Map").msg,
+    error.val("oops").msg,
   )
   ("oops" :~ Map).append() ~throws values(
-    "Map.append: contract violation",
-    "expected: Map",
-    "given: \"oops\"",
+    "Map.append: " ++ error.annot_msg(),
+    error.annot("Map").msg,
+    error.val("oops").msg,
   )

--- a/rhombus/rhombus/tests/mutable-list.rhm
+++ b/rhombus/rhombus/tests/mutable-list.rhm
@@ -39,17 +39,17 @@ check:
 check:
   MutableList.length([1, 2, 3])
   ~throws values(
-    "MutableList.length: contract violation",
-    "expected: MutableList",
-    "given: [1, 2, 3]",
+    "MutableList.length: " ++ error.annot_msg(),
+    error.annot("MutableList").msg,
+    error.val([1, 2, 3]).msg,
   )
 
 check:
   ([1, 2, 3] :~ MutableList).length()
   ~throws values(
-    "MutableList.length: contract violation",
-    "expected: MutableList",
-    "given: [1, 2, 3]",
+    "MutableList.length: " ++ error.annot_msg(),
+    error.annot("MutableList").msg,
+    error.val([1, 2, 3]).msg,
   )
 
 block:
@@ -253,40 +253,40 @@ version_guard.at_least "8.13.0.1":
   check:
     MutableList.to_sequence("oops")
     ~throws values(
-      who ++ "contract violation",
-      "expected: MutableList",
-      "given: \"oops\"",
+      who ++ error.annot_msg(),
+      error.annot("MutableList").msg,
+      error.val("oops").msg,
     )
   check:
     ("oops" :~ MutableList).to_sequence()
     ~throws values(
-      who ++ "contract violation",
-      "expected: MutableList",
-      "given: \"oops\"",
+      who ++ error.annot_msg(),
+      error.annot("MutableList").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: "oops" :~ MutableList):
       x
     ~throws values(
-      who ++ "contract violation",
-      "expected: MutableList",
-      "given: \"oops\"",
+      who ++ error.annot_msg(),
+      error.annot("MutableList").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: MutableList.to_sequence("oops")):
       x
     ~throws values(
-      who ++ "contract violation",
-      "expected: MutableList",
-      "given: \"oops\"",
+      who ++ error.annot_msg(),
+      error.annot("MutableList").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: ("oops" :~ MutableList).to_sequence()):
       x
     ~throws values(
-      who ++ "contract violation",
-      "expected: MutableList",
-      "given: \"oops\"",
+      who ++ error.annot_msg(),
+      error.annot("MutableList").msg,
+      error.val("oops").msg,
     )
 
 check:
@@ -415,47 +415,47 @@ check:
 check:
   ("oops" :~ MutableList)[0]
   ~throws values(
-    "MutableList.get: contract violation",
-    "expected: MutableList",
-    "given: \"oops\"",
+    "MutableList.get: " ++ error.annot_msg(),
+    error.annot("MutableList").msg,
+    error.val("oops").msg,
   )
 
 version_guard.at_least "8.14.0.2":
   check:
     (MutableList[1, 2, 3] :~ MutableList)["oops"]
     ~throws values(
-      "MutableList.get: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "MutableList.get: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
   check:
     (MutableList[1, 2, 3] :~ MutableList)[-1]
     ~throws values(
-      "MutableList.get: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "MutableList.get: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )
 
 check:
   ("oops" :~ MutableList)[0] := 0
   ~throws values(
-    "MutableList.set: contract violation",
-    "expected: MutableList",
-    "given: \"oops\"",
+    "MutableList.set: " ++ error.annot_msg(),
+    error.annot("MutableList").msg,
+    error.val("oops").msg,
   )
 
 version_guard.at_least "8.14.0.2":
   check:
     (MutableList[1, 2, 3] :~ MutableList)["oops"] := 0
     ~throws values(
-      "MutableList.set: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "MutableList.set: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
   check:
     (MutableList[1, 2, 3] :~ MutableList)[-1] := 0
     ~throws values(
-      "MutableList.set: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "MutableList.set: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )

--- a/rhombus/rhombus/tests/number.rhm
+++ b/rhombus/rhombus/tests/number.rhm
@@ -47,8 +47,8 @@ check:
   2 is_a Int.in(1, 2 ~inclusive) ~is #true
   2 is_a Int.in(1, 2 ~exclusive) ~is #false
 
-  1 is_a Int.in("oops", 2) ~throws values("contract violation", "Int", "\"oops\"")
-  1 is_a Int.in(1, "oops") ~throws values("contract violation", "Int", "\"oops\"")
+  1 is_a Int.in("oops", 2) ~throws values(error.annot_msg(), "Int", "\"oops\"")
+  1 is_a Int.in(1, "oops") ~throws values(error.annot_msg(), "Int", "\"oops\"")
 
 check:
   1 is_a NonnegReal ~is #true
@@ -90,12 +90,12 @@ check:
 
   "0.9" is_a Real.in(0, 1) ~is #false
 
-  1 is_a Real.above("oops") ~throws values("contract violation", "Real", "\"oops\"")
-  1 is_a Real.at_least("oops") ~throws values("contract violation", "Real", "\"oops\"")
-  1 is_a Real.below("oops") ~throws values("contract violation", "Real", "\"oops\"")
-  1 is_a Real.at_most("oops") ~throws values("contract violation", "Real", "\"oops\"")
-  1 is_a Real.in("oops", 2) ~throws values("contract violation", "Real", "\"oops\"")
-  1 is_a Real.in(1, "oops") ~throws values("contract violation", "Real", "\"oops\"")
+  1 is_a Real.above("oops") ~throws values(error.annot_msg(), "Real", "\"oops\"")
+  1 is_a Real.at_least("oops") ~throws values(error.annot_msg(), "Real", "\"oops\"")
+  1 is_a Real.below("oops") ~throws values(error.annot_msg(), "Real", "\"oops\"")
+  1 is_a Real.at_most("oops") ~throws values(error.annot_msg(), "Real", "\"oops\"")
+  1 is_a Real.in("oops", 2) ~throws values(error.annot_msg(), "Real", "\"oops\"")
+  1 is_a Real.in(1, "oops") ~throws values(error.annot_msg(), "Real", "\"oops\"")
 
   to_string(1/2) ~is "1/2"
   to_string(1/2, ~mode: #'expr) ~is "1/2"
@@ -105,153 +105,153 @@ check:
 // error reporting
 check:
   "oops" + 2 ~throws values(
-    "+: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "+: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   1 + "oops" ~throws values(
-    "+: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "+: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   "oops" - 2 ~throws values(
-    "-: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "-: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   1 - "oops" ~throws values(
-    "-: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "-: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   - "oops" ~throws values(
-    "-: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "-: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   "oops" * 2 ~throws values(
-    "*: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "*: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   1 * "oops" ~throws values(
-    "*: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "*: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   "oops" / 2 ~throws values(
-    "/: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "/: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   1 / "oops" ~throws values(
-    "/: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "/: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   "oops" ** 2 ~throws values(
-    "**: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "**: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   1 ** "oops" ~throws values(
-    "**: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    "**: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
 
 check:
   "oops" div 2 ~throws values(
-    "div: contract violation",
-    "expected: Integral",
-    "given: \"oops\"",
+    "div: " ++ error.annot_msg(),
+    error.annot("Integral").msg,
+    error.val("oops").msg,
   )
   1 div "oops" ~throws values(
-    "div: contract violation",
-    "expected: Integral",
-    "given: \"oops\"",
+    "div: " ++ error.annot_msg(),
+    error.annot("Integral").msg,
+    error.val("oops").msg,
   )
   "oops" rem 2 ~throws values(
-    "rem: contract violation",
-    "expected: Integral",
-    "given: \"oops\"",
+    "rem: " ++ error.annot_msg(),
+    error.annot("Integral").msg,
+    error.val("oops").msg,
   )
   1 rem "oops" ~throws values(
-    "rem: contract violation",
-    "expected: Integral",
-    "given: \"oops\"",
+    "rem: " ++ error.annot_msg(),
+    error.annot("Integral").msg,
+    error.val("oops").msg,
   )
   "oops" mod 2 ~throws values(
-    "mod: contract violation",
-    "expected: Integral",
-    "given: \"oops\"",
+    "mod: " ++ error.annot_msg(),
+    error.annot("Integral").msg,
+    error.val("oops").msg,
   )
   1 mod "oops" ~throws values(
-    "mod: contract violation",
-    "expected: Integral",
-    "given: \"oops\"",
+    "mod: " ++ error.annot_msg(),
+    error.annot("Integral").msg,
+    error.val("oops").msg,
   )
 
 check:
   "oops" .> 2 ~throws values(
-    ".>: contract violation",
-    "expected: Real",
-    "given: \"oops\"",
+    ".>: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val("oops").msg,
   )
   1 .> "oops" ~throws values(
-    ".>: contract violation",
-    "expected: Real",
-    "given: \"oops\"",
+    ".>: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val("oops").msg,
   )
   "oops" .>= 2 ~throws values(
-    ".>=: contract violation",
-    "expected: Real",
-    "given: \"oops\"",
+    ".>=: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val("oops").msg,
   )
   1 .>= "oops" ~throws values(
-    ".>=: contract violation",
-    "expected: Real",
-    "given: \"oops\"",
+    ".>=: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val("oops").msg,
   )
   "oops" .< 2 ~throws values(
-    ".<: contract violation",
-    "expected: Real",
-    "given: \"oops\"",
+    ".<: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val("oops").msg,
   )
   1 .< "oops" ~throws values(
-    ".<: contract violation",
-    "expected: Real",
-    "given: \"oops\"",
+    ".<: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val("oops").msg,
   )
   "oops" .<= 2 ~throws values(
-    ".<=: contract violation",
-    "expected: Real",
-    "given: \"oops\"",
+    ".<=: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val("oops").msg,
   )
   1 .<= "oops" ~throws values(
-    ".<=: contract violation",
-    "expected: Real",
-    "given: \"oops\"",
+    ".<=: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val("oops").msg,
   )
 
 check:
   "oops" .= 2 ~throws values(
-    ".=: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    ".=: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   1 .= "oops" ~throws values(
-    ".=: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    ".=: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   "oops" .!= 2 ~throws values(
-    ".!=: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    ".!=: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )
   1 .!= "oops" ~throws values(
-    ".!=: contract violation",
-    "expected: Number",
-    "given: \"oops\"",
+    ".!=: " ++ error.annot_msg(),
+    error.annot("Number").msg,
+    error.val("oops").msg,
   )

--- a/rhombus/rhombus/tests/pair.rhm
+++ b/rhombus/rhombus/tests/pair.rhm
@@ -28,33 +28,33 @@ check:
 check:
   Pair.first(1)
   ~throws values(
-    "Pair.first: contract violation",
-    "expected: Pair",
-    "given: 1",
+    "Pair.first: " ++ error.annot_msg(),
+    error.annot("Pair").msg,
+    error.val(1).msg,
   )
 
 check:
   (1 :~ Pair).first
   ~throws values(
-    "Pair.first: contract violation",
-    "expected: Pair",
-    "given: 1",
+    "Pair.first: " ++ error.annot_msg(),
+    error.annot("Pair").msg,
+    error.val(1).msg,
   )
 
 check:
   Pair.rest(2)
   ~throws values(
-    "Pair.rest: contract violation",
-    "expected: Pair",
-    "given: 2",
+    "Pair.rest: " ++ error.annot_msg(),
+    error.annot("Pair").msg,
+    error.val(2).msg,
   )
 
 check:
   (2 :~ Pair).rest
   ~throws values(
-    "Pair.rest: contract violation",
-    "expected: Pair",
-    "given: 2",
+    "Pair.rest: " ++ error.annot_msg(),
+    error.annot("Pair").msg,
+    error.val(2).msg,
   )
 
 check:

--- a/rhombus/rhombus/tests/pairlist.rhm
+++ b/rhombus/rhombus/tests/pairlist.rhm
@@ -35,9 +35,9 @@ check:
 check:
   PairList.length({1, 2, 3})
   ~throws values(
-    "PairList.length: contract violation",
-    "expected: PairList",
-    "given: {1, 2, 3}",
+    "PairList.length: " ++ error.annot_msg(),
+    error.annot("PairList").msg,
+    error.val({1, 2, 3}).msg,
   )
 
 check:
@@ -65,16 +65,16 @@ block:
   check:
     PairList[1, 2, 3] ++ [4, 5]
     ~throws values(
-      "PairList.append: contract violation",
-      "expected: PairList",
-      "given: [4, 5]",
+      "PairList.append: " ++ error.annot_msg(),
+      error.annot("PairList").msg,
+      error.val([4, 5]).msg,
     )
   check:
     PairList[1, 2, 3] ++ "oops"
     ~throws values(
-      "PairList.append: contract violation",
-      "expected: PairList",
-      "given: \"oops\""
+      "PairList.append: " ++ error.annot_msg(),
+      error.annot("PairList").msg,
+      error.val("oops").msg
     )
   check:
     PairList[1, 2, 3].append(PairList[4, 5])
@@ -288,9 +288,9 @@ check:
   PairList[1, 2].append(PairList[3]) ~is PairList[1, 2, 3]
   PairList[1, 2].append(PairList[3], PairList[4, 5]) ~is PairList[1, 2, 3, 4, 5]
   PairList[1, 2].append(3) ~throws values(
-    "PairList.append: contract violation",
-    "expected: PairList",
-    "given: 3",
+    "PairList.append: " ++ error.annot_msg(),
+    error.annot("PairList").msg,
+    error.val(3).msg,
   )
 
 check:
@@ -402,40 +402,40 @@ version_guard.at_least "8.13.0.1":
   check:
     PairList.to_sequence("oops")
     ~throws values(
-      "PairList.to_sequence: contract violation",
-      "expected: PairList",
-      "given: \"oops\"",
+      "PairList.to_sequence: " ++ error.annot_msg(),
+      error.annot("PairList").msg,
+      error.val("oops").msg,
     )
   check:
     ("oops" :~ PairList).to_sequence()
     ~throws values(
-      "PairList.to_sequence: contract violation",
-      "expected: PairList",
-      "given: \"oops\"",
+      "PairList.to_sequence: " ++ error.annot_msg(),
+      error.annot("PairList").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: "oops" :~ PairList):
       x
     ~throws values(
-      "PairList.to_sequence: contract violation",
-      "expected: PairList",
-      "given: \"oops\"",
+      "PairList.to_sequence: " ++ error.annot_msg(),
+      error.annot("PairList").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: PairList.to_sequence("oops")):
       x
     ~throws values(
-      "PairList.to_sequence: contract violation",
-      "expected: PairList",
-      "given: \"oops\"",
+      "PairList.to_sequence: " ++ error.annot_msg(),
+      error.annot("PairList").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: ("oops" :~ PairList).to_sequence()):
       x
     ~throws values(
-      "PairList.to_sequence: contract violation",
-      "expected: PairList",
-      "given: \"oops\"",
+      "PairList.to_sequence: " ++ error.annot_msg(),
+      error.annot("PairList").msg,
+      error.val("oops").msg,
     )
 
 check:
@@ -460,67 +460,67 @@ check:
 check:
   PairList[PairList.repet(PairList[1, 2, 3]), ...] ~is PairList[1, 2, 3]
   PairList[PairList.repet("oops"), ...] ~throws values(
-    "PairList.repet: contract violation",
-    "expected: PairList",
-    "given: \"oops\"",
+    "PairList.repet: " ++ error.annot_msg(),
+    error.annot("PairList").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ PairList)[0]
   ~throws values(
-    "PairList.get: contract violation",
-    "expected: PairList",
-    "given: \"oops\"",
+    "PairList.get: " ++ error.annot_msg(),
+    error.annot("PairList").msg,
+    error.val("oops").msg,
   )
 
 version_guard.at_least "8.14.0.4":
   check:
     (PairList[1, 2, 3] :~ PairList)["oops"]
     ~throws values(
-      "PairList.get: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "PairList.get: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
   check:
     (PairList[1, 2, 3] :~ PairList)[-1]
     ~throws values(
-      "PairList.get: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "PairList.get: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )
 
 check:
   ("oops" :~ PairList).first
   ~throws values(
-    "PairList.first: contract violation",
-    "expected: NonemptyPairList",
-    "given: \"oops\"",
+    "PairList.first: " ++ error.annot_msg(),
+    error.annot("NonemptyPairList").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ PairList).last
   ~throws values(
-    "PairList.last: contract violation",
-    "expected: NonemptyPairList",
-    "given: \"oops\"",
+    "PairList.last: " ++ error.annot_msg(),
+    error.annot("NonemptyPairList").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ PairList).rest
   ~throws values(
-    "PairList.rest: contract violation",
-    "expected: NonemptyPairList",
-    "given: \"oops\"",
+    "PairList.rest: " ++ error.annot_msg(),
+    error.annot("NonemptyPairList").msg,
+    error.val("oops").msg,
   )
 
 check:
   PairList.append("oops") ~throws values(
-    "PairList.append: contract violation",
-    "expected: PairList",
-    "given: \"oops\"",
+    "PairList.append: " ++ error.annot_msg(),
+    error.annot("PairList").msg,
+    error.val("oops").msg,
   )
   ("oops" :~ PairList).append() ~throws values(
-    "PairList.append: contract violation",
-    "expected: PairList",
-    "given: \"oops\"",
+    "PairList.append: " ++ error.annot_msg(),
+    error.annot("PairList").msg,
+    error.val("oops").msg,
   )

--- a/rhombus/rhombus/tests/port.rhm
+++ b/rhombus/rhombus/tests/port.rhm
@@ -147,15 +147,15 @@ check:
 check:
   ("oops" :~ Port.Output.String).get_string()
   ~throws values(
-    "Port.Output.get_string: contract violation",
-    "expected: Port.Output.String",
-    "given: \"oops\"",
+    "Port.Output.get_string: " ++ error.annot_msg(),
+    error.annot("Port.Output.String").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ Port.Output.String).get_bytes()
   ~throws values(
-    "Port.Output.get_bytes: contract violation",
-    "expected: Port.Output.String",
-    "given: \"oops\"",
+    "Port.Output.get_bytes: " ++ error.annot_msg(),
+    error.annot("Port.Output.String").msg,
+    error.val("oops").msg,
   )

--- a/rhombus/rhombus/tests/range.rhm
+++ b/rhombus/rhombus/tests/range.rhm
@@ -382,38 +382,38 @@ block:
     | #'~left:
         'check:
            "oops" $op $throws values(
-             #%literal $(to_string(op) ++ ": contract violation"),
-             "expected: Int",
-             "given: \"oops\"",
+             #%literal $(to_string(op) ++ ": " ++ error.annot_msg()),
+             error.annot("Int").msg,
+             error.val("oops").msg,
            )
            Range . $variant("oops") $throws values(
-             #%literal $("Range." ++ to_string(variant) ++ ": contract violation"),
-             "expected: Int",
-             "given: \"oops\"",
+             #%literal $("Range." ++ to_string(variant) ++ ": " ++ error.annot_msg()),
+             error.annot("Int").msg,
+             error.val("oops").msg,
            )'
     | #'~right:
         'check:
            $op "oops" $throws values(
-             #%literal $(to_string(op) ++ ": contract violation"),
-             "expected: Int",
-             "given: \"oops\"",
+             #%literal $(to_string(op) ++ ": " ++ error.annot_msg()),
+             error.annot("Int").msg,
+             error.val("oops").msg,
            )
            Range . $variant("oops") $throws values(
-             #%literal $("Range." ++ to_string(variant) ++ ": contract violation"),
-             "expected: Int",
-             "given: \"oops\"",
+             #%literal $("Range." ++ to_string(variant) ++ ": " ++ error.annot_msg()),
+             error.annot("Int").msg,
+             error.val("oops").msg,
            )'
     | #'~both:
         'check:
            "oops" $op 5 $throws values(
-             #%literal $(to_string(op) ++ ": contract violation"),
-             "expected: Int",
-             "given: \"oops\"",
+             #%literal $(to_string(op) ++ ": " ++ error.annot_msg()),
+             error.annot("Int").msg,
+             error.val("oops").msg,
            )
            0 $op "oops" $throws values(
-             #%literal $(to_string(op) ++ ": contract violation"),
-             "expected: Int",
-             "given: \"oops\"",
+             #%literal $(to_string(op) ++ ": " ++ error.annot_msg()),
+             error.annot("Int").msg,
+             error.val("oops").msg,
            )
            5 $op 0 $throws values(
              #%literal $(to_string(op) ++ ": starting point must be less than or equal to ending point"),
@@ -421,14 +421,14 @@ block:
              "ending point: 0",
            )
            Range . $variant("oops", 5) $throws values(
-             #%literal $("Range." ++ to_string(variant) ++ ": contract violation"),
-             "expected: Int",
-             "given: \"oops\"",
+             #%literal $("Range." ++ to_string(variant) ++ ": " ++ error.annot_msg()),
+             error.annot("Int").msg,
+             error.val("oops").msg,
            )
            Range . $variant(0, "oops") $throws values(
-             #%literal $("Range." ++ to_string(variant) ++ ": contract violation"),
-             "expected: Int",
-             "given: \"oops\"",
+             #%literal $("Range." ++ to_string(variant) ++ ": " ++ error.annot_msg()),
+             error.annot("Int").msg,
+             error.val("oops").msg,
            )
            Range . $variant(5, 0) $throws values(
              #%literal $("Range." ++ to_string(variant) ++ ": starting point must be less than or equal to ending point"),
@@ -700,86 +700,86 @@ block:
   check:
     Range.to_sequence("oops")
     ~throws values(
-      "Range.to_sequence: contract violation",
-      "expected: SequenceRange",
-      "given: \"oops\"",
+      "Range.to_sequence: " ++ error.annot_msg(),
+      error.annot("SequenceRange").msg,
+      error.val("oops").msg,
     )
   check:
     ("oops" :~ SequenceRange).to_sequence()
     ~throws values(
-      "Range.to_sequence: contract violation",
-      "expected: SequenceRange",
-      "given: \"oops\"",
+      "Range.to_sequence: " ++ error.annot_msg(),
+      error.annot("SequenceRange").msg,
+      error.val("oops").msg,
     )
   check:
     Range.step_by("oops", 2)
     ~throws values(
-      "Range.step_by: contract violation",
-      "expected: SequenceRange",
-      "given: \"oops\"",
+      "Range.step_by: " ++ error.annot_msg(),
+      error.annot("SequenceRange").msg,
+      error.val("oops").msg,
     )
   check:
     ("oops" :~ SequenceRange).step_by(2)
     ~throws values(
-      "Range.step_by: contract violation",
-      "expected: SequenceRange",
-      "given: \"oops\"",
+      "Range.step_by: " ++ error.annot_msg(),
+      error.annot("SequenceRange").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: "oops" :~ SequenceRange):
       x
     ~throws values(
-      "Range.to_sequence: contract violation",
-      "expected: SequenceRange",
-      "given: \"oops\"",
+      "Range.to_sequence: " ++ error.annot_msg(),
+      error.annot("SequenceRange").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: Range.to_sequence("oops")):
       x
     ~throws values(
-      "Range.to_sequence: contract violation",
-      "expected: SequenceRange",
-      "given: \"oops\"",
+      "Range.to_sequence: " ++ error.annot_msg(),
+      error.annot("SequenceRange").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: ("oops" :~ SequenceRange).to_sequence()):
       x
     ~throws values(
-      "Range.to_sequence: contract violation",
-      "expected: SequenceRange",
-      "given: \"oops\"",
+      "Range.to_sequence: " ++ error.annot_msg(),
+      error.annot("SequenceRange").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: Range.step_by("oops", 2)):
       x
     ~throws values(
-      "Range.step_by: contract violation",
-      "expected: SequenceRange",
-      "given: \"oops\"",
+      "Range.step_by: " ++ error.annot_msg(),
+      error.annot("SequenceRange").msg,
+      error.val("oops").msg,
     )
   check:
     for List (x: ("oops" :~ SequenceRange).step_by(2)):
       x
     ~throws values(
-      "Range.step_by: contract violation",
-      "expected: SequenceRange",
-      "given: \"oops\"",
+      "Range.step_by: " ++ error.annot_msg(),
+      error.annot("SequenceRange").msg,
+      error.val("oops").msg,
     )
 
 block:
   check:
     Range.to_list("oops")
     ~throws values(
-      "Range.to_list: contract violation",
-      "expected: ListRange",
-      "given: \"oops\"",
+      "Range.to_list: " ++ error.annot_msg(),
+      error.annot("ListRange").msg,
+      error.val("oops").msg,
     )
   check:
     ("oops" :~ ListRange).to_list()
     ~throws values(
-      "Range.to_list: contract violation",
-      "expected: ListRange",
-      "given: \"oops\"",
+      "Range.to_list: " ++ error.annot_msg(),
+      error.annot("ListRange").msg,
+      error.val("oops").msg,
     )
 
 // errors in optimized cases
@@ -788,17 +788,17 @@ block:
     for List (i: "oops"..5):
       i
     ~throws values(
-      "..: contract violation",
-      "expected: Int",
-      "given: \"oops\"",
+      "..: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("oops").msg,
     )
   check:
     for List (i: 0.."oops"):
       i
     ~throws values(
-      "..: contract violation",
-      "expected: Int",
-      "given: \"oops\"",
+      "..: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("oops").msg,
     )
   check:
     for List (i: 5..0):
@@ -812,17 +812,17 @@ block:
     for List (i: "oops"..=5):
       i
     ~throws values(
-      "..=: contract violation",
-      "expected: Int",
-      "given: \"oops\"",
+      "..=: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("oops").msg,
     )
   check:
     for List (i: 0..="oops"):
       i
     ~throws values(
-      "..=: contract violation",
-      "expected: Int",
-      "given: \"oops\"",
+      "..=: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("oops").msg,
     )
   check:
     for List (i: 5..=0):
@@ -836,9 +836,9 @@ block:
     for List (i: "oops"..):
       i
     ~throws values(
-      "..: contract violation",
-      "expected: Int",
-      "given: \"oops\"",
+      "..: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("oops").msg,
     )
 
 block:
@@ -846,17 +846,17 @@ block:
     for List (i: ("oops"..5).step_by(2)):
       i
     ~throws values(
-      "..: contract violation",
-      "expected: Int",
-      "given: \"oops\"",
+      "..: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("oops").msg,
     )
   check:
     for List (i: (0.."oops").step_by(2)):
       i
     ~throws values(
-      "..: contract violation",
-      "expected: Int",
-      "given: \"oops\"",
+      "..: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("oops").msg,
     )
   check:
     for List (i: (5..0).step_by(2)):
@@ -870,25 +870,25 @@ block:
     for List (i: (0..5).step_by("oops")):
       i
     ~throws values(
-      "Range.step_by: contract violation",
-      "expected: PosInt",
-      "given: \"oops\""
+      "Range.step_by: " ++ error.annot_msg(),
+      error.annot("PosInt").msg,
+      error.val("oops").msg
     )
   check:
     for List (i: ("oops"..=5).step_by(2)):
       i
     ~throws values(
-      "..=: contract violation",
-      "expected: Int",
-      "given: \"oops\"",
+      "..=: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("oops").msg,
     )
   check:
     for List (i: (0..="oops").step_by(2)):
       i
     ~throws values(
-      "..=: contract violation",
-      "expected: Int",
-      "given: \"oops\"",
+      "..=: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("oops").msg,
     )
   check:
     for List (i: (5..=0).step_by(2)):
@@ -902,25 +902,25 @@ block:
     for List (i: (0..=5).step_by("oops")):
       i
     ~throws values(
-      "Range.step_by: contract violation",
-      "expected: PosInt",
-      "given: \"oops\""
+      "Range.step_by: " ++ error.annot_msg(),
+      error.annot("PosInt").msg,
+      error.val("oops").msg
     )
   check:
     for List (i: ("oops"..).step_by(2)):
       i
     ~throws values(
-      "..: contract violation",
-      "expected: Int",
-      "given: \"oops\"",
+      "..: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("oops").msg,
     )
   check:
     for List (i: (0..).step_by("oops")):
       i
     ~throws values(
-      "Range.step_by: contract violation",
-      "expected: PosInt",
-      "given: \"oops\""
+      "Range.step_by: " ++ error.annot_msg(),
+      error.annot("PosInt").msg,
+      error.val("oops").msg
     )
 
 // non-unsafe for non-fixnums

--- a/rhombus/rhombus/tests/set.rhm
+++ b/rhombus/rhombus/tests/set.rhm
@@ -32,9 +32,9 @@ check:
 check:
   Set.length([1, 2, 3])
   ~throws values(
-    "Set.length: contract violation",
-    "expected: ReadableSet",
-    "given: [1, 2, 3]",
+    "Set.length: " ++ error.annot_msg(),
+    error.annot("ReadableSet").msg,
+    error.val([1, 2, 3]).msg,
   )
 
 block:
@@ -55,14 +55,14 @@ block:
     {1, 2, 3} ++ {4, 5} ~is {1, 2, 3, 4, 5}
     {1, 2, 3}.append({4, 5}) ~is {1, 2, 3, 4, 5}
     {1, 2, 3} ++ "oops" ~throws values(
-      "Set.append: contract violation",
-      "expected: Set",
-      "given: \"oops\"",
+      "Set.append: " ++ error.annot_msg(),
+      error.annot("Set").msg,
+      error.val("oops").msg,
     )
     {1, 2, 3} ++ MutableSet{4, 5} ~throws values(
-      "Set.append: contract violation",
-      "expected: Set",
-      "given: MutableSet{4, 5}",
+      "Set.append: " ++ error.annot_msg(),
+      error.annot("Set").msg,
+      error.val(MutableSet{4, 5}).msg,
     )
   check:
     Set("a", "b").length()
@@ -304,23 +304,23 @@ block:
   check:
     Set.append(MutableSet{1, 2, 3}, {4}, {5, 6})
     ~throws values(
-      "Set.append: contract violation",
-      "expected: Set",
-      "given: MutableSet{1, 2, 3}",
+      "Set.append: " ++ error.annot_msg(),
+      error.annot("Set").msg,
+      error.val(MutableSet{1, 2, 3}).msg,
     )
   check:
     Set.intersect(MutableSet{1, 3}, {2, 3}, {3, 4})
     ~throws values(
-      "Set.intersect: contract violation",
-      "expected: Set",
-      "given: MutableSet{1, 3}",
+      "Set.intersect: " ++ error.annot_msg(),
+      error.annot("Set").msg,
+      error.val(MutableSet{1, 3}).msg,
     )
   check:
     Set.union(MutableSet{1, 3}, {2, 3}, {3, 4})
     ~throws values(
-      "Set.union: contract violation",
-      "expected: Set",
-      "given: MutableSet{1, 3}",
+      "Set.union: " ++ error.annot_msg(),
+      error.annot("Set").msg,
+      error.val(MutableSet{1, 3}).msg,
     )
 
 block:
@@ -426,40 +426,40 @@ version_guard.at_least "8.13.0.1":
   check:
     Set.to_sequence("oops")
     ~throws values(
-      "Set.to_sequence: contract violation",
-      "expected: ReadableSet",
-      "given: \"oops\"",
+      "Set.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableSet").msg,
+      error.val("oops").msg,
     )
   check:
     ("oops" :~ Set).to_sequence()
     ~throws values(
-      "Set.to_sequence: contract violation",
-      "expected: ReadableSet",
-      "given: \"oops\"",
+      "Set.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableSet").msg,
+      error.val("oops").msg,
     )
   check:
     for Set (x: "oops" :~ Set):
       x
     ~throws values(
-      "Set.to_sequence: contract violation",
-      "expected: ReadableSet",
-      "given: \"oops\"",
+      "Set.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableSet").msg,
+      error.val("oops").msg,
     )
   check:
     for Set (x: Set.to_sequence("oops")):
       x
     ~throws values(
-      "Set.to_sequence: contract violation",
-      "expected: ReadableSet",
-      "given: \"oops\"",
+      "Set.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableSet").msg,
+      error.val("oops").msg,
     )
   check:
     for Set (x: ("oops" :~ Set).to_sequence()):
       x
     ~throws values(
-      "Set.to_sequence: contract violation",
-      "expected: ReadableSet",
-      "given: \"oops\"",
+      "Set.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableSet").msg,
+      error.val("oops").msg,
     )
 
 check:
@@ -1161,27 +1161,27 @@ block:
 check:
   ("oops" :~ Set)[0]
   ~throws values(
-    "Set.get: contract violation",
-    "expected: ReadableSet",
-    "given: \"oops\"",
+    "Set.get: " ++ error.annot_msg(),
+    error.annot("ReadableSet").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ MutableSet)[0] := 0
   ~throws values(
-    "MutableSet.set: contract violation",
-    "expected: MutableSet",
-    "given: \"oops\"",
+    "MutableSet.set: " ++ error.annot_msg(),
+    error.annot("MutableSet").msg,
+    error.val("oops").msg,
   )
 
 check:
   Set.append("oops") ~throws values(
-    "Set.append: contract violation",
-    "expected: Set",
-    "given: \"oops\"",
+    "Set.append: " ++ error.annot_msg(),
+    error.annot("Set").msg,
+    error.val("oops").msg,
   )
   ("oops" :~ Set).append() ~throws values(
-    "Set.append: contract violation",
-    "expected: Set",
-    "given: \"oops\"",
+    "Set.append: " ++ error.annot_msg(),
+    error.annot("Set").msg,
+    error.val("oops").msg,
   )

--- a/rhombus/rhombus/tests/statinfo-macro.rhm
+++ b/rhombus/rhombus/tests/statinfo-macro.rhm
@@ -88,7 +88,7 @@ block:
     statinfo_meta.wrap(c, statinfo_meta.intersect(statinfo_meta.gather(a), statinfo_meta.gather(b)))
   check (both ([]) ([]): [1])[0] ~is 1
   check (either ([]) ([]): [1])[0] ~is 1
-  check (both ([]) ([]): "")[0] ~throws "expected: List"
+  check (both ([]) ([]): "")[0] ~throws error.annot("List").msg
 
 check:
   ~eval

--- a/rhombus/rhombus/tests/string.rhm
+++ b/rhombus/rhombus/tests/string.rhm
@@ -46,9 +46,9 @@ block:
     "hello".get(0) ~is Char"h"
     "hello" ++ " " ++ "world" ~is "hello world"
     "hello" ++ " " ++ #"world" ~throws values(
-      "String.append: contract violation",
-      "expected: ReadableString",
-      "given: #\"world\"",
+      "String.append: " ++ error.annot_msg(),
+      error.annot("ReadableString").msg,
+      error.val(#"world").msg,
     )
     "hello".append(" world") ~is "hello world"
     "hello".append(" world", " and bye") ~is "hello world and bye"
@@ -236,135 +236,135 @@ version_guard.at_least "8.13.0.1":
   check:
     String.to_sequence(#"oops")
     ~throws values(
-      "String.to_sequence: contract violation",
-      "expected: ReadableString",
-      "given: #\"oops\"",
+      "String.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableString").msg,
+      error.val(#"oops").msg,
     )
   check:
     (#"oops" :~ ReadableString).to_sequence()
     ~throws values(
-      "String.to_sequence: contract violation",
-      "expected: ReadableString",
-      "given: #\"oops\"",
+      "String.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableString").msg,
+      error.val(#"oops").msg,
     )
   check:
     for List (x: #"oops" :~ ReadableString):
       x
     ~throws values(
-      "String.to_sequence: contract violation",
-      "expected: ReadableString",
-      "given: #\"oops\"",
+      "String.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableString").msg,
+      error.val(#"oops").msg,
     )
   check:
     for List (x: String.to_sequence(#"oops")):
       x
     ~throws values(
-      "String.to_sequence: contract violation",
-      "expected: ReadableString",
-      "given: #\"oops\"",
+      "String.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableString").msg,
+      error.val(#"oops").msg,
     )
   check:
     for List (x: (#"oops" :~ ReadableString).to_sequence()):
       x
     ~throws values(
-      "String.to_sequence: contract violation",
-      "expected: ReadableString",
-      "given: #\"oops\"",
+      "String.to_sequence: " ++ error.annot_msg(),
+      error.annot("ReadableString").msg,
+      error.val(#"oops").msg,
     )
 
 check:
   String.snapshot(#"oops") ~throws values(
-    "String.snapshot: contract violation",
-    "expected: ReadableString",
-    "given: #\"oops\"",
+    "String.snapshot: " ++ error.annot_msg(),
+    error.annot("ReadableString").msg,
+    error.val(#"oops").msg,
   )
   String.to_string(#"oops") ~throws values(
-    "String.to_string: contract violation",
-    "expected: ReadableString",
-    "given: #\"oops\"",
+    "String.to_string: " ++ error.annot_msg(),
+    error.annot("ReadableString").msg,
+    error.val(#"oops").msg,
   )
   (#"oops" :~ ReadableString).snapshot() ~throws values(
-    "String.snapshot: contract violation",
-    "expected: ReadableString",
-    "given: #\"oops\"",
+    "String.snapshot: " ++ error.annot_msg(),
+    error.annot("ReadableString").msg,
+    error.val(#"oops").msg,
   )
   (#"oops" :~ ReadableString).to_string() ~throws values(
-    "String.to_string: contract violation",
-    "expected: ReadableString",
-    "given: #\"oops\"",
+    "String.to_string: " ++ error.annot_msg(),
+    error.annot("ReadableString").msg,
+    error.val(#"oops").msg,
   )
 
 check:
   (#"oops" :~ ReadableString)[0]
   ~throws values(
-    "String.get: contract violation",
-    "expected: ReadableString",
-    "given: #\"oops\"",
+    "String.get: " ++ error.annot_msg(),
+    error.annot("ReadableString").msg,
+    error.val(#"oops").msg,
   )
 
 check:
   ("oops" :~ ReadableString)["oops"]
   ~throws values(
-    "String.get: contract violation",
-    "expected: NonnegInt",
-    "given: \"oops\"",
+    "String.get: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val("oops").msg,
   )
 
 check:
   ("oops" :~ ReadableString)[-1]
   ~throws values(
-    "String.get: contract violation",
-    "expected: NonnegInt",
-    "given: -1",
+    "String.get: " ++ error.annot_msg(),
+    error.annot("NonnegInt").msg,
+    error.val(-1).msg,
   )
 
 check:
   String.append(#"oops") ~throws values(
-    "String.append: contract violation",
-    "expected: ReadableString",
-    "given: #\"oops\"",
+    "String.append: " ++ error.annot_msg(),
+    error.annot("ReadableString").msg,
+    error.val(#"oops").msg,
   )
   (#"oops" :~ ReadableString).append() ~throws values(
-    "String.append: contract violation",
-    "expected: ReadableString",
-    "given: #\"oops\"",
+    "String.append: " ++ error.annot_msg(),
+    error.annot("ReadableString").msg,
+    error.val(#"oops").msg,
   )
 
 version_guard.at_least "8.14.0.7":
   check:
     String.make("oops", Char"a")
     ~throws values(
-      "String.make: contract violation",
-      "expected: NonnegInt",
-      "given: \"oops\"",
+      "String.make: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val("oops").msg,
     )
   check:
     String.make(-1, Char"a")
     ~throws values(
-      "String.make: contract violation",
-      "expected: NonnegInt",
-      "given: -1",
+      "String.make: " ++ error.annot_msg(),
+      error.annot("NonnegInt").msg,
+      error.val(-1).msg,
     )
   check:
     String.make(5, "oops")
     ~throws values(
-      "String.make: contract violation",
-      "expected: Char",
-      "given: \"oops\"",
+      "String.make: " ++ error.annot_msg(),
+      error.annot("Char").msg,
+      error.val("oops").msg,
     )
   check:
     String.make(5, "a")
     ~throws values(
-      "String.make: contract violation",
-      "expected: Char",
-      "given: \"a\"",
+      "String.make: " ++ error.annot_msg(),
+      error.annot("Char").msg,
+      error.val("a").msg,
     )
   check:
     String.make(5, Byte#"a")
     ~throws values(
-      "String.make: contract violation",
-      "expected: Char",
-      "given: 97",
+      "String.make: " ++ error.annot_msg(),
+      error.annot("Char").msg,
+      error.val(97).msg,
     )
 
 // checks static infos for elements


### PR DESCRIPTION
Use `raise-annotation-failure` interanally, and rewrite `'racket/primitive` messages from "contract violation" to "does not satisfy annotation".