### PR TITLE
shrubbery: fix handling of sign before `0x`/`0o`/`0b` integers

### DIFF
--- a/shrubbery/shrubbery/scribblings/token-parsing.scrbl
+++ b/shrubbery/shrubbery/scribblings/token-parsing.scrbl
@@ -187,7 +187,8 @@ but the table below describes the shape of @litchar("@") forms.
                        boptional(@nonterm{sign}),
                        @nonterm{nonneg}), ""],
     empty_line,
-    [no_lex, @nonterm{hexinteger}, bis, bseq(@litchar{0x},
+    [no_lex, @nonterm{hexinteger}, bis, bseq(boptional(@nonterm{sign}),
+                                             @litchar{0x},
                                              @nonterm{hex},
                                              kleenestar(@nonterm{ushex})), ""],
     empty_line,
@@ -200,7 +201,8 @@ but the table below describes the shape of @litchar("@") forms.
     empty_line,
 
 
-    [no_lex, @nonterm{octalinteger}, bis, bseq(@litchar{0o},
+    [no_lex, @nonterm{octalinteger}, bis, bseq(boptional(@nonterm{sign}),
+                                               @litchar{0o},
                                                @nonterm{octal},
                                                kleenestar(@nonterm{usoctal})), ""],
     empty_line,
@@ -210,7 +212,8 @@ but the table below describes the shape of @litchar("@") forms.
     ["", "", bor, bseq(@litchar{_}, @nonterm{octal}), ""],
     empty_line,
 
-    [no_lex, @nonterm{binaryinteger}, bis, bseq(@litchar{0b},
+    [no_lex, @nonterm{binaryinteger}, bis, bseq(boptional(@nonterm{sign}),
+                                                @litchar{0b},
                                                 @nonterm{bit},
                                                 kleenestar(@nonterm{usbit})), ""],
     empty_line,
@@ -222,7 +225,7 @@ but the table below describes the shape of @litchar("@") forms.
 
     [no_lex, @nonterm{fraction}, bis, bseq(@nonterm{integer}, @litchar{/}, @nonterm{nonneg}), @elem{@nonterm{nonneg} @notecol{not 0}}],
     empty_line,
-    
+
     [is_lex, @nonterm{boolean}, bis, @litchar{#true}, ""],
     ["", "", bor, @litchar{#false}, ""],
     empty_line,
@@ -285,6 +288,6 @@ but the table below describes the shape of @litchar("@") forms.
     [no_lex, @nonterm{atclose}, bis, @litchar("}"), ""],
     ["", "", bor, bseq(@litchar("}"), kleenestar(@nonterm{asciisym}), @litchar{|}),
      @notecol{flips opener chars}],
-    
+
   ]
 )

--- a/shrubbery/shrubbery/tests/input.rkt
+++ b/shrubbery/shrubbery/tests/input.rkt
@@ -32,7 +32,10 @@
          expected7
 
          input8
-         expected8)
+         expected8
+
+         input9
+         expected9)
 
 ;; input1 is split into parts to accommodate O(n^2) tests
 (define input1s
@@ -2407,3 +2410,100 @@ INPUT
   '(multi
     (group 1)
     (group 2)))
+
+(define input9
+#<<INPUT
+1
+1_0
+100_000
+
++1
++1_0
++100_000
+
+-1
+-1_0
+-100_000
+
+0b1
+0b1_0
+0b100_000
+
++0b1
++0b1_0
++0b100_000
+
+-0b1
+-0b1_0
+-0b100_000
+
+0o1
+0o1_0
+0o100_000
+
++0o1
++0o1_0
++0o100_000
+
+-0o1
+-0o1_0
+-0o100_000
+
+0x1
+0x1_0
+0x100_000
+0xABC_DEF
+
++0x1
++0x1_0
++0x100_000
++0xABC_DEF
+
+-0x1
+-0x1_0
+-0x100_000
+-0xABC_DEF
+INPUT
+  )
+
+(define expected9
+  '(multi
+    (group 1)
+    (group 10)
+    (group 100000)
+    (group +1)
+    (group +10)
+    (group +100000)
+    (group -1)
+    (group -10)
+    (group -100000)
+    (group #b1)
+    (group #b10)
+    (group #b100000)
+    (group #b+1)
+    (group #b+10)
+    (group #b+100000)
+    (group #b-1)
+    (group #b-10)
+    (group #b-100000)
+    (group #o1)
+    (group #o10)
+    (group #o100000)
+    (group #o+1)
+    (group #o+10)
+    (group #o+100000)
+    (group #o-1)
+    (group #o-10)
+    (group #o-100000)
+    (group #x1)
+    (group #x10)
+    (group #x100000)
+    (group #xABCDEF)
+    (group #x+1)
+    (group #x+10)
+    (group #x+100000)
+    (group #x+ABCDEF)
+    (group #x-1)
+    (group #x-10)
+    (group #x-100000)
+    (group #x-ABCDEF)))

--- a/shrubbery/shrubbery/tests/parse.rkt
+++ b/shrubbery/shrubbery/tests/parse.rkt
@@ -159,6 +159,7 @@
 (check 6 input6 expected6)
 (check 7 input7 expected7)
 (check 8 input8 expected8)
+(check 9 input9 expected9)
 
 (check 'mix (string-append "x:\n"
                            "  apple\tbanana\n"


### PR DESCRIPTION
Allow an optional sign before `0x`/`0o`/`0b` integers, like normal decimal integers.  Previously, the specification didn't allow an optional sign before `0x`/`0o`/`0b` integers, but the presence of sign would make the integer be parsed into `#false` instead of an error.