### PR TITLE
fill out `Path` and add support for path conventions

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/array.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/array.rkt
@@ -153,7 +153,7 @@
    'Array (string-append what " element") v annot-str
    "position" (unquoted-printing-string (number->string idx))))
 
-(void (set-primitive-subcontract! '(vector? (not/c immutable?)) 'mutable-vector?))
+(void (set-primitive-contract! '(and/c vector? (not/c immutable?)) "MutableArray"))
 (void (set-primitive-contract! 'mutable-vector? "MutableArray"))
 (define-annotation-syntax MutableArray (identifier-annotation mutable-vector? #,(get-array-static-infos)))
 (define-annotation-syntax ImmutableArray (identifier-annotation immutable-vector? #,(get-array-static-infos)))

--- a/rhombus-lib/rhombus/private/amalgam/boolean-annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/boolean-annotation.rkt
@@ -17,18 +17,9 @@
 ;; ----------------------------------------
 ;; &&
 
-(define (handle-combine/c sep-op-sep form)
-  (and (pair? (cdr form))
-       (list? (cdr form))
-       (or (get-primitive-subcontract (cdr form))
-           (apply string-append
-                  (get-or-format-primitive-contract (cadr form))
-                  (for/list ([contract/rkt (in-list (cddr form))])
-                    (string-append sep-op-sep (get-or-format-primitive-contract contract/rkt)))))))
-
-(define (handle-and/c form) (handle-combine/c " && " form))
-
-(void (set-primitive-contract-combinator! 'and/c handle-and/c))
+(void (set-primitive-contract-combinator! 'and/c
+                                          (lambda (form)
+                                            (get-combined-primitive-contract " && " form))))
 (define-annotation-syntax &&
   (annotation-infix-operator
    (lambda () `((,(annot-quote \|\|) . stronger)))
@@ -102,9 +93,9 @@
 ;; ----------------------------------------
 ;; ||
 
-(define (handle-or/c form) (handle-combine/c " || " form))
-
-(void (set-primitive-contract-combinator! 'or/c handle-or/c))
+(void (set-primitive-contract-combinator! 'or/c
+                                          (lambda (form)
+                                            (get-combined-primitive-contract " || " form))))
 (define-annotation-syntax \|\|
   (annotation-infix-operator
    null

--- a/rhombus-lib/rhombus/private/amalgam/boolean-annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/boolean-annotation.rkt
@@ -17,14 +17,16 @@
 ;; ----------------------------------------
 ;; &&
 
-(define (handle-and/c form)
+(define (handle-combine/c sep-op-sep form)
   (and (pair? (cdr form))
        (list? (cdr form))
        (or (get-primitive-subcontract (cdr form))
            (apply string-append
-                  (get-primitive-contract (cadr form))
+                  (get-or-format-primitive-contract (cadr form))
                   (for/list ([contract/rkt (in-list (cddr form))])
-                    (string-append " && " (get-primitive-contract contract/rkt)))))))
+                    (string-append sep-op-sep (get-or-format-primitive-contract contract/rkt)))))))
+
+(define (handle-and/c form) (handle-combine/c " && " form))
 
 (void (set-primitive-contract-combinator! 'and/c handle-and/c))
 (define-annotation-syntax &&
@@ -100,6 +102,9 @@
 ;; ----------------------------------------
 ;; ||
 
+(define (handle-or/c form) (handle-combine/c " || " form))
+
+(void (set-primitive-contract-combinator! 'or/c handle-or/c))
 (define-annotation-syntax \|\|
   (annotation-infix-operator
    null

--- a/rhombus-lib/rhombus/private/amalgam/box.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/box.rkt
@@ -113,7 +113,7 @@
 (define (raise-reboxer-error what v annot-str)
   (raise-binding-failure 'Box (string-append what " value") v annot-str))
 
-(void (set-primitive-subcontract! '(box? (not/c immutable?)) 'mutable-box?))
+(void (set-primitive-contract! '(and/c box? (not/c immutable?)) "MutableBox"))
 (void (set-primitive-contract! 'mutable-box? "MutableBox"))
 (define-annotation-syntax MutableBox (identifier-annotation mutable-box? #,(get-box-static-infos)))
 (define-annotation-syntax ImmutableBox (identifier-annotation immutable-box? #,(get-box-static-infos)))

--- a/rhombus-lib/rhombus/private/amalgam/bytes.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/bytes.rkt
@@ -66,7 +66,7 @@
    to_sequence
    snapshot))
 
-(void (set-primitive-subcontract! '(bytes? (not/c immutable?)) 'mutable-bytes?))
+(void (set-primitive-contract! '(and/c bytes? (not/c immutable?)) "MutableBytes"))
 (void (set-primitive-contract! 'mutable-bytes? "MutableBytes"))
 (define-annotation-syntax MutableBytes (identifier-annotation mutable-bytes? #,(get-bytes-static-infos)))
 (define-annotation-syntax ImmutableBytes (identifier-annotation immutable-bytes? #,(get-bytes-static-infos)))

--- a/rhombus-lib/rhombus/private/amalgam/class-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-primitive.rkt
@@ -90,6 +90,22 @@
                                    (string->symbol (format "~a/dispatch" (syntax-e #'name-method-proc))))
                                 nary))))
          ...)
+        (~optional (~seq #:dot-methods
+                         ((~and [dot-method name-dot-method-proc]
+                                (~parse dot-method-proc
+                                        (datum->syntax
+                                         #'dot-method
+                                         (string->symbol (format "~a/method" (syntax-e #'name-dot-method-proc)))))
+                                (~parse dot-method-dispatch
+                                        #`(#,(datum->syntax
+                                              #'dot-method
+                                              (string->symbol (format "~a/dispatch" (syntax-e #'name-dot-method-proc))))
+                                           nary)))
+                          ...))
+                   #:defaults ([(dot-method 1) null]
+                               [(name-dot-method-proc 1) null]
+                               [(dot-method-proc 1) null]
+                               [(dot-method-dispatch 1) null]))
         )
      #:do [(define transparent? (eq? '#:transparent (syntax-e #'mode)))
            (define translucent? (eq? '#:translucent (syntax-e #'mode)))
@@ -155,6 +171,8 @@
                         (hasheq (~@ 'prop prop-proc)
                                 ...
                                 (~@ 'method method-proc)
+                                ...
+                                (~@ 'dot-method dot-method-proc)
                                 ...)
                         #hasheq())
                  #,@(if (null? (syntax-e mutator-pairs))
@@ -168,6 +186,8 @@
                               (~@ 'prop prop-proc)
                               ...
                               (~@ 'method method-proc)
+                              ...
+                              (~@ 'dot-method dot-method-proc)
                               ...))
                  #,@(if (null? (syntax-e mutator-pairs))
                         '()
@@ -316,6 +336,8 @@
                                      (build-mutator-call (quote-syntax prop-mutator) e rhs reloc))))])]
                ...
                [(method) method-dispatch]
+               ...
+               [(dot-method) dot-method-dispatch]
                ...
                [else (~? (parent-dot-dispatch field-sym field-proc ary nary repetition? fail-k)
                          (fail-k))])))

--- a/rhombus-lib/rhombus/private/amalgam/core.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core.rkt
@@ -149,7 +149,8 @@
         "printable.rkt"
         "callable.rkt"
         "path-object.rkt"
-        "srcloc-object.rkt")
+        "srcloc-object.rkt"
+        "filesystem.rkt")
 
 (module reader racket/base
   (require (submod rhombus/private/core reader))

--- a/rhombus-lib/rhombus/private/amalgam/enum.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/enum.rkt
@@ -10,6 +10,8 @@
 (define-syntax (define-simple-symbol-enum stx)
   (syntax-parse stx
     [(_ name:id
+        (~or (~seq #:extra [extra-field ...])
+             (~seq))
         (~or* [val:id rkt-val:id]
               val:id)
         ...)
@@ -39,4 +41,7 @@
 
          (define-name-root name
            #:fields
-           ([val val-name] ...)))]))
+           ([val val-name]
+            ...
+            (~? (~@ extra-field
+                    ...)))))]))

