### PR TITLE
fill in `filesystem` API

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation.rkt
@@ -235,8 +235,7 @@
        (define-values (predicate-stx static-infos) (get))
        (define packed (annotation-predicate-form predicate-stx static-infos))
        (syntax-parse stx
-         [(self . tail)
-          (values (relocate+reraw #'self packed) #'tail)]
+         [(self . tail) (values (relocate+reraw #'self packed) #'tail)]
          [_ 'does-not-happen]))))
 
   (define-syntax (identifier-binding-annotation stx)
@@ -402,7 +401,7 @@
       '((default . stronger))
       'macro
       (lambda (stx)
-        (parse-annotation-of (replace-head-dotted-name stx)
+        (parse-annotation-of stx
                              predicate-stx (get-static-infos)
                              sub-n kws
                              predicate-maker info-maker

--- a/rhombus-lib/rhombus/private/amalgam/array.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/array.rkt
@@ -24,8 +24,7 @@
          "class-primitive.rkt"
          "rhombus-primitive.rkt"
          "../version-case.rkt"
-         (submod "list.rkt" for-compound-repetition)
-         (only-in "name-root-ref.rkt" replace-head-dotted-name))
+         (submod "list.rkt" for-compound-repetition))
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -116,7 +115,7 @@
    `((default . stronger))
    'macro
    (lambda (stx)
-     (syntax-parse (replace-head-dotted-name stx)
+     (syntax-parse stx
        [(form-id (~and args (_::parens len-g)) . tail)
         (values
          (relocate+reraw

--- a/rhombus-lib/rhombus/private/amalgam/error-adjust.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/error-adjust.rkt
@@ -1,15 +1,24 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre)
-         "rhombus-primitive.rkt")
+         "rhombus-primitive.rkt"
+         "expression.rkt"
+         "parens.rkt"
+         "parse.rkt")
 
 (provide with-error-adjust-primitive
-         call-with-local-error-adjust)
+         local_error_adjust)
 
 (define-syntax (with-error-adjust-primitive stx)
   (syntax-parse stx
     [(_ () body) #'body]
     [(_ () body ...) #'(let () body ...)]
+    [(_ ([rkt-sym rhm-sym]) body ...)
+     #'(with-continuation-mark
+           primitive-who-table-key '(rkt-sym . rhm-sym)
+           (let ()
+             body
+             ...))]
     [(_ ([rkt-sym rhm-sym] ...) body ...)
      (with-syntax ([table (for/hash ([rkt-sym (in-list (syntax->list #'(rkt-sym ...)))]
                                      [rhm-sym (in-list (syntax->list #'(rhm-sym ...)))])
@@ -20,7 +29,16 @@
                body
                ...)))]))
 
-(define (call-with-local-error-adjust from to thunk)
-  (with-continuation-mark
-      primitive-who-table-key (hasheq from to)
-      (thunk)))
+(define-syntax local_error_adjust
+  (expression-transformer
+    (lambda (stx)
+      (syntax-parse stx
+        #:datum-literals (group)
+        [(_ (_::braces (group rkt ... (rhs::block rhs-g ...)))
+            (blk::block g ...))
+         (values
+          #'(with-continuation-mark
+                primitive-who-table-key (cons (rhombus-expression (group rkt ...))
+                                              (rhombus-body-at rhs rhs-g ...))
+                (rhombus-body-at blk g ...))
+          #'())]))))

--- a/rhombus-lib/rhombus/private/amalgam/exn-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/exn-object.rkt
@@ -8,6 +8,7 @@
          "index-result-key.rkt"
          "define-arity.rkt"
          (submod "list.rkt" for-compound-repetition)
+         (submod "pair.rkt" for-static-info)
          (submod "syntax-object.rkt" for-quasiquote)
          (submod "srcloc-object.rkt" for-static-info)
          "annotation-failure.rkt")
@@ -162,7 +163,7 @@
 
 (define-exn Errno exn:fail:filesystem:errno
   #:parent Filesystem exn:fail:filesystem
-  #:fields ([(errno)])
+  #:fields ([(errno) #,(get-pair-static-infos)])
   #:children ())
 
 (define-exn fs_MissingModule exn:fail:filesystem:missing-module

--- a/rhombus-lib/rhombus/private/amalgam/filesystem.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/filesystem.rhm
@@ -4,6 +4,13 @@ import:
   lib("racket/base.rkt") as rkt
   lib("racket/path.rkt") as rkt_path
   "error-adjust.rkt" as rkt_error
+  "error.rhm" open
+  "maybe.rhm" open
+  "closeable.rhm" open
+  "path-object.rhm" open
+  "rename-parameter.rkt".#{rename-parameter}
+
+use_static
 
 export:
   filesystem
@@ -17,7 +24,28 @@ namespace filesystem:
     file_exists
     directory_exists
     link_exists
-    list_directory
+    type
+    files
+    roots
+    names:
+      rename
+    delete
+    make_directory
+    current_force_delete_permissions
+    make_temporary
+    make_link
+    copy
+    size
+    modify_seconds
+    permissions
+    identity
+    stat
+    read_bytes
+    read_string
+    read_lines
+    read_bytes_lines
+    write_bytes
+    write_string
 
   fun simplify_path(p :: PathString) :: Path:
     rkt.#{simplify-path}(p, #true)
@@ -25,12 +53,8 @@ namespace filesystem:
   fun normalize_path(p :: PathString) :: Path:
     // potential error from `simplify-path` as called by `simple-form-path`
     ~who: who
-    rkt_error.#{call-with-local-error-adjust}(
-      #'#{simple-form-path},
-      who,
-      fun ():
-        rkt_path.#{simple-form-path}(p)
-    )
+    rkt_error.local_error_adjust { #'#{simple-form-path}: who }:
+      rkt_path.#{simple-form-path}(p)
 
   fun resolve_path(p :: PathString) :: Path:
     rkt.#{resolve-path}(p)
@@ -47,5 +71,372 @@ namespace filesystem:
   fun link_exists(p :: PathString):
     rkt.#{link-exists?}(p)
 
-  fun list_directory(p :: PathString = Path.current_directory()) :~ List.of(Path):
-    List(& rkt.#{directory-list}(p))
+  fun type(p :: PathString,
+           ~must_exist = #false):
+    ~who: who
+    match (rkt_error.local_error_adjust { #'#{file-or-directory-type}: who }:
+             rkt.#{file-or-directory-type}(p, must_exist))
+    | #'#{directory-link}: #'directory_link
+    | s: s
+
+  // internal helper
+  fun file_type(who, p):
+    // should report errors as `who`, but it turns out that no error is possible
+    rkt.#{file-or-directory-type}(p, #false)
+
+  fun files(start_p :: PathString = Path.current_directory(),
+            ~recur = #false,
+            ~follow_links = #false,
+            ~keep: keep :: Path -> Any = fun (x): #true,
+            ~skip: skip :: Path -> Any = fun (x): #false,
+            ~add_path = #false) :~ List.of(Path):
+    ~who: who
+    fun files_here(accum :~ List, p, onto_path):
+      let files :~ PairList:
+        rkt_error.local_error_adjust { #'#{directory-list}: who }:
+          rkt.#{directory-list}(p, #{#:build?}: !onto_path && add_path)
+      for values (accum :~ List = accum) (file: files):
+        let file = (if onto_path | Path.add(onto_path, file) | file)
+        keep_when keep(file)
+        skip_when skip(file)
+        let new_accum = accum.add(file)
+        if recur
+        | let file_p:
+            if add_path | file | Path.add(start_p, file)
+          if (if follow_links
+              | directory_exists(file_p)
+              | type(file_p) == #'directory)
+          | files_here(new_accum, file_p, file)
+          | new_accum
+        | new_accum
+    files_here([], start_p, #false)
+
+  fun roots() :~ List.of(Path.Absolute):
+    ~who: who
+    rkt_error.local_error_adjust { #'#{filesystem-root-list}: who }:
+      List(& rkt.#{filesystem-root-list}())
+
+  fun rename(p :: PathString,
+             to_p :: PathString,
+             ~exists_ok = #false):
+    ~who: who
+    rkt_error.local_error_adjust { #'#{rename-file-or-directory}: who }:
+      rkt.#{rename-file-or-directory}(p, to_p, exists_ok)
+
+  fun delete(p :: PathString,
+             ~as: mode :: matching(#'any || #'file || #'directory) = #'any,
+             ~recur = #false,
+             ~must_exist = #true):
+    ~who: who
+    fun delete(p):
+      fun delete_file():
+        cond
+        | (rkt.#{system-type}() == #'windows) && rkt.#{file-exists?}(p):
+            let tmp = make_temporary()
+            let moved:
+              try:
+                rkt.#{rename-file-or-directory}(p, tmp, #true)
+                #true
+                ~catch (x :: Exn.Fail.Filesystem):
+                  #false
+            rkt_error.local_error_adjust { #'#{delete-file}: who }:
+              unless moved
+              | rkt.#{delete-file}(p)
+              rkt.#{delete-file}(tmp)
+        | ~else:
+            rkt_error.local_error_adjust { #'#{delete-file}: who }:
+              rkt.#{delete-file}(p)
+      cond
+      | (recur && mode != #'file) || mode == #'any:
+          match file_type(who, p)
+          | #'file || #'link:
+              delete_file()
+          | #'directory:
+              when recur
+              | let files :~ PairList:
+                  rkt_error.local_error_adjust { #'#{directory-list}: who }:
+                    rkt.#{directory-list}(p, #{#:build?}: #true)
+                for (f: files):
+                  delete(f)
+              rkt_error.local_error_adjust { #'#{delete-directory}: who }:
+                rkt.#{delete-directory}(p)
+          | #'#{directory-link}: // Windows only
+              rkt.#{delete-directory}(p)
+          | ~else:
+              when must_exist
+              | not_a_path_error(who, p)
+      | mode == #'file:
+          when must_exist || file_type(who, p)
+          | delete_file()
+      | mode == #'directory:
+          when must_exist || file_type(who, p)
+          | rkt_error.local_error_adjust { #'#{delete-directory}: who }:
+              rkt.#{delete-directory}(p)
+    delete(p)
+
+  fun make_directory(p :: PathString,
+                     ~parents = #false,
+                     ~permissions: permissions :: Int.in(0, 65535) = 0o777):
+    ~who: who
+    fun make_one(p):
+      rkt_error.local_error_adjust { #'#{make-directory}: who }:
+        rkt.#{make-directory}(p, permissions)
+    if parents
+    | let [root, next, ...] = Path.split(p)
+      fun maybe_make_one(p):
+        unless type(p)
+        | make_one(p)
+      maybe_make_one(
+        for values(p :~ Path = root) (next: [next, ...]):
+          maybe_make_one(p)
+          p.add(next)
+      )
+    | make_one(p)
+
+  def current_force_delete_permissions:
+    #{rename-parameter}(rkt.#{current-force-delete-permissions},
+                        #'#{filesystem.current_force_delete_permissions})
+
+  fun make_temporary(
+    ~in:
+      dir :: PathString = rkt.#{find-system-path}(#'#{temp-dir}),
+    ~as:
+      copy_from :: PathString || matching(#'file) || matching(#'directory) = #'file,
+    ~make_name:
+      make_name :: Function.all_of(String -> Path.Relative,
+                                   ~name: #'#{|make_name for make_temporary|})
+        = fun (s): Path("tmp" +& s),
+    ~permissions:
+      permissions :: maybe(Int.in(0, 65535)) = #false,
+    ~replace_permissions = #false
+  ) :~ Path:
+    ~who: who
+    fun make(s = rkt.#{current-seconds}(),
+             ms = math.exact(math.truncate(rkt.#{current-inexact-milliseconds}())),
+             tries = 0):
+      let tmp: Path.add(dir, make_name(s +& ms))
+      try:
+        match copy_from
+        | #'directory:
+            rkt_error.local_error_adjust { #'#{make-directory}: who }:
+              rkt.#{make-directory}(tmp, permissions || 0o777)
+        | #'file:
+            rkt_error.local_error_adjust { #'#{open-output-file}: who }:
+              Port.Output.close(rkt.#{open-output-file}(tmp,
+                                                        ~permissions: permissions || 0o666,
+                                                        #{#:replace-permissions?}: replace_permissions))
+        | ~else:
+            rkt_error.local_error_adjust { #'#{copy-file}: who }:
+              rkt.#{copy-file}(copy_from,
+                               tmp,
+                               ~permissions: permissions,
+                               #{#:replace-permissions?}: replace_permissions)
+        tmp
+        ~catch (exn :: (Exn.Fail.Filesystem.Exists
+                          || satisfying(fun
+                                        | (exn :: Exn.Fail.Filesystem.Errno):
+                                            exn.errno.first == #'windows
+                                              && exn.errno.rest == 5
+                                              && tries < 32
+                                        | (_): #false))):
+          make(s + math.random(10), ms + math.random(10), tries + 1)
+    make()
+
+  fun make_link(to_path :: PathString,
+                path :: PathString):
+    ~who: who
+    rkt_error.local_error_adjust { #'#{make-file-or-directory-link}: who }:
+      rkt.#{make-file-or-directory-link}(to_path,
+                                         path)
+
+  fun copy(src_path :: PathString,
+           dest_path :: PathString,
+           ~recur = #false,
+           ~exists_ok = #false,
+           ~permissions: permissions :: maybe(Int.in(0, 65535)) = #false,
+           ~replace_permissions = #true,
+           ~keep_modify_seconds = #false,
+           ~follow_links = #true):
+    ~who: who
+    fun copy_file(src_path, dest_path):
+      rkt_error.local_error_adjust { #'#{copy-file}: who }:
+        rkt.#{copy-file}(src_path,
+                         dest_path,
+                         #{#:exists-ok?}: exists_ok,
+                         ~permissions: permissions,
+                         #{#:replace-permissions?}: replace_permissions)
+      when keep_modify_seconds
+      | rkt_error.local_error_adjust { #'#{file-or-directory-modify-seconds}: who }:
+          rkt.#{file-or-directory-modify-seconds}(
+            src_path,
+            rkt.#{file-or-directory-modify-seconds}(dest_path)
+          )
+    fun copy_link(src_path, dest_path):
+      let link:
+        rkt_error.local_error_adjust { #'#{resolve-path}: who }:
+          rkt.#{resolve-path}(src_path)
+      rkt_error.local_error_adjust { #'#{make-file-or-directory-link}: who }:
+        rkt.#{make-file-or-directory-link}(link, dest_path)
+    cond
+    | !recur:
+        if !follow_links && rkt.#{link-exists?}(src_path)
+        | copy_link(src_path, dest_path)
+        | copy_file(src_path, dest_path)
+    | ~else:
+        fun recur(src_path, dest_path):
+          fun copy_dir():
+            fun get_perms(): // get `src_path` permissions only as needed
+              permissions || (rkt_error.local_error_adjust { #'#{make-directory}: who }:
+                                rkt.#{file-or-directory-permissions}(src_path, #'bits))
+            fun maybe_replace_perms(permissions):
+              when replace_permissions
+              | rkt_error.local_error_adjust { #'#{file-or-directory-permissions}: who }:
+                  rkt.#{file-or-directory-permissions}(dest_path, permissions)
+            cond
+            | !exists_ok || !rkt.#{directory-exists?}(dest_path):
+                let permissions = get_perms()
+                rkt_error.local_error_adjust { #'#{make-directory}: who }:
+                  rkt.#{make-directory}(dest_path, permissions)
+                maybe_replace_perms(permissions)
+            | ~else:
+                maybe_replace_perms(get_perms())
+            let files :~ PairList:
+              rkt_error.local_error_adjust { #'#{directory-list}: who }:
+                rkt.#{directory-list}(src_path)
+            for (file: files):
+              recur(Path.add(src_path, file), Path.add(dest_path, file))
+          match file_type(who, src_path)
+          | #'file: copy_file(src_path, dest_path)
+          | #'link:
+              cond
+              | !follow_links:
+                  copy_link(src_path, dest_path)
+              | rkt.#{directory-exists?}(src_path):
+                  copy_dir()
+              | ~else:
+                  copy_file(src_path, dest_path)
+          | #'#{directory-link}:
+              if !follow_links
+              | copy_link(src_path, dest_path)
+              | copy_dir()
+          | #'directory:
+              copy_dir()
+          | ~else:
+              not_a_path_error(who, src_path)
+        recur(src_path, dest_path)
+
+  fun size(path :: PathString) :: NonnegInt:
+    ~who: who
+    rkt_error.local_error_adjust { #'#{file-size}: who }:
+      rkt.#{file-size}(path)
+
+  fun modify_seconds(path :: PathString,
+                     ~set_to: change_to :: maybe(Int) = #false,
+                     ~must_exist = #true):
+    ~who: who
+    rkt_error.local_error_adjust { #'#{file-or-directory-modify-seconds}: who }:
+      if must_exist
+      | rkt.#{file-or-directory-modify-seconds}(path, change_to)
+      | rkt.#{file-or-directory-modify-seconds}(path, change_to,
+                                                if change_to
+                                                | fun (): #void
+                                                | fun (): #false)
+
+  fun permissions(path :: PathString,
+                  ~bits = #false,
+                  ~set_to: change_to :: maybe(Int.in(0, 65535)) = #false):
+    ~who: who
+    rkt_error.local_error_adjust { #'#{file-or-directory-permissions}: who }:
+      cond
+      | change_to:
+          rkt.#{file-or-directory-permissions}(path, change_to)
+      | bits:
+          rkt.#{file-or-directory-permissions}(path, #'bits)
+      | ~else:
+          Set(& rkt.#{file-or-directory-permissions}(path, #false))
+
+  fun identity(path :: PathString,
+               ~follow_links = #true) :: PosInt:
+    ~who: who
+    rkt_error.local_error_adjust { #'#{file-or-directory-identity}: who }:
+      rkt.#{file-or-directory-identity}(path, !follow_links)
+
+  fun stat(path :: PathString,
+           ~follow_links = #true) :~ Map:
+    ~who: who
+    rkt_error.local_error_adjust { #'#{file-or-directory-stat}: who }:
+      rkt.#{file-or-directory-stat}(path, !follow_links)
+
+  fun content(who, path, mode, get, append):
+    let size:
+      try:
+        rkt.#{file-size}(path)
+        ~catch _: 0
+    Closeable.let in = (rkt_error.local_error_adjust { #'#{open-input-file}: who }:
+                          rkt.#{open-input-file}(path, ~mode: mode))
+    let s = get(in, size)
+    // There's a good chance that `file-size' gets all the data:
+    match get(in, size+1)
+    | Port.eof: s
+    | more:
+        fun get_all(accum :~ List):
+          match get(in, 4096)
+          | Port.eof: append(& accum)
+          | more: get_all(accum.add(more))
+        get_all([s, more])
+
+  fun read_string(path :: PathString,
+                  ~mode: mode :: Port.Mode = #'binary) :~ String:
+    ~who: who
+    content(who, path, mode, Port.Input.read_string, String.append)
+
+  fun read_bytes(path :: PathString,
+                 ~mode: mode :: Port.Mode = #'binary) :~ Bytes:
+    ~who: who
+    content(who, path, mode, Port.Input.read_bytes, Bytes.append)
+
+  fun content_lines(who, path, mode, read_line):
+    Closeable.let in = (rkt_error.local_error_adjust { #'#{open-input-file}: who }:
+                          rkt.#{open-input-file}(path))
+    fun read(accum :~ List):
+      match read_line(in, ~mode: mode)
+      | Port.eof: accum
+      | more: read(accum.add(more))
+    read([])
+
+  fun read_lines(path :: PathString,
+                 ~mode: mode :: Port.ReadLineMode = #'any) :: List.of(String):
+    ~who: who
+    content_lines(who, path, mode, Port.Input.read_line)
+
+  fun read_bytes_lines(path :: PathString,
+                       ~mode: mode :: Port.ReadLineMode = #'any) :: List.of(Bytes):
+    ~who: who
+    content_lines(who, path, mode, Port.Input.read_bytes_line)
+
+  fun write_content(who, path, mode, exists, s, write):
+    Closeable.let out = (rkt_error.local_error_adjust { #'#{open-output-file}: who }:
+                           rkt.#{open-output-file}(path, ~mode: mode, ~exists: exists))
+    write(out, s)
+
+  fun write_string(path :: PathString,
+                   str :: String,
+                   ~exists: exists :: Port.Output.ExistsMode = #'error,
+                   ~mode: mode :: Port.Mode = #'binary):
+    ~who: who
+    write_content(who, path, mode, exists, str, Port.Output.write_string)
+
+  fun write_bytes(path :: PathString,
+                  bstr :: Bytes,
+                  ~exists: exists :: Port.Output.ExistsMode = #'error,
+                  ~mode: mode :: Port.Mode = #'binary):
+    ~who: who
+    write_content(who, path, mode, exists, bstr, Port.Output.write_bytes)
+
+  fun not_a_path_error(who, p):
+    throw Exn.Fail.Filesystem(error.message(
+                                            ~who: who,
+                                            "encountered path that is neither file nor directory",
+                                            error.val(~label: "path", p)
+                              ),
+                              Continuation.Marks.current())

--- a/rhombus-lib/rhombus/private/amalgam/function.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/function.rkt
@@ -36,7 +36,6 @@
          "rhombus-primitive.rkt"
          (submod "module.rkt" for-module+)
          (submod "arrow-annotation.rkt" for-arrow-annot)
-         (only-in "name-root-ref.rkt" replace-head-dotted-name)
          "name-prefix.rkt")
 
 (provide (for-spaces (#f
@@ -197,7 +196,7 @@
    '((default . stronger))
    'macro
    (lambda (stx)
-     (syntax-parse (replace-head-dotted-name stx)
+     (syntax-parse stx
        [(form-id (~and args (_::parens g ...+)) . tail)
         (with-syntax ([(kw ...) (for/list ([g (in-list (syntax->list #'(g ...)))]
                                            #:do [(define kw
@@ -250,7 +249,7 @@
    '((default . stronger))
    'macro
    (lambda (stx)
-     (parse-arrow-all-of (replace-head-dotted-name stx)))))
+     (parse-arrow-all-of stx))))
 
 (define (check-nonneg-int who v)
   (unless (exact-nonnegative-integer? v)

--- a/rhombus-lib/rhombus/private/amalgam/macro-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/macro-macro.rkt
@@ -437,7 +437,7 @@
   (define kind protocol)
   (definition-transformer
     (lambda (stx name-prefix)
-      (syntax-parse (replace-head-dotted-name stx)
+      (syntax-parse stx
         #:datum-literals (group)
         [(form-id (alts-tag::alts (_::block (group q::operator-syntax-quote
                                                    (~and rhs (_::block body ...))))

--- a/rhombus-lib/rhombus/private/amalgam/math.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/math.rkt
@@ -19,7 +19,7 @@
   (pi
    abs
    min max
-   floor ceiling round
+   floor ceiling round truncate
    sqrt
    log exp expt
    cos sin tan
@@ -41,7 +41,7 @@
 (define pi (atan 0 -1))
 
 (define-static-info-syntaxes (abs
-                              floor ceiling round
+                              floor ceiling round truncate
                               sqrt
                               exp
                               cos sin tan

--- a/rhombus-lib/rhombus/private/amalgam/pair.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/pair.rkt
@@ -21,6 +21,9 @@
 (module+ for-builtin
   (provide pair-method-table))
 
+(module+ for-static-info
+  (provide (for-syntax get-pair-static-infos)))
+
 (define-primitive-class Pair pair
   #:lift-declaration
   #:no-constructor-static-info

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -18,6 +18,7 @@
          "rhombus-primitive.rkt"
          "parens.rkt"
          "parse.rkt"
+         "rename-parameter.rkt"
          (submod "annotation.rkt" for-class)
          (submod "bytes.rkt" static-infos)
          (submod "function.rkt" for-info)
@@ -99,7 +100,8 @@
    [Directory Path.Directory]
    [Dot Path.Dot]
    [like Path.like]
-   [current_directory current-directory])
+   [current_directory Path.current_directory]
+   [current_directory_for_user Path.current_directory_for_user])
   #:properties
   ()
   #:methods
@@ -274,7 +276,9 @@
   (unless (this-system-path-element? p) (raise-annotation-failure who p "Path.Element"))
   (bytes->immutable-bytes (path-element->bytes p)))
 
-(define-static-info-syntax current-directory
+(define Path.current_directory (rename-parameter current-directory 'Path.current_directory))
+(define Path.current_directory_for_user (rename-parameter current-directory-for-user 'Path.current_directory_for_user))
+(define-static-info-syntaxes (Path.current_directory Path.current_directory_for_user)
   (#%function-arity 3)
   (#%call-result #,(get-path-static-infos))
   . #,(get-function-static-infos))

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
-(require (for-syntax racket/base)
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     shrubbery/print)
          "provide.rkt"
          (submod "annotation.rkt" for-class)
          "call-result-key.rkt"
@@ -12,6 +14,8 @@
          "class-primitive.rkt"
          "realm.rkt"
          "enum.rkt"
+         "binding.rkt"
+         "literal.rkt"
          (submod "print.rkt" for-port)
          "rename-parameter.rkt"
          "rhombus-primitive.rkt")
@@ -33,7 +37,8 @@
   ([Input Port.Input]
    [Output Port.Output]
    EOF
-   eof
+   [eof Port.eof]
+   Mode
    ReadLineMode)
   #:properties ()
   #:methods ())
@@ -60,6 +65,7 @@
    [read_bytes Port.Input.read_bytes]
    [read_char Port.Input.read_char]
    [read_line Port.Input.read_line]
+   [read_bytes_line Port.Input.read_bytes_line]
    [read_string Port.Input.read_string]))
 
 (define-primitive-class Port.Output output-port
@@ -76,11 +82,13 @@
    [open_string Port.Output.open_string]
    [get_bytes Port.Output.String.get_bytes]    ;; temporary: to be removed
    [get_string Port.Output.String.get_string]  ;; temporary: to be removed
-   ExistsFlag)
+   ExistsMode)
   #:properties ()
   #:methods
   ([close Port.Output.close]
    [flush Port.Output.flush]
+   [write_bytes Port.Output.write_bytes]
+   [write_string Port.Output.write_string]
    [print Port.Output.print]
    [println Port.Output.println]
    [show Port.Output.show]
@@ -130,6 +138,20 @@
 
 (define-annotation-syntax EOF (identifier-annotation eof-object? ()))
 
+(define Port.eof eof)
+(define-binding-syntax Port.eof
+  (binding-transformer
+   (lambda (stxes)
+     (syntax-parse stxes
+       [(form-id . tail)
+        (values (binding-form #'literal-infoer
+                              #`([#,eof #,(shrubbery-syntax->string #'form-id)]))
+                #'tail)]))))
+
+(define-simple-symbol-enum Mode
+  binary
+  text)
+
 (define-simple-symbol-enum ReadLineMode
   linefeed
   return
@@ -137,7 +159,7 @@
   any
   [any_one any-one])
 
-(define-simple-symbol-enum ExistsFlag
+(define-simple-symbol-enum ExistsMode
   error
   replace
   truncate
@@ -162,10 +184,11 @@
     [(bstr) (open-input-bytes bstr)]
     [(bstr name) (open-input-bytes bstr name)]))
 
-(define/arity (Port.Input.open_file path)
+(define/arity (Port.Input.open_file path
+                                    #:mode [mode 'binary])
   #:primitive (open-input-file)
   #:static-infos ((#%call-result #,(get-input-port-static-infos)))
-  (open-input-file path))
+  (open-input-file path #:mode mode))
 
 (define/arity Port.Input.open_string
   #:primitive (open-input-string)
@@ -181,13 +204,21 @@
     [() (open-output-bytes)]
     [(name) (open-output-bytes name)]))
 
-(define/arity (Port.Output.open_file path #:exists [exists-in 'error])
+(define/arity (Port.Output.open_file path
+                                     #:exists [exists-in 'error]
+                                     #:mode [mode 'binary]
+                                     #:permissions [permissions #o666]
+                                     #:replace_permissions [replace-permissions? #f])
   #:primitive (open-output-file)
   #:static-infos ((#%call-result #,(get-output-port-static-infos)))
-  (define exists (->ExistsFlag exists-in))
+  (define exists (->ExistsMode exists-in))
   (unless exists
-    (raise-annotation-failure who exists-in "Port.Output.ExistsFlag"))
-  (open-output-file path #:exists exists))
+    (raise-annotation-failure who exists-in "Port.Output.ExistsMode"))
+  (open-output-file path
+                    #:exists exists
+                    #:mode mode
+                    #:permissions permissions
+                    #:replace-permissions? replace-permissions?))
 
 (define/arity Port.Output.open_string
   #:primitive (open-output-string)
@@ -237,12 +268,23 @@
 (define/method (Port.Input.read_line port
                                      #:mode [mode-in 'any])
   #:primitive (read-line)
+  (unless (input-port? port) (raise-annotation-failure who port "Port.Input"))
   (define mode (->ReadLineMode mode-in))
   (unless mode
     (check-input-port who port)
     (raise-annotation-failure who mode-in "Port.Input.ReadLineMode"))
   (coerce-read-result
    (read-line port mode)))
+
+(define/method (Port.Input.read_bytes_line port
+                                           #:mode [mode-in 'any])
+  #:primitive (read-line)
+  (unless (input-port? port) (raise-annotation-failure who port "Port.Input"))
+  (define mode (->ReadLineMode mode-in))
+  (unless mode
+    (check-input-port who port)
+    (raise-annotation-failure who mode-in "Port.Input.ReadLineMode"))
+  (read-bytes-line port mode))
 
 (define/method (Port.Input.read_string port amt)
   #:primitive (read-string)
@@ -265,6 +307,18 @@
 (define/method (Port.Output.flush [p (current-output-port)])
   (check-output-port who p)
   (flush-output p))
+
+(define/method (Port.Output.write_bytes port bstr [start 0] [end (and (bytes? bstr) (bytes-length bstr))])
+  #:primitive (write-bytes)
+  (unless (output-port? port) (raise-annotation-failure who port "Port.Output"))
+  (write-bytes bstr port start end)
+  (void))
+
+(define/method (Port.Output.write_string port str [start 0] [end (and (string? str) (string-length str))])
+  #:primitive (write-string)
+  (unless (output-port? port) (raise-annotation-failure who port "Port.Output"))
+  (write-string str port start end)
+  (void))
 
 (define/method (Port.Output.print port
                                   #:mode [mode 'text]
@@ -289,3 +343,5 @@
                                    . vs)
   (do-print* who vs port 'expr pretty?)
   (newline port))
+
+(void (set-primitive-contract! '(or/c 'binary 'text) "Port.Mode"))

--- a/rhombus-lib/rhombus/private/amalgam/rhombus-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/rhombus-primitive.rkt
@@ -59,5 +59,9 @@
            (string-append sep-op-sep (get-or-format-primitive-contract contract/rkt)))))
 
 (define (get-primitive-who who/rkt)
-  (or (hash-ref (continuation-mark-set-first #f primitive-who-table-key #hasheq()) who/rkt #f)
+  (or (let ([t (continuation-mark-set-first #f primitive-who-table-key #hasheq())])
+        (cond
+          [(not t) #t]
+          [(pair? t) (and (eq? (car t) who/rkt) (cdr t))]
+          [else (hash-ref t who/rkt #f)]))
       (hash-ref primitive-who-table who/rkt #f)))

--- a/rhombus-lib/rhombus/private/amalgam/setmap-parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/setmap-parse.rkt
@@ -245,7 +245,7 @@
       [else (cons (car args) (loop (cdr args) (cdr argss)))])))
 
 (define-for-syntax (parse-key-comp stx k)
-  (syntax-parse (replace-head-dotted-name stx)
+  (syntax-parse stx
     #:datum-literals (group)
     [(form (~and args (p-tag::parens (group . name-seq::dotted-operator-or-identifier))) . tail)
      #:with (~var name(:hier-name-seq in-name-root-space in-key-comp-space name-path-op name-root-ref)) #'name-seq

--- a/rhombus-lib/rhombus/private/amalgam/system.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/system.rhm
@@ -2,6 +2,7 @@
 import:
   "core-meta.rkt" open
   lib("racket/base.rkt") as rkt
+  "error.rhm" open
 
 export:
   system
@@ -14,6 +15,7 @@ namespace system:
     host
     target_machine
     version
+    path
     TargetMachineSymbol
 
   fun type() :~ Symbol:
@@ -39,3 +41,12 @@ namespace system:
 
   fun version() :~ String:
     String.snapshot(rkt.#{version}())
+
+  fun path(which :: Symbol):
+    ~who: who
+    match which
+    | #'temp_dir: rkt.#{find-system-path}(#'#{temp-dir})
+    | ~else:
+        error(~who: who,
+              "unrecognized symbol",
+              error.val(~label: "symbol", which))

--- a/rhombus-lib/rhombus/private/amalgam/unquote-binding-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/unquote-binding-primitive.rkt
@@ -4,6 +4,7 @@
                      enforest/name-parse
                      enforest/hier-name-parse
                      enforest/syntax-local
+                     shrubbery/print
                      "name-path-op.rkt"
                      "attribute-name.rkt")
          syntax/parse/pre
@@ -158,8 +159,8 @@
         #:do [(define parser (syntax-local-value* (in-defn-space #'sc-hier.name) syntax-class-parser-ref))]
         #:when parser
         (define-values (open-attributes end-tail) (parse-open-block stx #'tail))
-        (define rsc ((syntax-class-parser-proc parser) (or (syntax-property #'sc-hier.name 'rhombus-dotted-name)
-                                                           (syntax-e #'sc-hier.name))
+        (define rsc ((syntax-class-parser-proc parser) (string->symbol
+                                                        (shrubbery-syntax->string #'sc-hier.name))
                                                        #'sc
                                                        (current-unquote-binding-kind)
                                                        match-id

--- a/rhombus/rhombus/scribblings/reference/filesystem.scrbl
+++ b/rhombus/rhombus/scribblings/reference/filesystem.scrbl
@@ -6,6 +6,22 @@
 @title(~tag: "filesystem"){Filesystem}
 
 @doc(
+  fun filesystem.type(path :: PathString,
+                      ~must_exist: must_exist = #false)
+    :: matching(#'file || #'directory || #'link || #'directory_link || #false)
+){
+
+ Reports whether @rhombus(path) refers to an existing file, directory,
+ or soft link, returning a corresponding symbol or @rhombus(#false) if
+ @rhombus(path) does not exist. If @rhombus(must_exist) is true, then
+ @rhombus(#false) is never returned, and an exception is thrown, instead.
+
+ The result can be @rhombus(#'directory_link) only on Windows, which
+ distinguishes file and directory links.
+
+}
+
+@doc(
   fun filesystem.file_exists(path :: PathString) :: Boolean
   fun filesystem.directory_exists(path :: PathString) :: Boolean
   fun filesystem.link_exists(path :: PathString) :: Boolean
@@ -20,6 +36,376 @@
 
 }
 
+@doc(
+    fun filesystem.files(
+      path :: PathString = Path.current_directory(),
+      ~add_path: add_path = #false,
+      ~recur: recur = #false,
+      ~follow_links: follow_links = #false,
+      ~keep: keep :: Path -> Any = fun (x): #true,
+      ~skip: skip :: Path -> Any = fun (x): #false
+    ) :: List.of(Path)
+){
+
+ Returns a list of paths within the directory referenced by
+ @rhombus(path). Each path in the result list is relative to
+ @rhombus(path), unless @rhombus(add_path) is true, in which case
+ @rhombus(Path.add) is used with @rhombus(path) and each result path in
+ the list.
+
+ If @rhombus(recur) is @rhombus(#false), then the result includes only
+ files, directories, and links immediately within @rhombus(path). If
+ @rhombus(recur) is true, then each directory within @rhombus(path) is
+ followed by its own recursive content in the result list. If
+ @rhombus(follow_links) true, the a recursive traversal continues into a
+ link that refers to a directory, otherwise the link is not traversed for
+ the result list; link cycles can cause @rhombus(filesystem.files) to
+ never return.
+
+ The @rhombus(keep) and @rhombus(skip) functions are applied to every
+ path encountered during a traversal, and a path is omitted from the list
+ when @rhombus(keep) returns @rhombus(#false) or @rhombus(skip) returns a
+ true value for the path. When @rhombus(recur) is true, skipping a
+ directory (or link that refers to a directory) means that it is not
+ traversed, so the directory's content is also skipped. If @rhombus(keep)
+ returns @rhombus(#false) for a path, then @rhombus(skip) is not applied
+ to the path.
+
+}
+
+@doc(
+  fun filesystem.roots() :: List.of(Path.Absolute)
+){
+
+ Returns a list of all roots on the current filesystem. For a filesystem
+ that uses Unix path conventions, the result is always
+ @rhombus([Path("/")]), but the result list can contain multiple drive
+ paths on Windows.
+
+}
+
+@doc(
+  fun filesystem.rename(path :: PathString,
+                        to_path :: PathString,
+                        ~exists_ok: exists_ok = #false)
+    :: Void
+){
+
+ Renames the file or directory @rhombus(path) to @rhombus(to_path). If
+ @rhombus(exists_ok) is true, then renaming can replace an existing file.
+
+ When @rhombus(exists_ok) is @rhombus(#false), a check is needed before
+ the move operation internally, and that combination is not atomic on
+ Unix and Mac OS. If @rhombus(to_path) exists and is replaced (when
+ @rhombus(exists_ok) is true), then the replacement is atomic on Unix and
+ Mac OS, but not necessarily atomic on Windows.
+
+}
+
+
+@doc(
+  fun filesystem.delete(
+    path :: PathString,
+    ~as: mode :: matching(#'any || #'file || #'directory) = #'any,
+    ~recur: recur = #false,
+    ~must_exist: must_exist = #true
+  ) :: Void
+){
+
+ Deletes the file, directory, or link referenced by @rhombus(path). If
+ @rhombus(mode) is @rhombus(#'file), then @rhombus(path) must refer to a
+ file or link, and if @rhombus(mode) is @rhombus(#'directory), then
+ @rhombus(path) must refer to a directory.
+
+ If @rhombus(recur) is true and if @rhombus(path) refers to a directory,
+ then each file and directory within @rhombus(path) is recursively
+ deleted before attempting to delete @rhombus(path) itself. When a link
+ that refers to a directory is deleted, then the directory content is not
+ deleted through the link, even when @rhombus(recur) is true.
+
+ If @rhombus(must_exist) is @rhombus(#true) and @rhombus(path) does not
+ refer to a file, directory, or link, then an exception is thrown.
+
+ When @rhombus(mode) is @rhombus(#'any) or @rhombus(must_exist) is
+ @rhombus(#false), the check for @rhombus(path)'s type/existence is not
+ atomic combined with the deletion of @rhombus(path), so an exception can
+ be thrown if a file, directory or link disappears or changes between the
+ check and deletion.
+
+ On Windows, a file or link is deleted by first renaming it to a file in
+ the temporary directory reported by @rhombus(system.path(#'temp_dir)),
+ and then deleting the file there. That two-step process can succeed in
+ situations when a file might otherwise be locked by an asynchronous
+ background process. If moving the file does not succeed, it is instead
+ deleted in-place. See also
+ @rhombus(filesystem.current_force_delete_permissions).
+
+}
+
+
+@doc(
+  fun filesystem.make_directory(
+    path :: PathString,
+    ~parents: parents = #false,
+    ~permissions: permissions :: Int.in(0, 65535) = 0o777
+  ) :: Void
+){
+
+ Creates a directory @rhombus(path). If @rhombus(parents) is true, then
+ any non-existent parent of @rhombus(path) is created, first. If
+ @rhombus(parents) is @rhombus(#false) and @rhombus(path) exists already,
+ then an exception is thrown.
+
+ The @rhombus(permissions) argument specifies permissions used for a new
+ created directory on Unix and Mac OS. The given @rhombus(permissions)
+ are adjusted based on the current process's umask. The
+ @rhombus(permissions) argument is ignored on Windows.
+
+}
+
+
+@doc(
+  fun filesystem.make_link(to_path :: PathString,
+                           path :: PathString)
+    :: Void
+){
+
+ Creates @rhombus(path) as a soft link whose content is the byte-string
+ form of @rhombus(path). An exception is thrown if @rhombus(path) exists
+ already.
+
+}
+
+
+@doc(
+  fun filesystem.make_temporary(
+    ~in: dir :: PathString = system.path(#'temp_dir),
+    ~as: mode :: (PathString || matching(#'file) || matching(#'directory))
+           = #'file,
+    ~make_name: make_name :: String -> Path.Relative
+                  = fun (s): Path("tmp" +& s),
+    ~permissions: permissions :: maybe(Int.in(0, 65535))
+                    = #false,
+    ~replace_permissions: replace_permissions = #false
+  ) :: Path
+){
+
+ Creates a temporary file or directory within @rhombus(dir) and returns
+ a path to the created file. If @rhombus(mode) is a path or
+ @rhombus(#'file), the result is a file path, otherwise it is a directory
+ path. If @rhombus(as) is a path, the temporary file is created as a copy
+ of @rhombus(as).
+
+ The name of the temporary file is based on the current time and the
+ @rhombus(make_name) function. The argument to @rhombus(make_name) is a
+ string containing only ASCII digits. The path returns by
+ @rhombus(make_name) is added to @rhombus(dir), and if a file, directory,
+ or link with that name exists already,
+ @rhombus(filesystem.make_temporary) starts again to try a new file name.
+
+ The @rhombus(permissions) and @rhombus(replace_permissions) arguments
+ apply to the newly created file. When @rhombus(mode) as a path, the
+ permissions argument as used as in @rhombus(filesystem.copy). Otherwise,
+ the permissions arguments are used as in @rhombus(Port.Output.open_file)
+ or @rhombus(filesystem.make_directory).
+
+}
+
+
+@doc(
+  fun filesystem.copy(
+    src_path :: PathString,
+    dest_path :: PathString,
+    ~recur: recur = #false,
+    ~exists_ok: exists_ok = #false,
+    ~follow_links: follow_links = #true,
+    ~permissions: permissions :: maybe(Int.in(0, 65535)) = #false,
+    ~replace_permissions: replace_permissions = #true,
+    ~keep_modify_seconds: keep_modify_seconds = #false
+  ) :: Void
+){
+
+ Copies the file or link @rhombus(src_path) to @rhombus(dest_path), or
+ recursively copies a directory when @rhombus(recur) is true.
+
+ If @rhombus(exists_ok) is false, an exception is thrown if
+ @rhombus(dest_path) exists already. When @rhombus(exists_ok) is true,
+ @rhombus(recur) is true, and a directory is copied, then the content of
+ @rhombus(src_path) is effectively spliced with any existing directory
+ tree @rhombus(dest_path).
+
+ When @rhombus(follow_links) is @rhombus(#false), then a link is copied
+ to a new link. Otherwise, the target of the link is copied to the new
+ path.
+
+ The @rhombus(permissions) argument is used for newly created files and
+ directories. When it is @rhombus(#false), then a new file or directory
+ uses the permissions of the copied files or directory, otherwise
+ @rhombus(permissions) is used for both copied files and new directories.
+ On Windows, if @rhombus(permissions) is supplied as
+ non-@rhombus(#false), then after copying, @rhombus(dest_path) is set to
+ read-only or not depending on whether the @rhombus(0o2) bit is present
+ in @rhombus(permissions).
+
+ The @rhombus(replace_permissions) argument is used only on Unix and Mac
+ OS. When a @rhombus(dest_path) is created, it is created with
+ @rhombus(permissions) or the permissions of @rhombus(src_path); however,
+ the process's umask may unset bits in the requested permissions. When
+ @rhombus(dest_path) already exists (and @rhombus(exists_ok) is true),
+ then the permissions of @rhombus(dest_path) are initially left as-is.
+ Finally, when @rhombus(replace_permissions) is a true value, then the
+ permissions of @rhombus(dest_path) are set after the file content is
+ copied (using again @rhombus(permissions) or the permissions of
+ @rhombus(src_path)) without modification by the process's umask.
+
+ On Windows, the modification time of @rhombus(src_path) is transferred
+ to @rhombus(dest_path). When @rhombus(keep_modify_seconds) is true, then
+ on Unix and Mac OS, too, the modification time of @rhombus(src_path) is
+ transferred to @rhombus(dest_path) after copying.
+
+}
+
+@doc(
+  fun filesystem.size(path :: PathString) :: NonnegInt
+){
+
+ Returns the size of the file referenced by @rhombus(path). An exception
+ is thrown if @rhombus(path) does not refer to an existing file.
+
+}
+
+
+@doc(
+  fun filesystem.modify_seconds(
+    path :: PathString,
+    ~set_to: set_to :: maybe(Int) = #false,
+    ~must_exist: must_exist = #true
+  ) :: maybe(Int) || Void
+){
+
+ Returns or changes (when @rhombus(set_to) is not @rhombus(#false))
+ the modification timestamp of @rhombus(path).
+
+ If @rhombus(path) cannot be accessed or the modification timestamp
+ cannot be changed, an exception is thrown only if @rhombus(must_exist)
+ is @rhombus(#false). Otherwise, @rhombus(#false) is reported for an
+ inaccessible timestamp and failure is silently ignored (and
+ @rhombus(#void) is still returned) when setting a timestamp fails.
+
+}
+
+@doc(
+  fun filesystem.permissions(
+    path :: PathString,
+    ~bits: bits = #false,
+    ~set_to: set_to :: maybe(Int.in(0, 65535)) = #false
+  ) :: Int || Set.of(matching(#'read || #'write || #'execute)) || Void
+){
+
+ Returns or changes (when @rhombus(set_to) is not @rhombus(#false))
+ the permissions of @rhombus(path).
+
+ When @rhombus(set_to) is provided, the result is @rhombus(#void).
+ Otherwise, the result is an integer when @rhombus(bits) is true, or it
+ is a list of distinct symbols when @rhombus(bits) is false. A
+ symbol-list result summarizes permissions for the current process's user
+ and group.
+
+}
+
+@doc(
+  fun filesystem.identity(
+    path :: PathString,
+    ~follow_links: follow_links = #true
+  ) :: PosInt
+){
+
+ Returns an integer representing the identity of the file or directory
+ referenced by @rhombus(path). This function can be used to check whether
+ two paths correspond to the same filesystem object.
+
+ When @rhombus(path) refers to a link, the result is the identity of the
+ link when @rhombus(follow_links) is @rhombus(#false), otherwise it is
+ the identity of the link target.
+
+}
+
+
+@doc(
+  fun filesystem.stat(path :: PathString,
+                      ~follow_links: follow_links = #true)
+    :: Map
+){
+
+ Returns a symbol-keyed map containing information about @rhombus(path).
+ The map includes information available from @rhombus(filesystem.type),
+ @rhombus(filesystem.modify_seconds), @rhombus(filesystem.permissions),
+ @rhombus(filesystem.identity), and other functions, but potentially in a
+ more detailed form. This information is relatively low-level, and the
+ result map uses Racket-style symbols as keys.
+
+ If @rhombus(path) refers to a link, then the result map describes the
+ target of the link unless @rhombus(follow_links) is @rhombus(false).
+
+}
+
+
+@doc(
+  fun filesystem.read_bytes(
+    path :: PathString,
+    ~mode: mode :: Port.Mode = #'binary
+  ) :: Bytes
+  fun filesystem.read_string(
+    path :: PathString,
+    ~mode: mode :: Port.Mode = #'binary
+  ) :: String
+){
+
+ Returns the content of the file referenced by @rhombus(path), either in
+ byte form or string form. The latter corresponds to a UTF-8 decoding of
+ the file's bytes.
+
+}
+
+@doc(
+  fun filesystem.read_bytes_lines(
+    path :: PathString,
+    ~mode: mode :: Port.ReadLineMode = #'any
+  ) :: List.of(String)
+  fun filesystem.read_lines(
+    path :: PathString,
+    ~mode: mode :: Port.ReadLineMode = #'any
+  ) :: List.of(String)
+){
+
+ Returns the content of the file referenced by @rhombus(path) as a list
+ of byte-string or string lines. The latter corresponds to a UTF-8
+ decoding of the file's bytes. The @rhombus(mode)
+ argument is the same as for @rhombus(Port.Input.open_file).
+
+}
+
+
+@doc(
+  fun filesystem.write_bytes(
+    path :: PathString,
+    bstr :: Bytes,
+    ~exists: exists :: Port.Output.ExistsMode = #'error,
+    ~mode: mode :: Port.Mode = #'binary
+  ) :: Void
+  fun filesystem.write_string(
+    path :: PathString,
+    str :: String,
+    ~exists: exists :: Port.Output.ExistsMode = #'error,
+    ~mode: mode :: Port.Mode = #'binary
+  ) :: Void
+){
+
+ Replaces the content of @rhombus(path) with @rhombus(bstr) or the UTF-8
+ encoding of @rhombus(str). The @rhombus(mode) and @rhombus(exists)
+ arguments are the same as for @rhombus(Port.Output.open_file).
+
+}
 
 @doc(
   fun filesystem.simplify_path(path :: PathString) :: Path
@@ -73,15 +459,16 @@
 
 }
 
+
 @doc(
-  fun filesystem.list_directory(path :: PathString
-                                  = Path.current_directory(),
-                                ~extend_path: extend = #false)
-    :: List.of(Path)
+  Parameter.def \
+  filesystem.current_force_delete_permissions
+    :: Any.to_boolean
 ){
 
-  Returns a list of all files and directories in the directory specified
-  by @rhombus(path).  If @rhombus(extend) is @rhombus(#true) the resulting
-  paths are extended from @rhombus(path).
+ When @rhombus(filesystem.current_force_delete_permissions) has a true
+ value (the default), then when attempting to delete a file on Windows,
+ the files is made writable before attempting to delete it. This mode
+ more closely imitates the behavior of file deletion on Unix.
 
 }

--- a/rhombus/rhombus/scribblings/reference/input_port.scrbl
+++ b/rhombus/rhombus/scribblings/reference/input_port.scrbl
@@ -40,7 +40,9 @@ Moreover, an @deftech{input string port} reads from a @tech{byte
 }
 
 @doc(
-  fun Port.Input.open_file(file :: PathString) :: Port.Input
+  fun Port.Input.open_file(file :: PathString,
+                           ~mode: mode :: Port.Mode = #'binary)
+    :: Port.Input
 ){
 
  Creates an @tech{input port} that reads from the @tech{path} @rhombus(file).

--- a/rhombus/rhombus/scribblings/reference/output_port.scrbl
+++ b/rhombus/rhombus/scribblings/reference/output_port.scrbl
@@ -58,10 +58,13 @@ an @deftech{output string port} writes to a @tech{byte string}.
 }
 
 @doc(
-  fun Port.Output.open_file(path :: PathString,
-                            ~exists: exists_flag
-                                       :: Port.Output.ExistsFlag = #'error)
-    :: Port.Output
+  fun Port.Output.open_file(
+    path :: PathString,
+    ~exists: exists_flag :: Port.Output.ExistsMode = #'error,
+    ~mode: mode :: Port.Mode = #'binary,
+    ~permissions: permissions :: Int.in(0, 65535) = 0o666,
+    ~replace_permissions: replace_permissions = #false
+  ) :: Port.Output
 ){
 
  Creates an @tech{output port} that writes to the @tech{path} @rhombus(file).
@@ -147,7 +150,7 @@ an @deftech{output string port} writes to a @tech{byte string}.
 }
 
 @doc(
-  enum Port.Output.ExistsFlag:
+  enum Port.Output.ExistsMode:
     error
     append
     update

--- a/rhombus/rhombus/scribblings/reference/port.scrbl
+++ b/rhombus/rhombus/scribblings/reference/port.scrbl
@@ -24,8 +24,22 @@ output; it is possible for an object to be both an input and output port.
 
 @doc(
  def Port.eof :: Port.EOF
+ bind.macro 'Port.eof'
 ){
 
- A value (distinct from all other values) that represents an end-of-file.
+ The @rhombus(Port.eof) value represents an end-of-file (distinct from
+ all other values), and the @rhombus(Port.eof) binding match matches that
+ value.
+
+}
+
+@doc(
+ enum Port.Mode:
+   binary
+   text
+){
+
+ Modes for reading and writing files that determine how newlines are
+ read and written.
 
 }

--- a/rhombus/rhombus/scribblings/reference/system.scrbl
+++ b/rhombus/rhombus/scribblings/reference/system.scrbl
@@ -69,3 +69,18 @@
  target machine.
 
 }
+
+@doc(
+  fun system.path(which :: Symbol) :: Path
+){
+
+ Returns a system-specific path categorized by @rhombus(which):
+
+@itemlist(
+
+ @item{@rhombus(#'temp_dir): a path to a directory for storing temporary
+  files.}
+
+)
+
+}

--- a/rhombus/rhombus/tests/annotation.rhm
+++ b/rhombus/rhombus/tests/annotation.rhm
@@ -131,3 +131,15 @@ check:
   "x" :: Any.of(#true, #false) ~throws "does not satisfy"
   "x" :: Any.to_boolean ~is #true
   "x" :: None ~throws "does not satisfy"
+
+block:
+  namespace ns:
+    export:
+      Int
+      Array
+      Posn
+    class Posn(x, y)
+  check "a" :: ns.Int ~throws "ns.Int"
+  check "a" :: ns.Array ~throws "ns.Array"
+  check "a" :: ns.Array.of_length(10) ~throws "ns.Array.of_length(10)"
+  check "a" :: ns.Posn ~throws "ns.Posn"

--- a/rhombus/rhombus/tests/filesystem.rhm
+++ b/rhombus/rhombus/tests/filesystem.rhm
@@ -5,6 +5,12 @@ import:
 
 runtime_path.def path_rhm: "path.rhm"
 
+def windows: system.type() == #'windows
+
+fun current_seconds():
+  import lib("racket/base.rkt")
+  base.#{current-seconds}()
+
 block:
   import "static_arity.rhm"
   static_arity.check:
@@ -56,3 +62,301 @@ block:
   check_annot filesystem.file_exists(cross_p)
   check_annot filesystem.directory_exists(cross_p)
   check_annot filesystem.link_exists(cross_p)
+
+block:
+  let tmp = filesystem.make_temporary(~as: #'directory)
+  check tmp.parent() ~is system.path(#'temp_dir)
+  check filesystem.directory_exists(tmp) ~is #true
+
+  let x = tmp.add("x")
+  block:
+    Closeable.let f = Port.Output.open_file(x)
+    f.write_bytes(#"hello world")
+  check filesystem.file_exists(x) ~is #true
+
+  let d = tmp.add("d")
+  check filesystem.make_directory(d) ~is #void
+  check filesystem.directory_exists(d) ~is #true
+
+  let y = d.add("y")
+  fun make_y():
+    Port.Output.open_file(y).close()
+  make_y()
+  check filesystem.file_exists(y) ~is #true
+
+  let nonesuch = tmp.add("nonesuch")
+
+  let link = !windows && tmp.add("link")
+  let link2 = !windows && tmp.add("link2")
+  let dlink = !windows && tmp.add("dlink")
+  fun make_link2():
+    filesystem.make_link("nonesuch", link2)
+  unless windows
+  | filesystem.make_link("x", link)
+    make_link2()
+    filesystem.make_link("d", dlink)
+
+  check filesystem.link_exists(tmp) ~is #false
+  check filesystem.link_exists(x) ~is #false
+  check filesystem.link_exists(d) ~is #false
+  unless windows
+  | check filesystem.link_exists(link) ~is #true
+    check filesystem.link_exists(link2) ~is #true
+    check filesystem.file_exists(link) ~is #true
+    check filesystem.directory_exists(link) ~is #false
+    check filesystem.file_exists(link2) ~is #false
+    check filesystem.directory_exists(link2) ~is #false
+    check filesystem.file_exists(dlink) ~is #false
+    check filesystem.directory_exists(dlink) ~is #true
+
+  check filesystem.type(x) ~is #'file
+  check filesystem.type(tmp) ~is #'directory
+  check filesystem.type(d) ~is #'directory
+  check filesystem.type(link) ~is !windows && #'link
+  check filesystem.type(link2) ~is !windows && #'link
+  check filesystem.type(dlink) ~is !windows && #'link
+
+  check filesystem.files(d) ~is [Path("y")]
+  check filesystem.files(d, ~recur: #true) ~is [Path("y")]
+  check filesystem.files(x) ~throws "filesystem.files:"
+  check filesystem.files(nonesuch) ~throws "filesystem.files:"
+
+  let all_files = (["d", Path("d").add("y")] ++ (if windows | [] | ["dlink", "link", "link2"]) ++ ["x"]).map(Path)
+  let all_immediate_files = all_files.remove(Path("d").add("y"))
+  check filesystem.files(tmp) ~is all_immediate_files
+  check filesystem.files(tmp, ~add_path: #true) ~is all_immediate_files.map(Path.add(tmp, _))
+  check filesystem.files(tmp, ~recur: #true) ~is all_files
+  check filesystem.files(tmp, ~recur: #true, ~add_path: #true) ~is all_files.map(Path.add(tmp, _))
+  check:
+    filesystem.files(tmp, ~recur: #true, ~follow_links: #true)
+    ~is List.append(& for List(f: all_files):
+                      if f == Path("dlink")
+                      | [Path("dlink"), Path("dlink").add("y")]
+                      | [f])
+  check:
+    filesystem.files(tmp, ~skip: fun (x): x == Path("d"))
+    ~is all_immediate_files.remove(Path("d"))
+  check:
+    filesystem.files(tmp, ~keep: fun (x): x != Path("d"))
+    ~is all_immediate_files.remove(Path("d"))
+  check:
+    filesystem.files(tmp, ~skip: fun (x): x == Path("x"))
+    ~is all_immediate_files.remove(Path("x"))
+  check:
+    filesystem.files(tmp, ~keep: fun (x): x != Path("x"))
+    ~is all_immediate_files.remove(Path("x"))
+  check:
+    filesystem.files(tmp, ~recur: #true, ~skip: fun (x): x == Path("d"))
+    ~is all_immediate_files.remove(Path("d"))
+  check:
+    filesystem.files(tmp,
+                     ~keep: fun (x): x != Path("d"),
+                     ~skip: fun (x): x == Path("x"))
+    ~is all_immediate_files.remove(Path("d")).remove(Path("x"))
+  check:
+    filesystem.files(tmp,
+                     ~keep: fun (x): x == Path("d"),
+                     ~skip: fun (x): x != Path("x"))
+    ~is []
+  check:
+    filesystem.files(tmp,
+                     ~keep: fun (x): x == Path("d"),
+                     ~skip: fun (x): x != Path("d"))
+    ~is [Path("d")]
+
+  check filesystem.roots() ~is_a List
+  when !windows
+  | check filesystem.roots() ~is [Path("/")]
+
+  check filesystem.rename(x, tmp.add("x_new")) ~is #void
+  check filesystem.files(tmp) ~is (for List (f: all_immediate_files):
+                                     if f == Path("x")
+                                     | Path("x_new")
+                                     | f)
+  check filesystem.rename(tmp.add("x_new"), x) ~is #void
+  check filesystem.rename(x, y) ~throws "filesystem.rename"
+  check filesystem.rename(x, y, ~exists_ok: #true) ~is #void
+  check filesystem.files(tmp) ~is all_immediate_files.remove(Path("x"))
+  check filesystem.rename(y, x) ~is #void
+  make_y()
+
+  check filesystem.delete(y) ~is #void
+  check filesystem.files(tmp) ~is all_immediate_files.remove(Path("y"))
+  check filesystem.delete(d, ~as: #'file) ~throws "filesystem.delete:"
+  check filesystem.delete(d, ~as: #'file, ~must_exist: #false) ~throws "filesystem.delete:"
+  check filesystem.delete(d) ~is #void
+  filesystem.make_directory(d)
+  make_y()
+  check filesystem.delete(y, ~as: #'directory) ~throws "filesystem.delete:"
+  check filesystem.delete(y, ~as: #'directory, ~must_exist: #false) ~throws "filesystem.delete:"
+  check filesystem.delete(d) ~throws "filesystem.delete:"
+  check filesystem.delete(d, ~recur: #true) ~is #void
+  check filesystem.type(y) ~is #false
+  check filesystem.type(d) ~is #false
+  check filesystem.delete(d, ~must_exist: #false) ~is #void
+  check filesystem.delete(d) ~throws "filesystem.delete:"
+  filesystem.make_directory(d)
+  make_y()
+
+  check filesystem.size(tmp) ~throws "filesystem.size:"
+  check filesystem.size(x) ~is 11
+  check filesystem.size(d) ~throws "filesystem.size:"
+  check filesystem.size(link) ~is filesystem.size(x)
+  check filesystem.size(link2) ~throws "filesystem.size:"
+
+  check filesystem.modify_seconds(tmp) ~is_a Int
+  check filesystem.modify_seconds(x) ~is_a Int
+  when !windows
+  | check filesystem.modify_seconds(link) ~is filesystem.modify_seconds(x)
+    check filesystem.modify_seconds(dlink) ~is filesystem.modify_seconds(d)
+  check filesystem.modify_seconds(link2) ~throws "filesystem.modify_seconds:"
+  check filesystem.modify_seconds(nonesuch) ~throws "filesystem.modify_seconds:"
+  check filesystem.modify_seconds(link, ~must_exist: #false) ~is !windows && filesystem.modify_seconds(x)
+  check filesystem.modify_seconds(link2, ~must_exist: #false) ~is #false
+  check filesystem.modify_seconds(nonesuch, ~must_exist: #false) ~is #false
+  let now = current_seconds()
+  check filesystem.modify_seconds(x) .<= now ~is #true
+  check filesystem.modify_seconds(x, ~set_to: now) ~is #void
+  check filesystem.modify_seconds(x) ~is now
+  check filesystem.modify_seconds(x, ~set_to: now-100) ~is #void
+  check filesystem.modify_seconds(x) ~is now-100
+  when !windows
+  | check filesystem.modify_seconds(link, ~set_to: now) ~is #void
+    check filesystem.modify_seconds(link) ~is now
+    check filesystem.modify_seconds(x) ~is now
+
+  check filesystem.permissions(tmp) ~is { #'read, #'write, #'execute }
+  check filesystem.permissions(x) ~is { #'read, #'write }
+  check filesystem.permissions(d) ~is { #'read, #'write, #'execute }
+  when !windows
+  | check filesystem.permissions(link) ~is { #'read, #'write }
+  check filesystem.permissions(x, ~set_to: 0o444) ~is #void
+  check filesystem.permissions(x) ~is { #'read }
+  check filesystem.permissions(x, ~bits: #true) bits.and 0o777 ~is 0o444
+  check filesystem.permissions(x, ~set_to: 0o666) ~is #void
+  check filesystem.permissions(x) ~is { #'read, #'write }
+
+  check filesystem.identity(tmp) ~is_a PosInt
+  check filesystem.identity(x) ~is_a PosInt
+  check filesystem.identity(d) ~is_a PosInt
+  check filesystem.identity(tmp, ~follow_links: #true) ~is filesystem.identity(tmp)
+  check filesystem.identity(x, ~follow_links: #true) ~is filesystem.identity(x)
+  check filesystem.identity(x) == filesystem.identity(tmp) ~is #false
+  check filesystem.identity(d) == filesystem.identity(tmp) ~is #false
+  unless windows
+  | check filesystem.identity(x) == filesystem.identity(link) ~is #true
+    check filesystem.identity(x) == filesystem.identity(link, ~follow_links: #false) ~is #false
+
+  check filesystem.stat(tmp) ~is_a Map
+  check filesystem.stat(x) ~is_a Map
+  check filesystem.stat(x, ~follow_links: #false) ~is filesystem.stat(x)
+  unless windows
+  | check filesystem.stat(link) ~is filesystem.stat(x)
+    check filesystem.stat(link, ~follow_links: #false) == filesystem.stat(x) ~is #false
+  check filesystem.stat(nonesuch) ~throws "filesystem.stat:"
+
+  check filesystem.read_bytes(x) ~is_now #"hello world"
+  check filesystem.read_string(x) ~is "hello world"
+  check filesystem.read_bytes_lines(x) ~is_now [#"hello world"]
+  check filesystem.read_lines(x) ~is ["hello world"]
+  block:
+    let inode = filesystem.identity(x)
+    block:
+      Closeable.let f = Port.Output.open_file(x, ~exists: #'truncate)
+      for (i: 0..4096):
+        println("hello world", ~out: f)
+    check filesystem.identity(x) ~is inode
+  check filesystem.size(x) ~is 12*4096
+  check filesystem.read_bytes(x) ~is_now Bytes.append(& for List (i: 0..4096): #"hello world\n")
+  check filesystem.read_string(x) ~is String.append(& for List (i: 0..4096): "hello world\n")
+  check filesystem.read_bytes_lines(x) ~is_now for List (i: 0..4096): #"hello world"
+  check filesystem.read_lines(x) ~is for List (i: 0..4096): "hello world"
+
+  check filesystem.write_bytes(x, #"hello world") ~throws "filesystem.write_bytes:"
+  check filesystem.write_bytes(x, #"hello world", ~exists: #'truncate) ~is #void
+  check filesystem.write_string(x, "hello world", ~exists: #'truncate) ~is #void
+  check filesystem.read_string(x) ~is "hello world"
+
+  block:
+    let tmp2 = filesystem.make_temporary(~as: #'directory)
+
+    let ex = tmp2.add("ex")
+    check filesystem.copy(x, ex) ~is #void
+    check filesystem.file_exists(ex) ~is #true
+    check filesystem.size(ex) ~is filesystem.size(x)
+    check filesystem.copy(y, ex) ~throws "filesystem.copy:"
+    check filesystem.copy(y, ex, ~exists_ok: #true) ~is #void
+    check filesystem.size(ex) ~is filesystem.size(y)
+    check filesystem.permissions(ex) ~is filesystem.permissions(y)
+    filesystem.delete(ex)
+    check filesystem.copy(x, ex, ~permissions: 0o444) ~is #void
+    check filesystem.permissions(ex) ~is { #'read }
+    filesystem.delete(ex)
+    check filesystem.copy(x, ex, ~permissions: 0o777, ~replace_permissions: #true) ~is #void
+    check filesystem.permissions(ex, ~bits: #true) ~is 0o777
+    check filesystem.copy(x, ex, ~exists_ok: #true) ~is #void
+    check filesystem.permissions(ex) ~is filesystem.permissions(x)
+    check filesystem.copy(x, ex, ~exists_ok: #true, ~keep_modify_seconds: #true) ~is #void
+    check filesystem.modify_seconds(ex) ~is filesystem.modify_seconds(x)
+
+    let sub = tmp2.add("sub")
+    check filesystem.copy(tmp, sub, ~recur: #true, ~follow_links: #false) ~is #void
+    check filesystem.files(sub, ~recur: #true) ~is filesystem.files(tmp, ~recur: #true)
+    filesystem.delete(sub, ~recur: #true)
+
+    unless windows
+    | check filesystem.copy(tmp, sub, ~recur: #true) ~throws values("filesystem.copy:", "link2")
+      filesystem.delete(sub, ~recur: #true)
+      filesystem.delete(link2)
+    check filesystem.copy(tmp, sub, ~recur: #true) ~is #void
+    check filesystem.files(sub, ~recur: #true) ~is filesystem.files(tmp, ~recur: #true, ~follow_links: #true)
+    unless windows
+    | make_link2()
+    filesystem.delete(sub, ~recur: #true)
+
+    check filesystem.copy(tmp, sub, ~recur: #true, ~follow_links: #false, ~keep_modify_seconds: #true) ~is #void
+    for (f: filesystem.files(sub, ~recur: #true)):
+      check filesystem.type(sub.add(f)) ~is filesystem.type(tmp.add(f))
+      when filesystem.file_exists(sub.add(f)) || filesystem.directory_exists(sub.add(f))
+      | check filesystem.permissions(sub.add(f)) ~is filesystem.permissions(tmp.add(f))
+      when filesystem.file_exists(sub.add(f))
+      | check filesystem.modify_seconds(sub.add(f)) ~is filesystem.modify_seconds(tmp.add(f))
+    filesystem.delete(sub, ~recur: #true)
+
+    filesystem.delete(tmp2, ~recur: #true)
+
+  block:
+    let tmp3 = filesystem.make_temporary(~in: tmp, ~as: x)
+    check filesystem.file_exists(tmp3) ~is #true
+    check filesystem.size(tmp3) ~is filesystem.size(x)
+    let mutable tries = 0
+    let tmp4 = filesystem.make_temporary(~in: tmp,
+                                         ~make_name:
+                                           fun (s :: String):
+                                             tries := tries + 1
+                                             if tries == 1
+                                             | tmp3.name()
+                                             | Path("mytmp_" ++ s))
+    check tmp4 != tmp3 ~is #true
+    check tries ~is 2
+    let tmp5 = filesystem.make_temporary(~in: tmp, ~permissions: 0o444)
+    check filesystem.permissions(tmp5) ~is { #'read }
+    let tmp6 = filesystem.make_temporary(~in: tmp, ~permissions: 0o777, ~replace_permissions: #true)
+    check filesystem.permissions(tmp6) ~is { #'read, #'write, #'execute }
+
+  filesystem.delete(tmp, ~recur: #true)
+  check filesystem.directory_exists(tmp) ~is #false
+  check filesystem.file_exists(x) ~is #false
+  check filesystem.directory_exists(d) ~is #false
+  check filesystem.link_exists(tmp) ~is #false
+  check filesystem.link_exists(d) ~is #false
+  check filesystem.link_exists(x) ~is #false
+  check filesystem.link_exists(link) ~is #false
+  check filesystem.link_exists(link2) ~is #false
+
+  check filesystem.type(tmp) ~is #false
+  check filesystem.type(x) ~is #false
+  check filesystem.type(d) ~is #false
+  check filesystem.type(tmp, ~must_exist: #true) ~throws "filesystem.type:"
+  check filesystem.type(x, ~must_exist: #true) ~throws "filesystem.type:"
+  check filesystem.type(d, ~must_exist: #true) ~throws "filesystem.type:"

--- a/rhombus/rhombus/tests/port.rhm
+++ b/rhombus/rhombus/tests/port.rhm
@@ -23,10 +23,24 @@ block:
     Port.Output.flush([out]) ~method
     Port.Output.current([out])
     Port.Output.current_error([out])
+    Port.Output.write_bytes(out, b, [start], [end])
+    Port.Output.write_string(out, s, [start], [end])
     Port.Output.print(v, ...) ~method
     Port.Output.println(v, ...) ~method
     Port.Output.show(v, ...) ~method
     Port.Output.showln(v, ...) ~method
+
+block:
+  check Port.eof ~is_a Port.EOF
+  check:
+    match Port.eof
+    | Port.eof: "ok"
+    ~is "ok"
+  check:
+    match #'eof
+    | Port.eof: "ok"
+    | ~else: "no"
+    ~is "no"
 
 block:
   let p = Port.Input.open_string("abλcdefμ")
@@ -100,6 +114,28 @@ block:
   check p.get_string() ~is "xy\n\"z\""
   p.showln("w")
   check p.get_string() ~is "xy\n\"z\"\"w\"\n"
+
+block:
+  let p = Port.Output.open_bytes()
+  p.write_bytes(#"apple")
+  check p.get_bytes() ~is_now #"apple"
+  p.write_bytes(#"apple", 3)
+  check p.get_bytes() ~is_now #"applele"
+  p.write_bytes(#"apple", 1, 4)
+  check p.get_bytes() ~is_now #"appleleppl"
+
+block:
+  let p = Port.Output.open_bytes()
+  p.write_string("apple")
+  check p.get_bytes() ~is_now #"apple"
+  p.write_string("apple", 3)
+  check p.get_bytes() ~is_now #"applele"
+  p.write_string("apple", 1, 4)
+  check p.get_bytes() ~is_now #"appleleppl"
+  p.write_string("λ")
+  check p.get_bytes() ~is_now #"appleleppl\316\273"
+  p.write_string("λλλλ", 1, 3)
+  check p.get_bytes() ~is_now #"appleleppl\316\273\316\273\316\273"
 
 // make sure `current` functions have static info
 block:

--- a/rhombus/rhombus/tests/shorthand.rhm
+++ b/rhombus/rhombus/tests/shorthand.rhm
@@ -46,4 +46,4 @@ block:
     '#%literal $(expr.to_source_string())'
   check source (_ ++ _) ~is "(_ ++ _)"
   check source [1, 2, 3].map(_) ~is "[1, 2, 3].map(_)"
-  check source List.map([1, 2, 3], _) ~is "map([1, 2, 3], _)"
+  check source List.map([1, 2, 3], _) ~is "List.map([1, 2, 3], _)"

--- a/rhombus/rhombus/tests/system.rhm
+++ b/rhombus/rhombus/tests/system.rhm
@@ -13,3 +13,5 @@ check system.host() ~is_a String
 check system.target_machine() ~is_a system.TargetMachineSymbol
 check #false is_a system.TargetMachineSymbol ~is #false
 check #'cek is_a system.TargetMachineSymbol ~is #false
+
+check system.path(#'temp_dir) ~is_a Path


### PR DESCRIPTION
This is a work in progress, especially because it's not yet tested, but the `filesystem` API here is ready for feedback.

The goal is to cover the best and most useful parts of `racket/base` and `racket/file`. In some cases, `racket/file` provides a more general version of a simple function provided from `racket/base`; only the general version is included in this `filesystem`, but with options that make the simple behavior accessible (if not always the default). The implementation uses only `racket/base`.

Many small changes compared to `racket/base` and `racket/file` are intended to make things clearer, more consistent, and read more nicely. But I'm unsure about some of the keyword choices, especially `~as`.

```
fun filesystem.type(path :: PathString,
                    ~must_exist: must_exist = #false)
  :: maybe(matching(#'file || #'directory || #'link || #'directory_link))

fun filesystem.file_exists(path :: PathString) :: Boolean
fun filesystem.directory_exists(path :: PathString) :: Boolean
fun filesystem.link_exists(path :: PathString) :: Boolean

// extends and replaces `list_directory`
fun filesystem.files(
  path :: PathString = Path.current_directory(),
  ~add_path: add_path = #false,
  ~recur: recur = #false,
  ~follow_links: follow_links = #false,
  ~skip: skip :: Path -> Any = fun (x): #false
) :: List.of(Path)

fun filesystem.roots() :: List.of(Path.Absolute)

fun filesystem.rename(path :: PathString,
                      to_path :: PathString,
                      ~exists_ok: exists_ok = #false)
  :: Void

fun filesystem.delete(
  path :: PathString,
  ~as: mode :: matching(#'any || #'file || #'directory) = #'any,
  ~recur: recur = #false,
  ~must_exist: must_exist = #false
) :: Void

fun filesystem.make_directory(
  path :: PathString,
  ~parents: parents = #false,
  ~permissions: permissions :: Int.in(0, 65535) = 0o777
) :: Void

fun filesystem.make_link(to_path :: PathString,
                         path :: PathString)
  :: Void

fun filesystem.make_temporary(
  ~in: dir :: PathString = system.path(#'temp_dir),
  ~as: as:: (PathString || matching(#'file) || matching(#'directory))
       = #'file,
  ~make_name: make_name :: String -> Path.Relative
                = fun (s): Path("tmp" +& s),
  ~permissions: permissions :: maybe(Int.in(0, 65535))
                  = #false,
  ~replace_permissions: replace_permissions = #false

) :: Path

fun filesystem.copy(
  src_path :: PathString,
  dest_path :: PathString,
  ~recur: recur = #false,
  ~exists_ok: exists_ok = #false,
  ~follow_links: follow_links = #true,
  ~permissions: permissions :: maybe(Int.in(0, 65535)) = #false,
  ~replace_permissions: replace_permissions = #true,
  ~keep_modify_seconds: keep_modify_seconds = #false
) :: Void

fun filesystem.size(path :: PathString) :: NonnegInt

fun filesystem.modify_seconds(
  path :: PathString,
  ~change_to: change_to :: maybe(Int) = #false
) :: Int || Void

fun filesystem.modify_seconds(
  path :: PathString,
  ~change_to: change_to :: maybe(Int) = #false,
  ~fail: fail_k :: Function.of_arity(0)
) :: ~any

fun filesystem.permissions(
  path :: PathString,
  ~bits: bits = #false,
  ~change_to: change_to :: maybe(Int.in(0, 65535)) = #false
) :: Int || List.of(matching(#'read || #'write || #'exceute)) || Void

fun filesystem.identity(
  path :: PathString,
  ~follow_links: follow_links = #true
) :: PosInt

fun filesystem.stat(path :: PathString,
                    ~follow_links: follow_links = #true)
  :: Map

fun filesystem.bytes(
  path :: PathString,
  ~mode: mode :: Port.Mode = #'binary
) :: Bytes

fun filesystem.string(
  path :: PathString,
  ~mode: mode :: Port.Mode = #'binary
) :: String

fun filesystem.bytes_lines(
  path :: PathString,
  ~mode: mode :: Port.ReadLineMode = #'any
) :: List.of(String)

fun filesystem.lines(
  path :: PathString,
  ~mode: mode :: Port.ReadLineMode = #'any
) :: List.of(String)

fun filesystem.write_string(
  path :: PathString,
  str :: String,
  ~mode: mode :: Port.Mode = #'binary
) :: Void

fun filesystem.write_bytes(
  path :: PathString,
  bstr :: Bytes,
  ~mode: mode :: Port.Mode = #'binary
) :: Void

fun filesystem.simplify_path(path :: PathString) :: Path
fun filesystem.normalize_path(path :: PathString) :: Path
fun filesystem.resolve_path(path :: PathString) :: Path
fun filesystem.expand_user_path(path :: PathString) :: Path

Parameter.def filesystem.current_force_delete_permissions
  :: Any.to_boolean
```
