### PR TITLE
support `~nonempty` after `...` to match 1 or more in a repetition

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/array.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/array.rkt
@@ -336,12 +336,16 @@
                                       #:rest-to-repetition #'in-vector
                                       #:rest-repetition? (and rest-arg #t)))
      (syntax-parse stx
-       [(form-id (tag::parens arg ... rest-arg (group _::...-bind)) . tail)
+       [(form-id (tag::parens arg ... rest-arg (group _::...-bind
+                                                      (~or (~seq) (~seq (~and nonempty #:nonempty)))))
+                 . tail)
         (define args (syntax->list #'(arg ...)))
         (define len (length args))
         (define pred #`(lambda (v)
                          (and (vector? v)
-                              (>= (vector-length v) #,len))))
+                              (>= (vector-length v) #,(+ len (if (attribute nonempty)
+                                                                 1
+                                                                 0))))))
         (build args len pred #'rest-arg #'form-id #'tail)]
        [(form-id (tag::parens arg ...) . tail)
         (define args (syntax->list #'(arg ...)))

--- a/rhombus/rhombus/scribblings/guide/list.scrbl
+++ b/rhombus/rhombus/scribblings/guide/list.scrbl
@@ -102,8 +102,7 @@ that supplies elements for the new list.
     got_milk(["apple", "coffee", "banana"])
 )
 
-While @rhombus(..., ~bind) can only be used at the end of a list in a
-binding, @rhombus(...) can be used anywhere in an expression, and it can
+A @rhombus(...) can be used anywhere in a binding or expression, and it can
 be used multiple times.
 
 @examples(

--- a/rhombus/rhombus/scribblings/reference/array.scrbl
+++ b/rhombus/rhombus/scribblings/reference/array.scrbl
@@ -109,13 +109,15 @@ contents, even if one is mutable and the other is immutable.
 
   grammar ellipsis:
     #,(dots)
+    #,(dots) ~nonempty
 ){
 
  Matches an array with as many elements as @rhombus(bind)s, where
  each element matches its corresponding @rhombus(bind), or at least
  as may elements as @rhombus(bind)s when a @rhombus(repet_bind) is
  provided.  When @rhombus(repet_bind) is provided, each additional element
- must match @rhombus(repet_bind).
+ must match @rhombus(repet_bind), and at least one match must be present
+ if @rhombus(ellipsis) includes @rhombus(~nonempty).
 
  Elements are extracted from a matching array eagerly, so mutations of
  the array afterward do no change the matched values. When
@@ -127,6 +129,10 @@ contents, even if one is mutable and the other is immutable.
   y
   def Array(1, z, ...) = Array(1, 2, 3)
   [z, ...]
+  def Array(1, z, ... ~nonempty) = Array(1, 2, 3)
+  [z, ...]
+  ~error:
+    def Array(1, z, ... ~nonempty) = Array(1)
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/list.scrbl
@@ -55,7 +55,6 @@ it supplies its elements in order.
 
   grammar ellipsis:
     #,(dots_expr)
-
 ){
 
  Constructs a list of the given @rhombus(v)s values or results of the
@@ -95,12 +94,25 @@ it supplies its elements in order.
     #,(@rhombus(&, ~bind)) $list_repet_bind #,(@litchar{,}) $ellipsis
   grammar ellipsis:
     #,(dots)
+    #,(dots_expr) ~nonempty
+    #,(dots_expr) ~once
 ){
 
  Matches a list with as many elements as @rhombus(bind)s, or if a
  @rhombus(splice) is included, at least as many elements as
- @rhombus(bind)s. Each @rhombus(splice) matches a sublist, and the
- matching sublist is deterministic if only one @rhombus(splice) is
+ @rhombus(bind)s. Each @rhombus(bind) matches an element of the list.
+ Each @rhombus(splice) matches a sublist:
+ @rhombus(repet_bind #,(@litchar{,}) ellipsis) matches a sublist of
+ elements that individually match @rhombus(repet_bind),
+ @rhombus(#,(@rhombus(&, ~bind)) list_bind) matches a sublist that itself
+ matches @rhombus(list_bind), and
+ @rhombus(#,(@rhombus(&, ~bind)) list_repet_bind #,(@litchar{,}) ellipsis)
+ matches a sublist that is a concatenation of sublists that each match
+ @rhombus(list_repet_bind). If @rhombus(ellipsis) includes @rhombus(~nonempty),
+ then the matching sublist must have at least one element, otherwise the matching
+ sublist can be empty. If @rhombus(ellipsis) includes @rhombus(~once),
+ then a matching sublist has 0 or 1 elements.
+ A matching sublist is deterministic if only one @rhombus(splice) is
  present with @rhombus(&) or @dots (but not both).
 
 @examples(
@@ -114,6 +126,13 @@ it supplies its elements in order.
   [x, ...]
   def List(1, x, ..., 3) = [1, 2, 3]
   [x, ...]
+  def List(1, x, ... ~nonempty, 3) = [1, 2, 3]
+  [x, ...]
+  ~error:
+    def List(1, x, ... ~nonempty, 3) = [1, 3]
+  def List(1, x, ... ~once, 3) = [1, 3]
+  ~error:
+    def List(1, x, ... ~once, 3) = [1, 2, 2, 3]
 )
 
  If multiple @rhombus(splice)s are present, matching is greedy: the
@@ -123,6 +142,8 @@ it supplies its elements in order.
 
 @examples(
   def List(x, ..., z, ...) = [1, 2, "c", 5]
+  [[x, ...], [z, ...]]
+  def List(x, ..., z, ... ~nonempty) = [1, 2, "c", 5]
   [[x, ...], [z, ...]]
   def List(x, ..., #'stop, z, ...) = [1, 2, "c", #'stop, 5]
   [[x, ...], [z, ...]]

--- a/rhombus/rhombus/scribblings/reference/pair.scrbl
+++ b/rhombus/rhombus/scribblings/reference/pair.scrbl
@@ -172,6 +172,8 @@ list is a pair, a pair is a pair list only if its ``rest'' is a list.
     #,(@rhombus(&, ~bind)) $pair_list_repet_bind #,(@litchar{,}) $ellipsis
   grammar ellipsis:
     #,(dots)
+    #,(dots) ~nonempty
+    #,(dots) ~once
 ){
 
  Matches a @tech{pair list} with @rhombus(bind_or_splice)s in the same

--- a/rhombus/rhombus/scribblings/reference/stxobj.scrbl
+++ b/rhombus/rhombus/scribblings/reference/stxobj.scrbl
@@ -148,9 +148,11 @@ suffix corresponds to text after the closer.
  portion of a candidate syntax object.
  A @dots in @rhombus(term, ~var) following a subpattern matches any number
  of instances of the preceding subpattern, and escapes in the pattern
- are bound as @tech{repetitions}. Unlike binding forms such as @rhombus(List),
- @dots can appear before the end of a sequence, and
- multiple @dots can be used in the same group; when matching
+ are bound as @tech{repetitions}. A @rhombus(#,(dots) ~nonempty) following a subpattern
+ matches one or more instances, instead of zero or more instances. A
+ @rhombus(#,(dots) ~once) following a subpattern
+ matches zero instances or one instance. Multiple
+ @dots can appear within a sequence; when matching
  is ambiguous, matching prefers earlier @dots repetitions to
  later ones.
 
@@ -158,7 +160,9 @@ suffix corresponds to text after the closer.
  each of those literally. To match @rhombus($, ~datum) or
  @rhombus(..., ~datum) literally within a larger sequence of @rhombus(term)s,
  use @rhombus($, ~bind) to escape to a nested pattern, such as
- @rhombus(#,(@rhombus($, ~bind))('#,(@rhombus($))')).
+ @rhombus(#,(@rhombus($, ~bind))('#,(@rhombus($))')). Simialrly,
+ to match a literal @rhombus(~nonempty) or @rhombus(~once) after a @dots repetition, use
+ @rhombus(#,(@rhombus($, ~bind))('~nonempty')) or @rhombus(#,(@rhombus($, ~bind))('~once')).
 
  To match identifier or operators based on binding instead of
  symbolically, use @rhombus($, ~bind) to escape, and then use
@@ -175,6 +179,12 @@ suffix corresponds to text after the closer.
   | '$x ... * 3': [x, ...]
   match '1 + 2 * 3'
   | '$x ... * $y ...': values([x, ...], [y, ...])
+  match '1 + 2 * 3'
+  | '$x ... ~nonempty $y ... ~nonempty': values([x, ...], [y, ...])
+  match '1 ! = 3'
+  | '$x $(n && '!') ... ~once = $y': [x, [n, ...], y]
+  match '1 = 3'
+  | '$x $(n && '!') ... ~once = $y': [x, [n, ...], y]
 )
 
 }

--- a/rhombus/rhombus/tests/array.rhm
+++ b/rhombus/rhombus/tests/array.rhm
@@ -103,6 +103,10 @@ block:
     Array(v, ...).length()
     ~is 3
   check:
+    def [v, ... ~nonempty] = dynamic([1, 2, 3])
+    Array(v, ...).length()
+    ~is 3
+  check:
     class Posn(x, y)
     def arr :: Array.later_of(Posn) = Array(Posn(1, 2))
     arr[0].x
@@ -182,6 +186,15 @@ check:
 check:
   def Array(0, _, ...) = Array(0, 1, 2)
   ~completes
+
+check:
+  def Array(0, _, ...) = Array(0)
+  ~completes
+
+check:
+  def Array(0, _, ... ~nonempty) = Array(0)
+  "ok"
+  ~raises error.annot_msg()
 
 check:
   def Array(0, x, ...) = Array(0, 1, 2)

--- a/rhombus/rhombus/tests/list.rhm
+++ b/rhombus/rhombus/tests/list.rhm
@@ -519,6 +519,16 @@ check:
   ~is [[1, 2], []]
 
 check:
+  def [x, ..., y, ... ~nonempty] = [1, 2]
+  [[x, ...], [y, ...]]
+  ~is [[1], [2]]
+
+check:
+  def [x :: Int, ..., y :: Int, ... ~nonempty, & tail] = [1, 2, "a", "b"]
+  [[x, ...], [y, ...], tail]
+  ~is [[1], [2], ["a", "b"]]
+
+check:
   def [x, ..., 2, y, ...] = [1, 2, 3, 4]
   [[x, ...], [y, ...]]
   ~is [[1], [3, 4]]
@@ -575,6 +585,65 @@ check:
   | [& [x :: Int, ..., "end"], ..., z]:
       [[[x, ...], ...], z]
   ~is [[[1], [2, 3, 4]], 5]
+
+check:
+  match [4, 5]
+  | [& [x, ...], ... ~nonempty, z]:
+      [[[x, ...], ...], z]
+  ~is [[[4]], 5]
+
+check:
+  match [5]
+  | [& [x, ...], ... ~nonempty, z]:
+      [[[x, ...], ...], z]
+  | ~else:
+      #false
+  ~is #false
+
+check:
+  match [1, 2, 3]
+  | [b, & a, ...]: [a, ...]
+  ~is [[2, 3]]
+                                 
+check:
+  match [1, 2, 3]
+  | [b, & a, ... ~once]: [a, ...]
+  ~is [[2, 3]]
+
+check:
+  def [1, x, ... ~nonempty, 3] = [5]
+  "oops"
+  ~throws "matching(List(1, _, ... ~nonempty, 3))"
+
+check:
+  def [1, x, ... ~once, 3] = [5]
+  "oops"
+  ~throws "matching(List(1, _, ... ~once, 3))"
+
+check:
+  def [1, x, ... ~nonempty, 3, & _] = [5]
+  "oops"
+  ~throws "matching(List(1, _, ... ~nonempty, 3, & _))"
+
+check:
+  def [1, x, ... ~once, 3, & _] = [5]
+  "oops"
+  ~throws "matching(List(1, _, ... ~once, 3, & _))"
+
+check:
+  def [1, x, ..., 3] = [5]
+  "oops"
+  ~throws "matching(List(1, _, ..., 3))"
+
+check:
+  def [1, & x, 3] = [5]
+  "oops"
+  ~throws "matching(List(1, & _, 3))"
+
+check:
+  def [1, & x, ..., 3] = [5]
+  "oops"
+  ~throws "matching(List(1, & _, ..., 3))"
 
 check:
   [List.repet([1, 2, 3]), ...] ~is [1, 2, 3]
@@ -656,11 +725,21 @@ block:
   check:
     list_bounds(matching([x, y, z])) ~is [3, 3]
     list_bounds(matching([x, ..., z])) ~is [1, #false]
+    list_bounds(matching([x, ... ~nonempty, z])) ~is [2, #false]
+    list_bounds(matching([x, ... ~once, z])) ~is [1, 2]
     list_bounds(matching([& y, z])) ~is [1, #false]
     list_bounds(matching([x, & y, z])) ~is [2, #false]
     list_bounds(matching([x, y, ..., z])) ~is [2, #false]
     list_bounds(matching([x, y, ..., z, ...])) ~is [1, #false]
+    list_bounds(matching([x, y, ... ~nonempty, z, ...])) ~is [2, #false]
+    list_bounds(matching([x, y, ..., z, ... ~nonempty])) ~is [2, #false]
+    list_bounds(matching([x, y, ... ~nonempty, z, ... ~nonempty])) ~is [3, #false]
+    list_bounds(matching([x, y, ... ~once, z, ... ~once])) ~is [1, 3]
     list_bounds(matching([x, & [y1, y2, y3], z])) ~is [5, 5]
+    list_bounds(matching([& y, ..., z])) ~is [1, #false]
+    list_bounds(matching([& [x, y, z], ..., z])) ~is [1, #false]
+    list_bounds(matching([& [x, y, z], ... ~nonempty, z])) ~is [4, #false]
+    list_bounds(matching([& [x, y, z], ... ~once, z])) ~is [1, 4]
     list_bounds(Triple) ~is [3, 3]
     list_bounds(matching([x, & _ :: Triple, y])) ~is [5, 5]
     list_bounds(matching([x, & _ :: List && Triple, y])) ~is [5, 5]

--- a/rhombus/rhombus/tests/pairlist.rhm
+++ b/rhombus/rhombus/tests/pairlist.rhm
@@ -448,6 +448,17 @@ check:
   ~is PairList[PairList[1, 2], PairList[]]
 
 check:
+  def PairList[x, ..., y, ... ~nonempty] = PairList[1, 2]
+  PairList[PairList[x, ...], PairList[y, ...]]
+  ~is PairList[PairList[1], PairList[2]]
+
+check:
+  def PairList[x :: Int, ..., y :: Int, ... ~nonempty, & tail] = PairList[1, 2, "a", "b"]
+  PairList[PairList[x, ...], PairList[y, ...], tail]
+  ~is PairList[PairList[1], PairList[2], PairList["a", "b"]]
+
+
+check:
   def PairList[x, ..., 2, y, ...] = PairList[1, 2, 3, 4]
   PairList[PairList[x, ...], PairList[y, ...]]
   ~is PairList[PairList[1], PairList[3, 4]]

--- a/rhombus/rhombus/tests/quasiquote.rhm
+++ b/rhombus/rhombus/tests/quasiquote.rhm
@@ -60,6 +60,87 @@ check:
   ~completes
 
 check:
+  def '$x ... ~nonempty': '1 2 3'
+  [x, ...]
+  ~matches ['1', '2', '3']
+
+check:
+  def '1 $x ... ~nonempty': '1'
+  "oops"
+  ~raises error.annot_msg()
+
+check:
+  def '[1, $x, ... ~nonempty]': '[1, 2]'
+  [x, ...]
+  ~matches ['2']
+
+check:
+  def '[1, $x, ... ~nonempty]': '[1]'
+  "oops"
+  ~raises error.annot_msg()
+
+check:
+  def 'b: 1; $x; ... ~nonempty': 'b: 1; 2 3; 4 5 6'
+  [x, ...]
+  ~matches ['2 3', '4 5 6']
+
+check:
+  def 'b: 1; $x; ... ~nonempty': 'b: 1'
+  "oops"
+  ~raises error.annot_msg()
+
+
+check:
+  def '$x ... ~once': '1'
+  [x, ...]
+  ~matches ['1']
+
+check:
+  def '$x ... ~once': ''
+  [x, ...]
+  ~matches []
+
+check:
+  def '1 $x ... ~once 3': '1 3'
+  [x, ...]
+  ~is []
+
+check:
+  def '1 $x ... ~once 3': '1 2 3'
+  [x, ...]
+  ~matches ['2']
+
+check:
+  def '[1, $x, ... ~once]': '[1, 2]'
+  [x, ...]
+  ~matches ['2']
+
+check:
+  def '[1, $x, ... ~once]': '[1]'
+  [x, ...]
+  ~matches []
+
+check:
+  def '[1, $x, ... ~once]': '[1, 2, 3]'
+  "oops"
+  ~raises error.annot_msg()
+
+check:
+  def 'b: 1; $x; ... ~once': 'b: 1; 2 3'
+  [x, ...]
+  ~matches ['2 3']
+
+check:
+  def 'b: 1; $x; ... ~once': 'b: 1'
+  [x, ...]
+  ~is []
+
+check:
+  def 'b: 1; $x; ... ~once': 'b: 1; 2 3; 4 5 6'
+  "oops"
+  ~raises error.annot_msg()
+
+check:
   def '1 $x 3' = '1 2 3'
   x
   ~matches '2'


### PR DESCRIPTION
Example:

```
> :
    match [1, 3]
    | [1, x, ..., 3]: [x, ...]
[]
> :
    match [1, 3]
    | [1, x, ... ~nonempty, 3]: [x, ...]
match: no matching case
> :
    match [1, 2, 3]
    | [1, x, ... ~nonempty, 3]: [x, ...]
[2]
```