--- a/rhombus-lib/rhombus/private/amalgam/error-adjust.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/error-adjust.rkt
@@ -1,0 +1,20 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre)
+         "rhombus-primitive.rkt")
+
+(provide with-error-adjust-primitive)
+
+(define-syntax (with-error-adjust-primitive stx)
+  (syntax-parse stx
+    [(_ () body) #'body]
+    [(_ () body ...) #'(let () body ...)]
+    [(_ ([rkt-sym rhm-sym] ...) body ...)
+     (with-syntax ([table (for/hash ([rkt-sym (in-list (syntax->list #'(rkt-sym ...)))]
+                                     [rhm-sym (in-list (syntax->list #'(rhm-sym ...)))])
+                            (values (syntax-e rkt-sym) (syntax-e rhm-sym)))])
+       #'(with-continuation-mark
+             primitive-who-table-key table
+             (let ()
+               body
+               ...)))]))

--- a/rhombus-lib/rhombus/private/amalgam/filesystem.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/filesystem.rkt
@@ -1,0 +1,55 @@
+#lang racket/base
+(require (for-syntax racket/base)
+         racket/path
+         "name-root.rkt"
+         "define-arity.rkt"
+         "annotation-failure.rkt"
+         "call-result-key.rkt"
+         (submod "path-object.rkt" for-static-info))
+
+(provide (for-space rhombus/namespace
+                    filesystem))
+
+(define-name-root filesystem
+  #:fields
+  ([simplify_path filesystem.simplify_path]
+   [normalize_path filesystem.normalize_path]
+   [resolve_path filesystem.resolve_path]
+   [expand_user_path filesystem.expand_user_path]
+   [file_exists filesystem.file_exists]
+   [directory_exists filesystem.directory_exists]
+   [link_exists filesystem.link_exists]))
+
+(define/arity (filesystem.simplify_path p)
+  #:local-primitive (simplify-path)
+  #:static-infos ((#%call-result #,(get-path-static-infos)))
+  (unless (path-string? p) (raise-annotation-failure who p "PathString"))
+  (simplify-path p #t))
+
+(define/arity (filesystem.normalize_path p)
+  #:local-primitive (simplify-path) ; potential error from `simplify-path` as called by `simple-form-path`
+  #:static-infos ((#%call-result #,(get-path-static-infos)))
+  (unless (path-string? p) (raise-annotation-failure who p "PathString"))
+  (simple-form-path p))
+
+(define/arity (filesystem.resolve_path p)
+  #:local-primitive (resolve-path)
+  #:static-infos ((#%call-result #,(get-path-static-infos)))
+  (resolve-path p))
+
+(define/arity (filesystem.expand_user_path p)
+  #:primitive (expand-user-path)
+  #:static-infos ((#%call-result #,(get-path-static-infos)))
+  (expand-user-path p))
+
+(define/arity (filesystem.file_exists p)
+  #:primitive (file-exists?)
+  (file-exists? p))
+
+(define/arity (filesystem.directory_exists p)
+  #:primitive (directory-exists?)
+  (directory-exists? p))
+
+(define/arity (filesystem.link_exists p)
+  #:primitive (link-exists?)
+  (link-exists? p))

--- a/rhombus-lib/rhombus/private/amalgam/map.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/map.rkt
@@ -162,7 +162,7 @@
    [snapshot Map.snapshot]
    [to_sequence Map.to_sequence]))
 
-(void (set-primitive-subcontract! '(hash? immutable?) 'immutable-hash?))
+(void (set-primitive-contract! '(and/c hash? immutable?) "Map"))
 (define-primitive-class Map map immutable-hash
   #:lift-declaration
   #:no-constructor-static-info
@@ -191,7 +191,7 @@
   (append
    remove))
 
-(void (set-primitive-subcontract! '(hash? (not/c immutable?)) 'mutable-hash?))
+(void (set-primitive-contract! '(and/c hash? (not/c immutable?)) "MutableMap"))
 (define-primitive-class MutableMap mutable-map mutable-hash
   #:lift-declaration
   #:no-constructor-static-info

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rhm
@@ -20,7 +20,7 @@ namespace PathString:
   fun
   | to_absolute_path(p :: PathString):
       Path.to_absolute_path(p)
-  | to_absolute_path(p :: PathString, ~relative_to: base_path :: PathString):
+  | to_absolute_path(p :: PathString, ~relative_to: base_path):
       Path.to_absolute_path(p, ~relative_to: base_path)
 
   annot.macro 'to_path':
@@ -33,8 +33,8 @@ namespace PathString:
   | 'to_absolute_path':
       'converting(fun (p :: PathString) :~ Path: to_absolute_path(p))'
 
-operator ((l_path :: PathString)
-            +/ (r_path :: PathString || matching(#'up) || matching(#'same)))
+operator ((l_path :: PathString || CrossPath || Path.Dot)
+            +/ (r_path :: PathString || CrossPath || Path.Dot))
   :~ Path:
     ~weaker_than ++
     Path.add(l_path, r_path)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
-(require (for-syntax racket/base)
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     "srcloc.rkt")
 	 racket/path
          "provide.rkt"
          "class-primitive.rkt"
@@ -9,17 +11,26 @@
          "compare-key.rkt"
          "index-result-key.rkt"
          "static-info.rkt"
+         "annotation-failure.rkt"
+         "enum.rkt"
+         "name-root.rkt"
+         "realm.rkt"
+         "rhombus-primitive.rkt"
+         "parens.rkt"
+         "parse.rkt"
          (submod "annotation.rkt" for-class)
          (submod "bytes.rkt" static-infos)
          (submod "function.rkt" for-info)
          (submod "list.rkt" for-listable)
-         (submod "string.rkt" static-infos))
+         (submod "string.rkt" static-infos)
+         (submod "symbol.rkt" for-static-info))
 
 (provide (for-spaces (rhombus/namespace
                       #f
                       rhombus/bind
                       rhombus/annot)
-                     Path)
+                     Path
+                     CrossPath)
          (for-space rhombus/annot
                     PathString))
 
@@ -29,27 +40,53 @@
 (module+ for-static-info
   (provide (for-syntax get-path-static-infos)))
 
-(define (path<=? p q)
-  (or (equal? p q) (path<? p q)))
+(define (path-order who p q)
+  (cond
+    [(path? p)
+     (cond
+       [(path? q) (cond
+                    [(path<? p q) -1]
+                    [(path<? q p) 1]
+                    [else 0])]
+       [(path-for-some-system? q) (if (eq? (path-convention-type p) 'unix)
+                                      1
+                                      -1)]
+       [else (raise-annotation-failure who q "CrossPath")])]
+    [(path-for-some-system? p)
+     (cond
+       [(path? q) 1]
+       [(path-for-some-system? q)
+        (cond
+          [(eq? (path-convention-type p)
+                (path-convention-type q))
+           (cond
+             [(bytes<? (path->bytes p) (path->bytes q)) -1]
+             [(bytes>? (path->bytes p) (path->bytes q)) 1]
+             [else 0])]
+          [(eq? (path-convention-type p) 'unix) -1]
+          [else 1])]
+       [else (raise-annotation-failure who q "CrossPath")])]
+    [else (raise-annotation-failure who p "CrossPath")]))
 
-(define (path!=? p q)
-  (not (equal? p q)))
+(define (cross-path<? p q) ((path-order '|Path.(<)| p q) . < . 0))
+(define (path<=? p q) ((path-order '|Path.(<=)| p q) . <= . 0))
+(define (path=? p q) ((path-order '|Path.(=)| p q) . = . 0))
+(define (path>=? p q) ((path-order '|Path.(>=)| p q) . >= . 0))
+(define (path>? p q) ((path-order '|Path.(>)| p q) . > . 0))
+(define (path!=? p q) (not ((path-order '|Path.(=)| p q) . = . 0)))
 
-(define (path>=? p q)
-  (or (equal? p q) (path<? q p)))
-
-(define (path>? p q)
-  (path<? q p))
+(define-static-info-getter get-any-path-static-infos
+  (#%compare ((< cross-path<?)
+              (<= path<=?)
+              (> path>?)
+              (>= path>=?)
+              (= path=?)
+              (!= path!=?))))
 
 (define-primitive-class Path path
   #:lift-declaration
   #:no-constructor-static-info
-  #:instance-static-info ((#%compare ((< path<?)
-                                      (<= path<=?)
-                                      (> path>?)
-                                      (>= path>=?)
-                                      (= equal?)
-                                      (!= path!=?))))
+  #:instance-static-info #,(get-any-path-static-infos)
   #:existing
   #:translucent
   #:fields
@@ -57,17 +94,32 @@
   #:namespace-fields
   ([Absolute Path.Absolute]
    [Relative Path.Relative]
+   [DriveRelative Path.DriveRelative]
+   [Element Path.Element]
+   [Directory Path.Directory]
+   [Dot Path.Dot]
+   [like Path.like]
    [current_directory current-directory])
   #:properties
   ()
   #:methods
-  (bytes
+  (name
+   parent
+   bytes
+   string
+   convention
    add
    split
-   string
    to_absolute_path
+   to_directory_path
    directory_only
-   add_suffix))
+   suffix
+   add_suffix
+   replace_suffix
+   cleanse
+   normal_case
+   simplify
+   as_relative_to))
 
 (define/arity #:name Path (path c)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
@@ -75,15 +127,82 @@
     [(path? c) c]
     [(bytes? c) (bytes->path c)]
     [(string? c) (string->path c)]
-    [else (raise-annotation-failure who c "String || Bytes || Path")]))
+    [(or (eq? c 'up) (eq? c 'same)) (build-path c)]
+    [else (raise-annotation-failure who c "ReadableString || Bytes || Path || Path.Dot")]))
+
+(define-primitive-class CrossPath path-for-some-system
+  #:lift-declaration
+  #:no-constructor-static-info
+  #:instance-static-info #,(get-any-path-static-infos)
+  #:existing
+  #:translucent
+  #:fields
+  ([bytes Path.bytes #,(get-bytes-static-infos)]
+   [convention Path.convention #,(get-symbol-static-infos)])
+  #:namespace-fields
+  ([Absolute CrossPath.Absolute]
+   [Relative CrossPath.Relative]
+   [DriveRelative CrossPath.DriveRelative]
+   [Element CrossPath.Element]
+   [Directory CrossPath.Directory]
+   [Unix CrossPath.Unix]
+   [Windows CrossPath.Windows]
+   [Convention CrossPath.Convention])
+  #:properties
+  ()
+  #:methods
+  ()
+  #:dot-methods
+  ([name Path.name]
+   [parent Path.parent]
+   [bytes Path.bytes]
+   [string Path.string]
+   [convention Path.convention]
+   [add Path.add]
+   [split Path.split]
+   [to_absolute_path Path.to_absolute_path]
+   [to_directory_path Path.to_directory_path]
+   [directory_only Path.directory_only]
+   [suffix Path.suffix]
+   [add_suffix Path.add_suffix]
+   [replace_suffix Path.replace_suffix]
+   [cleanse Path.cleanse]
+   [normal_case Path.normal_case]
+   [simplify Path.simplify]
+   [as_relative_to Path.as_relative_to]))
+
+(define/arity #:name CrossPath (path-for-some-system bstr [c (system-path-convention-type)])
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (unless (or (bytes? bstr) (eq? bstr 'up) (eq? bstr 'same))
+    (raise-annotation-failure who bstr "Bytes || Path.Dot"))
+  (unless (or (eq? c 'unix) (eq? c 'windows)) (raise-annotation-failure who c "CrossPath.Convention"))
+  (if (bytes? bstr)
+      (bytes->path bstr c)
+      (build-path/convention-type c bstr)))
 
 (define (path-is-absolute? v)
   (and (path? v)
-       (absolute-path? v)))
+       (complete-path? v)))
 
 (define (path-is-relative? v)
   (and (path? v)
-       (not (absolute-path? v))))
+       (relative-path? v)))
+
+(define (path-is-drive-relative? v)
+  (and (path? v)
+       (absolute-path? v)
+       (not (complete-path? v))))
+
+(define (path-dot? v)
+  (or (eq? v 'same) (eq? v 'up)))
+
+(define (path-directory? s)
+  (and (path? s)
+       (let-values ([(base name dir?) (split-path s)])
+         dir?)))
+
+(define (this-system-path-element? s)
+  (and (path? s) (path-element? s)))
 
 (define-annotation-syntax Path.Absolute
   (identifier-annotation path-is-absolute? #,(get-path-static-infos)))
@@ -91,15 +210,101 @@
 (define-annotation-syntax Path.Relative
   (identifier-annotation path-is-relative? #,(get-path-static-infos)))
 
+(define-annotation-syntax Path.DriveRelative
+  (identifier-annotation path-is-absolute? #,(get-path-static-infos)))
+
+(define-name-root Path.Element
+  #:fields
+  ([maybe Path.Element.maybe]
+   [string Path.Element.string]
+   [bytes Path.Element.bytes]))
+
+(define-annotation-syntax Path.Element
+  (identifier-annotation this-system-path-element? #,(get-path-static-infos)))
+
+(define-annotation-syntax Path.Directory
+  (identifier-annotation path-directory? #,(get-path-static-infos)))
+
+(define-simple-symbol-enum Path.Dot
+  up
+  same)
+
+(define-annotation-syntax Path.like
+  (annotation-prefix-operator
+   '((default . stronger))
+   'macro
+   (lambda (stx)
+     (syntax-parse stx
+       [(form-id (~and args (_::parens g)) . tail)
+        (values (annotation-predicate-form
+                 (relocate+reraw
+                  (datum->syntax #f (list #'form-id #'args))
+                  #`(let ([c (path-like-convention 'form-id (rhombus-expression g))])
+                      (lambda (v)
+                        (and (path-for-some-system? v)
+                             (eq? (path-convention-type v) c)))))
+                 (get-path-for-some-system-static-infos))
+                #'tail)]))))
+
+(define (path-like-convention who v)
+  (cond
+    [(path-for-some-system? v)
+     (path-convention-type v)]
+    [(or (path-string? v)
+         (eq? v 'up)
+         (eq? v 'same))
+     (system-path-convention-type)]
+    [else (raise-annotation-failure who v "PathString || CrossPath || Path.Dot")]))
+
+(define/arity (Path.Element bstr)
+  #:primitive (bytes->path-element)
+  #:static-infos ((#%call-result #,(get-path-static-infos)))
+  (unless (bytes? bstr) (raise-annotation-failure who bstr "Bytes"))
+  (bytes->path-element bstr))
+
+(define/arity (Path.Element.maybe bstr)
+  (unless (bytes? bstr) (raise-annotation-failure who bstr "Bytes"))
+  (bytes->path-element bstr (system-path-convention-type) #t))
+
+(define/arity (Path.Element.string p)
+  (unless (this-system-path-element? p) (raise-annotation-failure who p "Path.Element"))
+  (string->immutable-string (path-element->string p)))
+
+(define/arity (Path.Element.bytes p)
+  (unless (this-system-path-element? p) (raise-annotation-failure who p "Path.Element"))
+  (bytes->immutable-bytes (path-element->bytes p)))
+
 (define-static-info-syntax current-directory
   (#%function-arity 3)
   (#%call-result #,(get-path-static-infos))
   . #,(get-function-static-infos))
 
-(define/method (Path.bytes s)
+(define/method (Path.name p)
+  #:local-primitive (split-path)
+  (define-values (parent name dir?) (split-path p))
+  name)
+
+(define/method (Path.parent p)
+  #:local-primitive (split-path)
+  (define-values (parent name dir?) (split-path p))
+  parent)
+
+(define/method (Path.bytes p)
   #:primitive (path->bytes)
   #:static-infos ((#%call-result #,(get-bytes-static-infos)))
-  (bytes->immutable-bytes (path->bytes s)))
+  (bytes->immutable-bytes (path->bytes p)))
+
+(define/method (Path.string s)
+  #:primitive (path->string)
+  #:static-infos ((#%call-result #,(get-string-static-infos)))
+  (if (path-for-some-system? s)
+      (string->immutable-string (some-system-path->string s))
+      (string->immutable-string (path->string s))))
+
+(define/method (Path.convention p)
+  #:primitive (path-convention-type)
+  #:static-infos ((#%call-result #,(get-symbol-static-infos)))  
+  (path-convention-type p))
 
 (define/method (Path.add p . ss)
   #:primitive (build-path)
@@ -108,26 +313,144 @@
 
 (define/method (Path.split p)
   #:primitive (explode-path)
-  #:static-infos ((#%call-result #,(get-treelist-static-infos)))
+  #:static-infos ((#%call-result (#,@(get-treelist-static-infos)
+                                  (#%ref-result #,(get-path-static-infos)))))
   (to-treelist #f (explode-path p)))
 
 (define/method (Path.directory_only p)
   #:primitive (path-only)
   (path-only p))
 
-(define/method (Path.add_suffix p sfx)
-  #:primitive (path-add-suffix)
-  #:static-infos ((#%call-result #,(get-path-static-infos)))
-  (path-add-suffix p sfx))
+(define/method (Path.suffix p)
+  #:primitive (path-get-extension)
+  (define maybe-bstr (path-get-extension p))
+  (and maybe-bstr (bytes->immutable-bytes maybe-bstr)))
 
-(define/method (Path.string s)
-  #:primitive (path->string)
-  #:static-infos ((#%call-result #,(get-string-static-infos)))
-  (string->immutable-string (path->string s)))
+(define/method (Path.add_suffix p sfx #:sep [sep "_"])
+  #:primitive (path-add-extension)
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (path-add-extension p sfx sep))
+
+(define/method (Path.replace_suffix p sfx)
+  #:primitive (path-replace-extension)
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (path-replace-extension p sfx))
 
 (define/method (Path.to_absolute_path p #:relative_to [base-path (current-directory)])
   #:primitive (path->complete-path)
-  #:static-infos ((#%call-result #,(get-path-static-infos)))
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
   (path->complete-path p base-path))
 
+(define/method (Path.to_directory_path p)
+  #:primitive (path->directory-path)
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (path->directory-path p))
+
+(define/method (Path.cleanse p)
+  #:primitive (cleanse-path)
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (cleanse-path p))
+
+(define/method (Path.normal_case p)
+  #:primitive (normal-case-path)
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (normal-case-path p))
+
+(define/method (Path.simplify p)
+  #:primitive (simplify)
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (unless (path-string? p) (raise-annotation-failure who p "PathString"))
+  (simplify-path p #f))
+
+(define/method (Path.as_relative_to p base-p
+                                    #:more_than_root [more-than-root? #f]
+                                    #:more_than_same [more-than-same? #t]
+                                    #:normal_case [normalize-case? #t])
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (unless (or (path-string? p) (path-for-some-system? p)) (raise-annotation-failure who p "PathString || CrossPath"))
+  (unless (or (path-string? base-p) (path-for-some-system? p)) (raise-annotation-failure who base-p "PathString || CrossPath"))
+  (find-relative-path base-p
+                      (if (string? p) (string->path p) p)
+                      #:more-than-root? more-than-root?	 
+                      #:more-than-same? more-than-same?	 
+                      #:normalize-case? normalize-case?))
+
 (define-annotation-syntax PathString (identifier-annotation path-string? ()))
+
+(define (path-for-some-system-is-absolute? v)
+  (and (path-for-some-system? v)
+       (complete-path? v)))
+
+(define (path-for-some-system-is-relative? v)
+  (and (path-for-some-system? v)
+       (relative-path? v)))
+
+(define (path-for-some-system-is-drive-relative? v)
+  (and (path-for-some-system? v)
+       (absolute-path? v)
+       (not (complete-path? v))))
+
+(define (some-system-path-element? s)
+  (path-element? s))
+
+(define (some-system-path-directory? s)
+  (and (path-element? s)
+       (let-values ([(base name dir?) (split-path s)])
+         dir?)))
+
+(define-annotation-syntax CrossPath.Absolute
+  (identifier-annotation path-for-some-system-is-absolute? #,(get-path-for-some-system-static-infos)))
+
+(define-annotation-syntax CrossPath.Relative
+  (identifier-annotation path-for-some-system-is-relative? #,(get-path-for-some-system-static-infos)))
+
+(define-annotation-syntax CrossPath.DriveRelative
+  (identifier-annotation path-for-some-system-is-drive-relative? #,(get-path-for-some-system-static-infos)))
+
+(define-annotation-syntax CrossPath.Element
+  (identifier-annotation some-system-path-element? #,(get-path-for-some-system-static-infos)))
+
+(define-annotation-syntax CrossPath.Directory
+  (identifier-annotation some-system-path-directory? #,(get-path-for-some-system-static-infos)))
+
+(define-simple-symbol-enum CrossPath.Convention
+  #:extra
+  ([current CrossPath.Convention.current])
+  unix
+  windows)
+
+(define/arity (CrossPath.Convention.current)
+  #:static-infos ((#%call-result #,(get-symbol-static-infos)))
+  (system-path-convention-type))
+
+(define (path-is-unix? v)
+  (and (path-for-some-system? v)
+       (eq? 'unix (path-convention-type v))))
+
+(define (path-is-windows? v)
+  (and (path-for-some-system? v)
+       (eq? 'windows (path-convention-type v))))
+
+(define-annotation-syntax CrossPath.Unix
+  (identifier-annotation path-is-unix? #,(get-path-for-some-system-static-infos)))
+
+(define-annotation-syntax CrossPath.Windows
+  (identifier-annotation path-is-windows? #,(get-path-for-some-system-static-infos)))
+
+(define (CrossPath/convention who bstr convention)
+  (unless (or (bytes? bstr) (eq? bstr 'up) (eq? bstr 'same))
+    (raise-annotation-failure who bstr "Bytes || Path.Dot"))
+  (if (bytes? bstr)
+      (bytes->path bstr convention)
+      (build-path/convention-type convention bstr)))
+
+(define/arity (CrossPath.Unix bstr)
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (CrossPath/convention who bstr 'unix))
+
+(define/arity (CrossPath.Windows bstr)
+  #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (CrossPath/convention who bstr 'windows))
+
+(void (set-primitive-contract! 'path-string? "PathString"))
+(void (set-primitive-contract! '(or/c path-string? path-for-some-system? 'up 'same) "PathString || CrossPath || Path.Dot"))

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -96,7 +96,7 @@
   (and (output-port? v)
        (string-port? v)))
 
-(void (set-primitive-subcontract! '(output-port? string-port?) 'output-string-port?))
+(void (set-primitive-contract! '(and/c output-port? string-port?) "Port.Output.String"))
 (define-primitive-class Port.Output.String output-string-port
   #:lift-declaration
   #:existing

--- a/rhombus-lib/rhombus/private/amalgam/print.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/print.rkt
@@ -150,14 +150,25 @@
      (display (if v "#true" "#false") op)]
     [(void? v)
      (display "#void" op)]
-    [(path? v)
+    [(path-for-some-system? v)
      (cond
        [(display?)
         (display v op)]
        [else
         (concat
-         (display "Path(" op)
-         (write (path->string v) op)
+         (cond
+           [(path? v)
+            (concat
+             (display "Path(" op)
+             (write (path->string v) op))]
+           [(eq? (path-convention-type v) 'unix)
+            (concat
+             (display "CrossPath.Unix(" op)
+             (write (path->bytes v) op))]
+           [else
+            (concat
+             (display "CrossPath.Windows(" op)
+             (write (path->bytes v) op))])
          (display ")" op))])]
     [(and (procedure? v)
           (not (printer-ref v #f)))

--- a/rhombus-lib/rhombus/private/amalgam/rhombus-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/rhombus-primitive.rkt
@@ -4,6 +4,7 @@
          set-primitive-subcontract!
          set-primitive-who!
          get-primitive-contract
+         get-or-format-primitive-contract
          get-primitive-subcontract
          get-primitive-who
          primitive-who-table-key)
@@ -39,6 +40,18 @@
      => (lambda (handler)
           (handler contract/rkt))]
     [else #f]))
+
+(define (get-or-format-primitive-contract ctc)
+  (or (get-primitive-contract ctc)
+      (cond
+        [(not ctc) "False"]
+        [(and (pair? ctc)
+              (eq? 'quote (car ctc))
+              (= 2 (length ctc)))
+         (format "matching(~a)"
+                 ((error-value->string-handler) (cadr ctc) (error-print-width)))]
+        [else
+         ((error-value->string-handler) ctc (error-print-width))])))
 
 (define (get-primitive-subcontract contracts/rkt)
   (cond

--- a/rhombus-lib/rhombus/private/amalgam/rhombus-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/rhombus-primitive.rkt
@@ -5,7 +5,8 @@
          set-primitive-who!
          get-primitive-contract
          get-primitive-subcontract
-         get-primitive-who)
+         get-primitive-who
+         primitive-who-table-key)
 
 (define primitive-contract-table (make-hash))
 
@@ -14,6 +15,8 @@
 (define primitive-subcontract-table (make-hash))
 
 (define primitive-who-table (make-hasheq))
+
+(define primitive-who-table-key (gensym 'who-table))
 
 (define (set-primitive-contract! contract/rkt contract/rhm)
   (hash-set! primitive-contract-table contract/rkt contract/rhm))
@@ -29,11 +32,13 @@
 
 (define (get-primitive-contract contract/rkt)
   (cond
+    [(hash-ref primitive-contract-table contract/rkt #f)
+     => (lambda (contract/rhm) contract/rhm)]
     [(and (pair? contract/rkt)
           (hash-ref primitive-contract-combinator-table (car contract/rkt) #f))
      => (lambda (handler)
           (handler contract/rkt))]
-    [else (hash-ref primitive-contract-table contract/rkt #f)]))
+    [else #f]))
 
 (define (get-primitive-subcontract contracts/rkt)
   (cond
@@ -43,4 +48,5 @@
     [else #f]))
 
 (define (get-primitive-who who/rkt)
-  (hash-ref primitive-who-table who/rkt #f))
+  (or (hash-ref (continuation-mark-set-first #f primitive-who-table-key #hasheq()) who/rkt #f)
+      (hash-ref primitive-who-table who/rkt #f)))

--- a/rhombus-lib/rhombus/private/amalgam/string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/string.rkt
@@ -76,6 +76,8 @@
   #:properties
   ()
   #:methods
+  ()
+  #:dot-methods
   ([length String.length]
    [get String.get]
    [contains String.contains]

--- a/rhombus-scribble-lib/rhombus/scribble/private/rhombus-doc.rkt
+++ b/rhombus-scribble-lib/rhombus/scribble/private/rhombus-doc.rkt
@@ -278,11 +278,11 @@
 (define-for-syntax (identifier-macro-extract-typeset stx space-name subst)
   (syntax-parse stx
     #:datum-literals ($ group op quotes)
-    [(group _::doc-form (quotes (~and g (group (~var id (identifier-target space-name)) e ...)) g2 ...))
+    [(group _::doc-form (quotes (~and g ((~and g-tag group) (~var id (identifier-target space-name)) e ...)) g2 ...))
      (rb #:at #'g
          #:pattern? #t
          #`(multi
-            (group #,@(subst #'id.name) e ...)
+            (g-tag #,@(subst #'id.name) e ...)
             g2
             ...))]
     [(group _::doc-form (quotes (~var id (identifier-target space-name))))

--- a/rhombus/rhombus/scribblings/reference/cross_path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/cross_path.scrbl
@@ -1,0 +1,107 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@title(~tag: "cross-path"){Cross-Platform Paths}
+
+A @deftech{cross-platform path} value represents a filesystem path
+combined with @rhombus(#'unix) or @rhombus(#'windows) to indicate the
+filesystem's path convention. A cross-platform path whose convention
+matches the current host system is also a @tech{path}. The @rhombus(.)
+operator can be used on a cross-platform path expression in the same way
+as path expressions.
+
+Cross-platform paths are @tech{comparable} the same as paths, which
+means that generic operations like @rhombus(<) and @rhombus(>) work on
+paths, cross-platform paths, and combinations. Paths with the
+@rhombus(#'unix) convention are ordered before paths with the
+@rhombus(#'windows) convention.
+
+@doc(
+  enum CrossPath.Convention:
+    unix
+    windows
+  annot.macro 'CrossPath'
+  annot.macro 'CrossPath.Absolute'
+  annot.macro 'CrossPath.Relative'
+  annot.macro 'CrossPath.DriveRelative'
+  annot.macro 'CrossPath.Directory'
+  annot.macro 'CrossPath.Element'
+  annot.macro 'CrossPath.Unix'
+  annot.macro 'CrossPath.Windows'
+){
+
+ The @rhombus(CrossPath.Convention, ~annot) enumeration represents the
+ two supported path conventions. Other annotations are analogous to
+ @rhombus(Path, ~annot), @rhombus(Path.Absolute, ~annot),
+ @rhombus(Path.Relative, ~annot), @rhombus(Path.DriveRelative, ~annot),
+ @rhombus(Path.Directory, ~annot), @rhombus(Path.Element, ~annot). The
+ @rhombus(CrossPath.Unix, ~annot) and @rhombus(CrossPath.Windows, ~annot)
+ annotations are satisfied by cross-platform paths with those respective
+ conventions.
+
+ Every @rhombus(Path, ~annot) is also a @rhombus(CrossPath, ~annot), and
+ @rhombus(Path.convention) for a @rhombus(Path, ~annot) will produce the
+ same symbol as @rhombus(CrossPath.Convention.current()). Operations on
+ @rhombus(CrossPath, ~annot)s also work on @rhombus(Path, ~annot), but
+ they typically do not accept strings, instead requiring
+ @rhombus(Path, ~annot) or @rhombus(CrossPath, ~annot) values that have
+ an associated convention.
+
+}
+
+
+@doc(
+  fun CrossPath(
+    cross_path :: Bytes || Path.Dot || CrossPath,
+    convention :: CrossPath.Convention = CrossPath.Convention.current()
+  ) :: CrossPath
+  fun CrossPath.Unix(cross_path :: Bytes || Path.Dot) :: CrossPath
+  fun CrossPath.Windows(cross_path :: Bytes || Path.Dot) :: CrossPath
+){
+
+ The @rhombus(CrossPath) function constructs a @tech{cross-platform
+  path} given a byte string and path convention. When a cross-platform
+ path is provided as @rhombus(cross_path), then the result is
+ @rhombus(cross_path).
+
+ The @rhombus(CrossPath.Unix) and @rhombus(CrossPath.Windows) functions
+ are shorthands for @rhombus(CrossPath) with @rhombus(#'unix) and
+ @rhombus(#'windows), respectively.
+
+@examples(
+  def p = CrossPath(#"/home/rhombus/shape.txt", #'unix)
+  p.string()
+  p.convention()
+)
+
+}
+
+@doc(
+  ~nonterminal:
+    bytes_bind: def bind ~defn
+    convention_bind: def bind ~defn
+  bind.macro 'CrossPath($bytes_bind, $convention_bind)'
+){
+
+ Matches a cross-platform path where the byte-string form of the path
+ matches @rhombus(bytes_bind) and the convention matches
+ @rhombus(convention_bind).
+
+@examples(
+  def CrossPath(bstr, _) = Path("/home/rhombus/shape.txt")
+  bstr
+)
+
+}
+
+
+@doc(
+  fun CrossPath.Convention.current() :: CrossPath.Convention
+){
+
+ Reports the convention of the current platform, either @rhombus(#'unix)
+ or @rhombus(#'windows).
+
+}

--- a/rhombus/rhombus/scribblings/reference/filesystem.scrbl
+++ b/rhombus/rhombus/scribblings/reference/filesystem.scrbl
@@ -1,0 +1,74 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@title(~tag: "filesystem"){Filesystem}
+
+@doc(
+  fun filesystem.file_exists(path :: PathString) :: Boolean
+  fun filesystem.directory_exists(path :: PathString) :: Boolean
+  fun filesystem.link_exists(path :: PathString) :: Boolean
+){
+
+ Reports whether @rhombus(path) refers to an existing file, directory,
+ or soft link, respectively. The @rhombus(filesystem.link_exists) result
+ is not mutually exclusive with the other two: when @rhombus(path) refers
+ to a soft link, @rhombus(filesystem.file_exists) and
+ @rhombus(filesystem.directory_exists) report whether the link reaches a
+ file or directory.
+
+}
+
+
+@doc(
+  fun filesystem.simplify_path(path :: PathString) :: Path
+  fun filesystem.normalize_path(path :: PathString) :: Path
+){
+
+ The @rhombus(filesystem.simplify_path) is similar to
+ @rhombus(Path.simplify), but @rhombus(filesystem.simplify_path)
+ simplifies based on the filesystem, while @rhombus(Path.simplify) is a
+ purely syntactic simplification. In particular, when a prefix of
+ @rhombus(path) refers to a link, the link is resolved before a
+ subsequent directory-navigation element is simplified, which can produce
+ a different reference than a syntactic simplication.
+
+ The @rhombus(filesystem.normalize_path) function is equivalent to
+ @rhombus(filesystem.simplify_path(Path.to_absolute_path(path))). Note
+ that normalization @emph{does not} use @rhombus(Path.normal_case).
+
+}
+
+
+@doc(
+  fun filesystem.resolve_path(path :: PathString) :: Path
+){
+
+ Uses @rhombus(Path.cleanse) on @rhombus(path) and then returns a path
+ that references the same file or directory as path. If @rhombus(path)
+ refers to a soft link to another path, then the referenced path is
+ returned (which may be a relative path with respect to the directory
+ parent of @rhombus(path)), otherwise the cleansed @rhombus(path) is
+ returned.
+
+ On Windows, the path for a link should be simplified syntactically, so
+ that an up-directory indicator removes a preceding path element
+ independent of whether the preceding element itself refers to a link.
+ Beware that relative-paths links require further care.
+
+}
+
+
+@doc(
+  fun filesystem.expand_user_path(path :: PathString) :: Path
+){
+
+ Uses @rhombus(Path.cleanse) on @rhombus(path) and then, on platforms
+ that use the @rhombus(#'unix) path convention, checks for a leading
+ @litchar{~} and replaces the path element starting from @litchar{~} with
+ the path to the specified user's home directory. A
+ @rhombus(Exn.Fail.Filesystem, ~annot) exception is thrown if the home
+ directory cannot be found.
+
+}

--- a/rhombus/rhombus/scribblings/reference/io.scrbl
+++ b/rhombus/rhombus/scribblings/reference/io.scrbl
@@ -6,7 +6,6 @@
 
 @local_table_of_contents()
 
-@include_section("path.scrbl")
 @include_section("port.scrbl")
 @include_section("input_port.scrbl")
 @include_section("output_port.scrbl")

--- a/rhombus/rhombus/scribblings/reference/os.scrbl
+++ b/rhombus/rhombus/scribblings/reference/os.scrbl
@@ -1,0 +1,11 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open)
+
+@title(~style: #'toc, ~tag: "os"){Operating System}
+
+@local_table_of_contents()
+
+@include_section("path.scrbl")
+@include_section("cross_path.scrbl")
+@include_section("filesystem.scrbl")

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -3,56 +3,107 @@
     "common.rhm" open
     "nonterminal.rhm" open)
 
-@title{Paths}
+@title(~tag: "path"){Paths}
 
-A @deftech{path} value represents a filesystem path.
+A @deftech{path} value represents a filesystem path for the host
+operating system. A @tech{cross-platform path} is a generalization of a
+path, and most path operations also accept cross-platform paths, but
+they produce specifically paths when given paths.
 
 @dispatch_table(
-  "path"
+  "path or cross-platform path"
   Path
   path.bytes()
+  path.string()
   path.add(part, ...)
   path.split()
-  path.string()
+  path.name()
+  path.parent()
+  path.directory_only(...)
+  path.to_directory_path(...)
   path.to_absolute_path(...)
+  path.suffix(...)
+  path.replace_suffix(...)
+  path.add_suffix(...)
+  path.cleanse(...)
+  path.simplify(...)
+  path.normal_case(...)
+  path.as_relative_to(...)
 )
 
 Paths are @tech{comparable}, which means that generic operations like
 @rhombus(<) and @rhombus(>) work on paths.
 
 @doc(
+  ~nonterminal:
+    base_expr: block expr
   annot.macro 'Path'
   annot.macro 'PathString'
-  annot.macro 'PathString.to_absolute_path'
-  annot.macro 'PathString.to_absolute_path(~relative_to: base :: PathString)'
   annot.macro 'PathString.to_path'
+  annot.macro 'PathString.to_absolute_path'
+  annot.macro 'PathString.to_absolute_path(~relative_to: $base_expr)'
   annot.macro 'Path.Absolute'
   annot.macro 'Path.Relative'
+  annot.macro 'Path.DriveRelative'
+  annot.macro 'Path.Directory'
+  annot.macro 'Path.Element'
+  enum Path.Dot:
+    same
+    up
+  annot.macro 'Path.like($expr)'
 ){
 
- Matches a path value.  The @rhombus(PathString, ~annot) annotation allows
- @rhombus(ReadableString, ~annot) as well as @rhombus(Path, ~annot) values.
- The @rhombus(PathString.to_path, ~annot)
+ Matches a path value. The @rhombus(PathString, ~annot) annotation
+ allows @rhombus(ReadableString, ~annot) as well as
+ @rhombus(Path, ~annot) values. The @rhombus(PathString.to_path, ~annot)
  @tech(~doc: guide_doc){converter annotation} allows
  @rhombus(PathString, ~annot) values, but converts
- @rhombus(ReadableString, ~annot) values to @rhombus(Path) values.  Similarly
- @rhombus(PathString.to_absolute_path, ~annot) is a converter annotation that
- converts a @rhombus(PathString, ~annot) into an absolute path relative to
- @rhombus(Path.current_directory()) or to the specified @rhombus(base)
- directory.
+ @rhombus(ReadableString, ~annot) values to @rhombus(Path) values.
+ Similarly @rhombus(PathString.to_absolute_path, ~annot) is a converter
+ annotation that converts a @rhombus(PathString, ~annot) into an absolute
+ path relative to @rhombus(Path.current_directory()) or to the
+ directory @rhombus(base_expr), where @rhombus(base_expr) must satisfy
+ @rhombus((PathString.to_path && Path.Absolute) || CrossPath.Absolute, ~annot).
 
  The @rhombus(Path.Absolute, ~annot) annotation only matches
- @rhombus(Path, ~annot)s that begin with the root directory of the filesystem
- or drive.  The @rhombus(Path.Relative, ~annot) annotation only matches
- @rhombus(Path, ~annot)s that are relative to some base directory.
+ @rhombus(Path, ~annot)s that begin with a root directory or drive. The
+ @rhombus(Path.Relative, ~annot) annotation only matches
+ @rhombus(Path, ~annot)s that are relative to some base directory. The
+ @rhombus(Path.DriveRelative, ~annot) annotation only matches Windows
+ @rhombus(Path, ~annot)s that are relative to a drive.
+
+ The @rhombus(Path.Directory, ~annot) annotation only matches
+ @rhombus(Path, ~annot)s that syntactically refer to a directory; see
+ @rhombus(filesystem.directory_exists) for checking whether a path refers
+ to a directory on the filesystem.
+
+ The @rhombus(Path.Element, ~annot) annotation matches a path that
+ represents a single path element---that is, a path for which
+ @rhombus(Path.split) returns a list containing one element.
+
+ A @rhombus(Path.Dot, ~annot) symbols refer to an abstract
+ directory-navigation path element. For both path conventions currently
+ supported, the symbol @rhombus(#'same) as a @rhombus(Path.Dot, ~annot)
+ is equivalent to @rhombus("."), and the symbol @rhombus(#'same) as a
+ @rhombus(Path.Dot, ~annot) is equivalent to @rhombus("..").
+
+ A @rhombus(Path.like(expr), ~annot) annotation is satisfied by a
+ cross-platform path with the same convention as the result of
+ @rhombus(expr), where the result of @rhombus(expr) must satisfy
+ @rhombus(PathString || CrossPath || Path.Dot, ~annot), and a
+ @rhombus(PathString, ~annot) or @rhombus(Path.Dot, ~annot) implies the
+ current platform's convention.
+
 }
 
+
 @doc(
-  fun Path(path :: Bytes || ReadableString || Path) :: Path
+  fun Path(path :: Bytes || PathString || Path.Dot) :: Path
 ){
 
- Constructs a path given a byte string, string, or existing path. When a
- path is provided as @rhombus(path), then the result is @rhombus(path).
+ Constructs a path given a byte string, string, existing path, or
+ directory-navigation symbol. When a path is provided as @rhombus(path),
+ then the result is @rhombus(path).
 
 @examples(
   def p = Path("/home/rhombus/shape.txt")
@@ -71,8 +122,8 @@ Paths are @tech{comparable}, which means that generic operations like
  @rhombus(bind).
 
 @examples(
-  def Path(p) = Path("/home/rhombus/shape.txt")
-  p
+  def Path(bstr) = Path("/home/rhombus/shape.txt")
+  bstr
 )
 
 }
@@ -80,11 +131,15 @@ Paths are @tech{comparable}, which means that generic operations like
 @doc(
   Parameter.def Path.current_directory :: Path
 ){
-  A @tech{context parameter} for the current directory.
+
+ A @tech{context parameter} for the current directory. This directory
+ need not actually exist on the filesystem.
+
 }
 
+
 @doc(
-  fun Path.bytes(path :: Path) :: Bytes
+  fun Path.bytes(path :: CrossPath) :: Bytes
 ){
 
  Converts a path to a byte-string form, which does not lose any
@@ -98,71 +153,9 @@ Paths are @tech{comparable}, which means that generic operations like
 
 }
 
-@doc(
-  fun Path.add(path :: PathString,
-               part :: PathString
-                 || matching(#'up)
-                 || matching(#'same), ...) :: Path
-  operator ((base :: PathString) +/ (part :: PathString
-                                       || matching(#'up)
-                                       || matching(#'same))) :: Path
-){
-
-  Creates a path given a base path and any number of sub-path
-  extensions. If @rhombus(path) is an absolute path,
-  the result is an absolute path, otherwise the result is a relative path.
-
-  The @rhombus(path) and each @rhombus(part) must be either a relative
-  path, the symbol @rhombus(#'up) (indicating the relative parent
-  directory), or the symbol @rhombus(#'same) (indicating the
-  relative current directory).  For Windows paths, if @rhombus(path) is a
-  drive specification (with or without a trailing slash) the first
-  @rhombus(part) can be an absolute (driveless) path. For all platforms,
-  the last @rhombus(part) can be a filename.
-
-  The @rhombus(path) and @rhombus(part) arguments can be paths for
-  any platform. The platform for the resulting path is inferred from the
-  @rhombus(path) and @rhombus(part) arguments, where string arguments imply
-  a path for the current platform. If different arguments are for
-  different platforms, the @rhombus(Exn.Fail.Contract, ~class) exception
-  is thrown.  If no argument implies a platform (i.e., all are @rhombus(#'up)
-  or @rhombus(#'same)), the generated path is for the current platform.
-
-  Each @rhombus(part) and @rhombus(path) can optionally end in a directory
-  separator. If the last @rhombus(part) ends in a separator, it is
-  included in the resulting path.
-
-  The @rhombus(Path.add) procedure builds a path @italic{without}
-  checking the validity of the path or accessing the filesystem.
-
-@examples(
-  def p = Path("/home/rhombus")
-  Path.add(p, "shape.txt")
-  p.add("shape.txt")
-  p +/ "shape.txt"
-)
-
-}
 
 @doc(
-  fun Path.split(path :: PathString) :: List.of(Path || #'up || #'same)
-){
-
-  Returns a list of path elements that constitute @rhombus(path).
-
-  The @rhombus(Path.split) function computes its result in time
-  proportional to the length of @rhombus(path).
-
-@examples(
-  def p = Path("/home/rhombus/shape.txt")
-  Path.split(p)
-  p.split()
-)
-
-}
-
-@doc(
-  fun Path.string(path :: Path) :: String
+  fun Path.string(path :: CrossPath) :: String
 ){
 
  Converts a path to a human-readable form, but the conversion may lose
@@ -177,32 +170,272 @@ Paths are @tech{comparable}, which means that generic operations like
 
 }
 
+
 @doc(
-  fun Path.directory_only(path :: PathString) :: Path
+  fun Path.convention(path :: CrossPath) :: CrossPath.Convention
 ){
 
- Returns @rhombus(path) without its final path element in the case
- that @rhombus(path) is not syntactically a directory; if
- @rhombus(path) has only a single, non-directory path element, #f is
- returned. If @rhombus(path) is syntactically a directory, then
- @rhombus(path) is returned unchanged (but as a path, if it was a
- string).
+ Reports the convention of a path. For a @rhombus(path) that satisfies
+ @rhombus(Path), the result is the same as
+ @rhombus(CrossPath.Convention.current()).
+
+@examples(
+  def p = CrossPath(#"/home/rhombus/shape.txt", #'unix)
+  p.convention()
+)
+
+}
+
+
+@doc(
+  fun Path.add(path :: PathString || CrossPath || Path.Dot,
+               part :: PathString || CrossPath || Path.Dot,
+               ...)
+    :: Path.like(path)
+  operator ((path :: PathString || CrossPath || Path.Dot)
+              +/ (part :: PathString || CrossPath || Path.Dot))
+    :: Path.like(path)
+){
+
+ Creates a path given a base path and any number of sub-path extensions
+ (in the case of @rhombus(Path.add)) or on extension (in the case of
+ @rhombus(+/)). If @rhombus(path) is an absolute path, the result is an
+ absolute path, otherwise the result is a relative path.
+
+ The @rhombus(path) and each @rhombus(part) must be either a relative
+ path, the symbol @rhombus(#'up) (indicating the relative parent
+ directory), or the symbol @rhombus(#'same) (indicating the relative
+ current directory). For Windows paths, if @rhombus(path) is a drive
+ specification (with or without a trailing slash) the first
+ @rhombus(part) can be a drive-relative path. For all platforms, the last
+ @rhombus(part) can be a filename.
+
+ The @rhombus(path) and @rhombus(part) arguments can be paths or
+ cross-platform paths. The platform for the resulting path is inferred
+ from the @rhombus(path) and @rhombus(part) arguments, where string
+ arguments imply a path for the current platform. If different arguments
+ are for different platforms, the @rhombus(Exn.Fail.Annot, ~class)
+ exception is thrown. If no argument implies a platform (i.e., all are
+ @rhombus(#'up) or @rhombus(#'same)), the generated path is for the
+ current platform.
+
+ Each @rhombus(part) and @rhombus(path) can optionally end in a
+ directory separator. If the last @rhombus(part) ends in a separator, it
+ is included in the resulting path.
+
+ The @rhombus(Path.add) procedure builds a path @italic{without}
+ checking the validity of the path or accessing the filesystem.
+
+@examples(
+  def p = Path("/home/rhombus")
+  Path.add(p, "shape.txt")
+  p.add("shape.txt")
+  p +/ "shape.txt"
+)
+
+}
+
+
+@doc(
+  fun Path.split(path :: PathString || CrossPath)
+    :: List.of((CrossPath.Element && Path.like(path)) || Path.Dot)
+){
+
+ Returns a list of path elements that constitute @rhombus(path).
+ Directory-navigation elements are detected and represented as
+ @rhombus(Path.Dot) elements. When @rhombus(path) is a
+ @rhombus(PathString), then result list's @rhombus(CrossPath.Element)
+ values are more specifically @rhombus(Path.Element) values.
+
+ The @rhombus(Path.split) function computes its result in time
+ proportional to the length of @rhombus(path).
+
+@examples(
+  def p = Path("/home/rhombus/shape.txt")
+  Path.split(p)
+  p.split()
+)
 
 }
 
 @doc(
-  fun Path.to_absolute_path(path :: PathString,
-                            ~relative_to: base
-                                          :: PathString
-                                            = Path.current_directory())
-    :: Path
+  fun Path.name(path :: PathString || CrossPath)
+    :: (CrossPath.Element && Path.like(path)) || Path.Dot
+  fun Path.parent(path :: PathString || CrossPath)
+    :: ((CrossPath.Directory && Path.like(path))
+          || matching(#'relative) || False)
+  fun Path.directory_only(path :: PathString || CrossPath)
+    :: CrossPath.Directory && Path.like(path)
+  fun Path.to_directory_path(path :: PathString || CrossPath)
+    :: CrossPath.Directory && Path.like(path)
 ){
- Returns @rhombus(path) as an absolute path. If @rhombus(path) is already an
- absolute path, it is returned as the result. Otherwise, @rhombus(path) is
- resolved with respect to the absolute path @rhombus(base). If @rhombus(base) is
- not an absolute path, the @rhombus(Exn.Fail.Contract, ~class) exception is
- thrown.
+
+ The @rhombus(Path.name) and @rhombus(Path.parent) functions produce the
+ last element or @rhombus(path) and the path before its last element,
+ respectively.
+
+ The @rhombus(Path.directory_only) function returns @rhombus(path)
+ without its final path element in the case that @rhombus(path) is not
+ syntactically a directory; if @rhombus(path) has only a single,
+ non-directory path element, #f is returned. If @rhombus(path) is
+ syntactically a directory, then @rhombus(path) is returned unchanged
+ (but as a path, if it was a string).
+
+ The @rhombus(Path.to_directory_path) function converts @rhombus(path)
+ to one that syntactically represents a directory path if it does not
+ already, typically by adding a path separator to the end.
+
+@examples(
+  def p = Path("/home/rhombus/shape.txt")
+  Path.name(p)
+  Path.parent(p)
+  Path.directory_only(p)
+  Path.directory_only(Path.parent(p))
+  Path.to_directory_path(p)
+)
+
 }
+
+@doc(
+  fun Path.to_absolute_path(
+    path :: PathString || CrossPath,
+    ~relative_to: base :: ((PathString.to_path && Path.Absolute)
+                             || CrossPath.Absolute)
+                    = Path.current_directory()
+  ) :: Path.like(path)
+){
+
+ Returns @rhombus(path) as an absolute path. If @rhombus(path) is a
+ @rhombus(Path) or @rhombus(CrossPath) and already an absolute path, it is
+ returned as the result. Otherwise, @rhombus(path) is resolved with
+ respect to the absolute path @rhombus(base). If @rhombus(base) is not an
+ absolute path, the @rhombus(Exn.Fail.Annot, ~class) exception is thrown.
+ If @rhombus(path) and @rhombus(base) have different path conventions,
+ then the @rhombus(Exn.Fail.Annot, ~class) exception is thrown.
+
+@examples(
+  def p = CrossPath(#"shape.txt", #'unix)
+  p.to_absolute_path(
+    ~relative_to: CrossPath(#"/home/rhombus", #'unix)
+  ).bytes()
+)
+
+}
+
+
+@doc(
+  fun Path.suffix(path :: PathString || CrossPath) :: maybe(Bytes)
+  fun Path.replace_suffix(
+    path :: PathString || CrossPath,
+    suffix :: Bytes || ReadableString
+  ) :: Path.like(path)
+  fun Path.add_suffix(
+    path :: PathString || CrossPath,
+    suffix :: Bytes || ReadableString,
+    ~sep: sep :: Bytes || ReadableString = "_"
+  ) :: Path.like(path)
+){
+
+ Extracts or adjusts the suffix of a path, which is the part of
+ @rhombus(Path.name(path).bytes()) that starts with with last
+ @rhombus(Byte#".") and runs to the end of the byte string. If the path
+ name has no @rhombus(Byte#"."), then the path has no suffix, and
+ @rhombus(Path.suffix) returns @rhombus(#false).
+
+ The @rhombus(Path.replace_suffix) function removes the suffix from a
+ path, if any, and then adds @rhombus(suffix), which can be @rhombus("")
+ or @rhombus(#"") to just remove a suffix from @rhombus(path) or
+ otherwise normally starts with @rhombus(Char".") or @rhombus(Byte#".").
+
+ The @rhombus(Path.add_suffix) function first changes a
+ @rhombus(Byte#".") in the path that starts its current prefix with
+ @rhombus(sep), and then it adds the given @rhombus(suffix).
+
+@examples(
+  def p = Path("/home/rhombus/shape.txt")
+  p.suffix()
+  p.replace_suffix(".rhm")
+  p.add_suffix(".rhm")
+)
+
+}
+
+@doc(
+  fun Path.cleanse(path :: PathString || CrossPath)
+    :: Path.like(path)
+  fun Path.simplify(path :: PathString || CrossPath)
+    :: Path.like(path)
+  fun Path.normal_case(path :: PathString || CrossPath)
+    :: Path.like(path)
+){
+
+ The @rhombus(Path.cleanse) function removes redundant directory
+ separators, normalizes the separator character for Windows paths, and
+ performs some other normalization steps for unusual Windows paths.
+
+ The @rhombus(Path.simplify) function performs the same cleansing, and
+ then removes @rhombus(#'same) path elements and syntactically resolves
+ @rhombus(#'up) elements where preceding elements can be removed. This
+ simplification is purely syntactic and does not consult the filesystem;
+ see also @rhombus(filesystem.simplify_path).
+
+ The @rhombus(Path.normal_case) function has no effect on platforms that
+ use Unix path conventions, and it case-folds a path's string form on
+ Windows.
+
+@examples(
+  Path.cleanse("a/..//b")
+  Path.simplify("a/..//b")
+)
+
+}
+
+
+@doc(
+  fun Path.as_relative_to(
+    path :: PathString || CrossPath,
+    rel_to_path :: PathString || CrossPath,
+    ~more_than_root: more_than_root = #false,
+    ~more_than_same: more_than_same = #true,
+    ~normal_case: normal_case = #true
+  ) :: Path.like(Path)
+){
+
+ Returns a @rhombus(path) that is syntactically equivalent to
+ @rhombus(path), but made relative to @rhombus(rel_to_path). Note that
+ constructing a relative path may involve using @rhombus(#'up) path
+ elements. For Windows paths, it is possible for no relative path to
+ exist from @rhombus(rel_to_path) to @rhombus(path) if the paths start
+ with different drives. Typically, @rhombus(path) and
+ @rhombus(rel_to_path) should be first converted to absolute paths;
+ @rhombus(Path.as_relative_to) does not perform that conversion, so it
+ cannot change a relative @rhombus(path) given an absolute
+ @rhombus(rel_to_path).
+
+ If @rhombus(more_than_root) is @rhombus(#true), then if @rhombus(path)
+ and @rhombus(rel_to_path) has only a root path element in common, then
+ @rhombus(path) is returned unchanged (except converted to a
+ @rhombus(Path) object if it is a string).
+
+ If @rhombus(more_than_same) is @rhombus(#true), then if @rhombus(path)
+ and @rhombus(rel_to_path) are syntacticaly equivalent, then
+ @rhombus(path) is returned unchanged.
+
+ If @rhombus(normal) is @rhombus(#true), then on Windows, path elements
+ are normalized for comparsion. Otherwise, path elements are considered
+ equivalent only when they have the same case.
+
+ If @rhombus(path) and @rhombus(rel_to_path) use different path
+ conventions, the @rhombus(Exn.Fail.Annot, ~annot) exception is thrown.
+
+@examples(
+  def p = Path("/home/rhombus/shape.txt")
+  p.as_relative_to("/home")
+  p.as_relative_to("/home/racket")
+)
+
+}
+
 
 @// ------------------------------------------------------------
 

--- a/rhombus/rhombus/scribblings/reference/rhombus-reference.scrbl
+++ b/rhombus/rhombus/scribblings/reference/rhombus-reference.scrbl
@@ -34,8 +34,9 @@ For a general overview of the language, see @docref(guide_doc).
 @include_section("protocol.scrbl")
 @include_section("control.scrbl")
 @include_section("code.scrbl")
-@include_section("io.scrbl")
 @include_section("format.scrbl")
+@include_section("io.scrbl")
+@include_section("os.scrbl")
 @include_section("runtime.scrbl")
 
 @include_section("meta-lib.scrbl")

--- a/rhombus/rhombus/tests/filesystem.rhm
+++ b/rhombus/rhombus/tests/filesystem.rhm
@@ -1,0 +1,58 @@
+#lang rhombus/static/and_meta
+import:
+  "path.rhm" open
+  rhombus/runtime_path
+
+runtime_path.def path_rhm: "path.rhm"
+
+block:
+  import "static_arity.rhm"
+  static_arity.check:
+    filesystem.simplify_path(p)
+    filesystem.normalize_path(p)
+    filesystem.resolve_path(p)
+    filesystem.expand_user_path(p)
+    filesystem.file_exists(p)
+    filesystem.directory_exists(p)
+    filesystem.link_exists(p)
+
+block:
+  // assuming "x" in the current directory is not a link!
+  check filesystem.simplify_path(Path("x")) ~is Path("x")
+  check filesystem.simplify_path("x") ~is Path("x")
+  check filesystem.simplify_path(Path("x")).string() ~is "x"
+  check_annot filesystem.simplify_path(cross_p)
+
+block:
+  // assuming "x" in the current directory is not a link!
+  check filesystem.normalize_path(Path("x")) ~is Path("x").to_absolute_path()
+  check filesystem.normalize_path("x") ~is Path("x").to_absolute_path()
+  check filesystem.normalize_path(Path("x")).string() ~is Path("x").to_absolute_path().string()
+  check_annot filesystem.normalize_path(cross_p)
+
+block:
+  // assuming "x" in the current directory is not a link!
+  check filesystem.resolve_path(Path("x")) ~is Path("x")
+  check filesystem.resolve_path("x") ~is Path("x")
+  check filesystem.resolve_path(Path("x")).string() ~is "x"
+  check_annot filesystem.resolve_path(cross_p)
+
+block:
+  // assuming "x" in the current directory is not a link!
+  check filesystem.expand_user_path(Path("x")) ~is_a Path
+  check filesystem.expand_user_path("x") ~is_a Path
+  check filesystem.expand_user_path(Path("x")).string() ~is_a String
+  when CrossPath.Convention.current() == #'unix
+  | check filesystem.expand_user_path(Path("~no_such_user")) ~throws "bad username"
+    check filesystem.expand_user_path(Path("~no_such_user")).string() ~throws "bad username"
+  check_annot filesystem.expand_user_path(#'same)
+  check_annot filesystem.expand_user_path(cross_p)
+
+block:
+  check filesystem.file_exists(Path(path_rhm)) ~is #true
+  check filesystem.directory_exists(Path(path_rhm)) ~is #false
+  check filesystem.directory_exists(Path(path_rhm).to_absolute_path().parent()) ~is #true
+  check filesystem.link_exists(Path(path_rhm)) ~is #false
+  check_annot filesystem.file_exists(cross_p)
+  check_annot filesystem.directory_exists(cross_p)
+  check_annot filesystem.link_exists(cross_p)

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -1,28 +1,73 @@
-#lang rhombus
+#lang rhombus/static/and_meta
 
 import:
   "version_guard.rhm"
+
+export:
+  check_annot
+  cross_p
 
 block:
   import "static_arity.rhm"
   static_arity.check:
     Path(s)
+    Path.name(p) ~method
+    Path.parent(p) ~method
     Path.bytes(p) ~method
     Path.string(p) ~method
+    Path.convention(p) ~method
+    Path.add(p, arg, ...) ~method
+    Path.split(p) ~method
+    Path.to_absolute_path(p) ~method
+    Path.to_directory_path(p) ~method
+    Path.directory_only(p) ~method
+    Path.suffix(p) ~method
+    Path.add_suffix(p, sfx) ~method
+    Path.replace_suffix(p, sfx) ~method
+    Path.cleanse(p) ~method
+    Path.normal_case(p) ~method
+    Path.simplify(p) ~method
+    Path.as_relative_to(p, wrt) ~method
 
-check:
-  use_static
-  def p = Path("x")
-  [p.bytes(), p.string()]
-  ~is [#"x", "x"]
+expr.macro
+| 'check_annot $c($args) . $m $tail ...':
+    ~op_stx: self
+    '$('check'.relocate(self)) $c($args) . $m $tail ... ~throws values(#' $c +& "." +& #' $m, error.annot_msg())'
+| 'check_annot $who $tail ...':
+    ~op_stx: self
+    '$('check'.relocate(self)) $who $tail ... ~throws values(to_string(#' $who), error.annot_msg())'
 
-check:
-  def p = dynamic(Path("x"))
-  [p.bytes(), p.string()]
-  ~is [#"x", "x"]
+def (cross_p :~ CrossPath, cross_abs_p :~ CrossPath, root_p :~ Path):
+  match CrossPath.Convention.current()
+  | #'unix: values(CrossPath(#"x", #'windows),
+                   CrossPath(#"C:/d", #'windows),
+                   Path("/"))
+  | ~else: values(CrossPath(#"x", #'unix),
+                  CrossPath(#"/d", #'unix),
+                  Path("C:/"))
 
 block:
-  use_static
+  def p = Path("x")
+  check [p.bytes(), p.string()] ~is [#"x", "x"]
+  check p.string().length() ~is 1
+  check p.bytes().length() ~is 1
+  check [cross_p.bytes(), cross_p.string()] ~is [#"x", "x"]
+  check_annot Path.bytes(0)
+  check_annot Path.string(0)
+
+block:
+  use_dynamic
+  def p = dynamic(Path("x"))
+  check [p.bytes(), p.string()] ~is [#"x", "x"]
+  check p.string().length() ~is 1
+  check p.bytes().length() ~is 1
+
+block:
+  check Path("x").convention() ~is CrossPath.Convention.current()
+  check CrossPath(#"x", #'unix).convention() ~is #'unix
+  check CrossPath(#"x", #'windows).convention() ~is #'windows
+
+block:
   def p = Path("/")
   def q = Path("/etc")
   check p < q ~is #true
@@ -42,6 +87,7 @@ block:
     check p != q ~is #true
 
 block:
+  use_dynamic
   def p = dynamic(Path("/"))
   def q = dynamic(Path("/etc"))
   check p < q ~is #true
@@ -69,35 +115,81 @@ block:
     check p1 == p2 ~is #true
 
 block:
-  def p1 = Path("/etc/passwd")
-  check p1.split() ~is [Path("/"), Path("etc"), Path("passwd")]
-  def p2 = Path("C:/windows")
-  check p2.split() ~is [Path("C:"), Path("windows")]
-  def p3 = Path("../a/b/./c")
-  check p3.split() ~is [#'up, Path("a"), Path("b"), #'same, Path("c")]
+  def p1 = Path("/etc")
+  def p2 = Path("etc")
+  check "/etc" is_a Path.Absolute ~is #false
+  check "etc" is_a Path.Relative ~is #false
+  check "etc" is_a Path.DriveRelative ~is #false
+  check "/etc" is_a Path.DriveRelative ~is CrossPath.Convention.current() == #'windows
+  check p1 is_a Path.Absolute ~is #true
+  check p1 is_a Path.Relative ~is #false
+  check p2 is_a Path.Absolute ~is #false
+  check p2 is_a Path.Relative ~is #true
+  check p1 is_a Path.Directory ~is #false
+  check p2 is_a Path.Directory ~is #false
+  check Path(#'up) is_a Path.Directory ~is #true
+  check Path(#'same) is_a Path.Directory ~is #true
+  check Path("x/") is_a Path.Directory ~is #true
+  check CrossPath(#"x", #'unix) is_a CrossPath.Unix ~is #true
+  check CrossPath(#"x", #'windows) is_a CrossPath.Unix ~is #false
+  check CrossPath(#"x", #'windows) is_a CrossPath.Windows ~is #true
+  check CrossPath.Unix(#"x") ~is CrossPath(#"x", #'unix)
+  check CrossPath.Windows(#"x") ~is CrossPath(#"x", #'windows)
+  check CrossPath.Unix(#'up) ~is CrossPath(#'up, #'unix)
+  check CrossPath.Windows(#'up) ~is CrossPath(#'up, #'windows)
+  check CrossPath.Unix(#'same) ~is CrossPath(#'same, #'unix)
+  check CrossPath.Windows(#'same) ~is CrossPath(#'same, #'windows)
+
+block:
+  check Path("x").name() ~is Path("x")
+  check Path("x").parent() ~is #'relative
+  check Path("x/y").name() ~is Path("y")
+  check Path("x/y").parent() ~is Path("x/")
+  check Path("x/y/z").name() ~is Path("z")
+  check Path("x/y/z").parent() ~is Path("x/y/")
+  check Path.name("x/y") ~is Path("y")
+  check Path.parent("x/y") ~is Path("x/")
+  check Path.name(Path("x").add(#'same)) ~is #'same  
+  check Path(root_p).parent() ~is #false
 
 block:
   check Path("/").add("etc", Path("passwd")) ~is Path("/etc/passwd")
   check Path.add("C:", "win32", "sys") ~is Path("C:/win32/sys")
   check Path("/") +/ Path("etc") +/ "passwd" ~is Path("/etc/passwd")
   check Path("..") +/ "a" +/ "b" +/ #'same +/ "c" ~is Path("../a/b/./c")
-  check "/" +/ "App" ++ "lications" +/ "Racket v10.04" \
-  ~is Path ("/Applications/Racket v10.04")
+  check: "/" +/ "App" ++ "lications" +/ "Racket v10.04"
+         ~is Path ("/Applications/Racket v10.04")
+  check Path.add("x", "y") ~is Path("x").add("y")
+  check Path.add("x", "y").string() ~is Path("x").add("y").string()
+  check Path.add(#'same, "y") ~is Path(#'same).add("y")
+  check_annot Path.add(0, "y")
+  check_annot Path.add("y", 0)
+  check_annot Path("x").add(0)
+  check Path.add("x", "/y") ~throws values("Path.add",
+                                           "absolute path cannot be added to a path")
 
 block:
-  def p1 = Path("/etc")
-  def p2 = Path("etc")
-  check "/etc" is_a Path.Absolute ~is #false
-  check "etc" is_a Path.Relative ~is #false
-  check p1 is_a Path.Absolute ~is #true
-  check p1 is_a Path.Relative ~is #false
-  check p2 is_a Path.Absolute ~is #false
-  check p2 is_a Path.Relative ~is #true
+  def p1 = Path("/etc/passwd")
+  check p1.split() ~is [Path("/"), Path("etc"), Path("passwd")]
+  def p2 = Path("C:/windows")
+  check p2.split() ~is [Path("C:"), Path("windows")]
+  def p3 = Path("../a/b/./c")
+  check p3.split() ~is [#'up, Path("a"), Path("b"), #'same, Path("c")]
+  check Path.split("x/y") ~is [Path("x"), Path("y")]
+  check Path.split("x/y").length() ~is 2
+  check cross_p.split() ~is [cross_p]
+  check_annot Path.split(0)
 
 block:
+  check root_p.to_absolute_path() ~is root_p
   def p1 = Path("shadow")
   check p1.to_absolute_path() ~is Path.current_directory().add("shadow")
   check p1.to_absolute_path(~relative_to: "/etc") ~is Path("/etc/shadow")
+  check p1.to_absolute_path(~relative_to: "/etc").string() ~is "/etc/shadow"
+  check Path.to_absolute_path(cross_p) ~throws values("Path.to_absolute_path",
+                                                      "incompatible with convention")
+  check Path.to_absolute_path(cross_p, ~relative_to: cross_abs_p) ~is_a CrossPath
+  check_annot Path.to_absolute_path(0)
 
   def p2 :: PathString.to_absolute_path(~relative_to: "/etc") = "shadow"
   check p2 ~is Path("/etc/shadow")
@@ -105,3 +197,75 @@ block:
 
   def p3 = Path.to_absolute_path("shadow", ~relative_to: "/etc")
   check p3 ~is Path("/etc/shadow")
+
+block:
+  check Path("x").suffix() ~is #false
+  check Path("x.y").suffix() ~is #".y"
+  check Path("x/y.zzzzz").suffix() ~is #".zzzzz"
+  check Path.suffix("x/y.z") ~is #".z"
+  check cross_p.suffix() ~is #false
+  check_annot Path.suffix(0)
+
+block:
+  check Path("x").add_suffix(".z") ~is Path("x.z")
+  check Path("x").add_suffix("z") ~is Path("xz")
+  check Path("x").add_suffix(".z").string() ~is "x.z"
+  check Path("x/y").add_suffix(".z") ~is Path("x/y.z")
+  check Path("x/y.w").add_suffix(".z") ~is Path("x/y_w.z")
+  check Path("x/y.w").add_suffix(".z", ~sep: "=") ~is Path("x/y=w.z")
+  check Path.add_suffix("x/y", ".z") ~is Path("x/y.z")
+  check Path.add_suffix(cross_p, ".z") ~is_a CrossPath
+  check_annot Path("x").add_suffix(#'oops)
+  version_guard.at_least "8.15.0.3":
+    check Path(#'same).add_suffix(".z") ~throws values("Path.add_suffix",
+                                                       "cannot add an extension")
+
+block:
+  check Path("x").replace_suffix(".z") ~is Path("x.z")
+  check Path("x").replace_suffix("z") ~is Path("xz")
+  check Path("x.q").replace_suffix("z") ~is Path("xz")
+  check Path("x").replace_suffix(".z").string() ~is "x.z"
+  check Path("x/y.q").replace_suffix(".z") ~is Path("x/y.z")
+  check Path.replace_suffix("x/y", ".z") ~is Path("x/y.z")
+  check Path.replace_suffix(cross_p, ".z") ~is_a CrossPath
+  check_annot Path("x").replace_suffix(#'oops)
+  version_guard.at_least "8.15.0.3":
+    check Path(#'same).replace_suffix(".z") ~throws values("Path.replace_suffix",
+                                                           "cannot add an extension")
+
+block:
+  check Path("x///y").cleanse() ~is Path("x/y")
+  check Path("x").cleanse() ~is Path("x")
+  check Path("x").cleanse().string() ~is "x"
+  check Path.cleanse("x///y") ~is Path("x/y")
+  check Path.cleanse("x").string() ~is "x"
+  check_annot Path.cleanse(0)
+
+block:
+  check Path("x/y").normal_case() ~is Path("x/y")
+  check Path("x/y").normal_case().string() ~is "x/y"
+  check: Path("X/Y").normal_case()
+         ~is Path(match CrossPath.Convention.current()
+                  | #'windows: "x/y"
+                  | ~else: "X/Y")
+  check_annot Path.normal_case(0)
+
+block:
+  check Path("x").add(#'same, #'same, "y").simplify() ~is Path("x").add("y")
+  check Path("x").simplify().string() ~is "x"
+  check_annot Path.simplify(0)
+
+block:
+  check Path("x/y").as_relative_to("x") ~is Path("y")
+  check Path("x").simplify().string() ~is "x"
+  check Path("x").as_relative_to("x/y") ~is Path(#'up)
+  check Path("x").as_relative_to("x") ~is Path("x")
+  check Path("x").as_relative_to("x", ~more_than_same: #false) ~is Path(#'same)
+  check Path(root_p).add("x").as_relative_to(Path(root_p).add("y")) ~is Path(#'up).add("x")  
+  check Path(root_p).add("x").as_relative_to(Path(root_p).add("y"), ~more_than_root: #true) ~is root_p.add("x")  
+  check Path("X/Y").as_relative_to("x/z") ~is Path(match CrossPath.Convention.current()
+                                                   | #'windows: "Y"
+                                                   | ~else: "X/Y")
+  check Path("X/Y").as_relative_to("x/z", ~normal_case: #false) ~is Path("X/Y")
+  check_annot Path.as_relative_to(0, "x")
+  check_annot Path.as_relative_to("x", 0)


### PR DESCRIPTION
This update is intended to cover all of the syntactic operations on paths. There's a new `filesystem` namespace to house filesystem-sensitive operations, mostly to innustrate the intent of putting filesystem-sensitive operations there instead of methods of `Path`.

The main addition is `CrossPath`, which corresponds to `path-for-some-system?` at the Racket level. Every `Path` is also a `CrossPath`, and `Path` methods generally accept `PathString || CrossPath`; the documentation uses `Path.like` inn result annotations to clarify that `CrossPath`s will result only when non-`Path` `CrossPath`s are given. Filesystem operations require `PathString`s (i.e., they do not accept `CrossPath`s).

I first experimented with making `Path` operations not accept `CrossPath`s and adding separate `CrossPath` methods, instead, but I didn't think worked out as well.

Constructor summary:
```
   Path(s)
   CrossPath(s, convention)
   CrossPath.Unix(s) // = CrossPath(s,  #'unix)
   CrossPath.Windows(s) // = CrossPath(s,  #'windows)
   Path.Element(s)
   CrossPath.Element(s, convention)
```

Method summary:
```
   Path.name(p)
   Path.parent(p)
   Path.bytes(p)
   Path.string(p)
   Path.convention(p)
   Path.add(p, path, ...)
   Path.split(p)
   Path.to_absolute_path(p, ~relative_to: base)
   Path.to_directory_path(p)
   Path.directory_only(p)
   Path.suffix(p)
   Path.replace_suffix(p, sfx)
   Path.add_suffix(p, sfx, sep)
   Path.cleanse(p)
   Path.normal_case(p)
   Path.simplify(p) // not filesystem-sensitive
   Path.as_relative_to(p, base)
   Path.Element.bytes(p)
   Path.Element.string(p)
```
Annotation summary:
```
   Path
   Path.Absolute
   Path.Relative
   Path.DriveRelative // mutually exclusive with Absolute & Relative
   Path.Element
   Path.Directory // a directory syntactically
   Path.Dot // #'up or #'same
   Path.like(expr) // Path or CrossPath, depending on expr
   CrossPath
   CrossPath.Absolute
   CrossPath.Relative
   CrossPath.DriveRelative
   CrossPath.Element
   CrossPath.Directory
   CrossPath.Unix
   CrossPath.Windows
   CrossPath.Convention
```
