### PR TITLE
fill in `String` methods

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/rx-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/rx-object.rkt
@@ -1,0 +1,12 @@
+#lang racket/base
+
+(provide rx?
+         rx-regexp
+         set-rx!)
+
+(define rx? not)
+(define rx-regexp values)
+
+(define (set-rx! pred sel)
+  (set! rx? pred)
+  (set! rx-regexp sel))

--- a/rhombus-lib/rhombus/private/amalgam/rx_object.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx_object.rhm
@@ -6,6 +6,7 @@ import:
   "recur.rhm" open
   "error.rhm" open
   "rx_match.rhm" open
+  "rx-object.rkt" as rkt
 
 export:
   RX
@@ -223,3 +224,6 @@ fun splice_regexp(who, PairList(a, ...) && as, var_seq, has_backref, src) :~ RX:
       vars,
       has_backref,
       src)
+
+// register predicate and selector for use by `String`
+rkt.#{set-rx!}(fun (x): x is_a RX, _RX._rkt_partial_rx)

--- a/rhombus-lib/rhombus/private/amalgam/string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/string.rkt
@@ -2,9 +2,11 @@
 (require (for-syntax racket/base
                      syntax/parse/pre
                      "make-get-veneer-like-static-infos.rkt")
-         (only-in racket/string string-contains?)
+         racket/string
          racket/symbol
          racket/keyword
+         racket/unsafe/undefined
+         "../version-case.rkt"
          "provide.rkt"
          "define-operator.rkt"
          (only-in "arithmetic.rkt"
@@ -23,12 +25,15 @@
          (submod "literal.rkt" for-info)
          (submod "annotation.rkt" for-class)
          (submod "char.rkt" for-static-info)
+         (submod "list.rkt" for-compound-repetition)
          "mutability.rkt"
          "pack.rkt"
          "define-arity.rkt"
          "class-primitive.rkt"
          "number.rkt"
-         "static-info.rkt")
+         "treelist.rkt"
+         "static-info.rkt"
+         "rx-object.rkt")
 
 (provide (for-spaces (#f
                       rhombus/repet)
@@ -43,7 +48,11 @@
          (for-space rhombus/annot
                     ReadableString
                     StringCI
-                    ReadableStringCI))
+                    ReadableStringCI
+                    StringLocale
+                    ReadableStringLocale
+                    StringLocaleCI
+                    ReadableStringLocaleCI))
 
 (module+ for-builtin
   (provide string-method-table))
@@ -80,9 +89,15 @@
   #:dot-methods
   ([length String.length]
    [get String.get]
+   [find String.find]
    [contains String.contains]
+   [starts_with String.starts_with]
+   [ends_with String.ends_with]
    [append String.append]
    [substring String.substring]
+   [trim String.trim]
+   [split String.split]
+   [replace String.replace]
    [utf8_bytes String.utf8_bytes]
    [latin1_bytes String.latin1_bytes]
    [locale_bytes String.locale_bytes]
@@ -93,6 +108,8 @@
    [downcase String.downcase]
    [foldcase String.foldcase]
    [titlecase String.titlecase]
+   [locale_upcase String.locale_upcase]
+   [locale_downcase String.locale_downcase]
    [normalize_nfd String.normalize_nfd]
    [normalize_nfkd String.normalize_nfkd]
    [normalize_nfc String.normalize_nfc]
@@ -116,8 +133,14 @@
    [append String.append]
    [length String.length]
    [get String.get]
+   [find String.find]
    [contains String.contains]
+   [starts_with String.starts_with]
+   [ends_with String.ends_with]
    [substring String.substring]
+   [trim String.trim]
+   [split String.split]
+   [replace String.replace]
    [make String.make]
    [utf8_bytes String.utf8_bytes]
    [latin1_bytes String.latin1_bytes]
@@ -129,6 +152,8 @@
    [downcase String.downcase]
    [foldcase String.foldcase]
    [titlecase String.titlecase]
+   [locale_upcase String.locale_upcase]
+   [locale_downcase String.locale_downcase]
    [normalize_nfd String.normalize_nfd]
    [normalize_nfkd String.normalize_nfkd]
    [normalize_nfc String.normalize_nfc]
@@ -166,6 +191,53 @@
   (identifier-annotation immutable-string? #,(get-string-ci-static-infos) #:static-only))
 (define-annotation-syntax ReadableStringCI
   (identifier-annotation string? #,(get-readable-string-ci-static-infos) #:static-only))
+
+(define-for-syntax (convert-string-locale-compare-static-info static-info)
+  (syntax-parse static-info
+    #:datum-literals (#%compare)
+    [(#%compare . _) #'(#%compare ((< string-locale<?)
+                                   (<= string-locale<=?)
+                                   (= string-locale=?)
+                                   (!= string-locale!=?)
+                                   (>= string-locale>=?)
+                                   (> string-locale>?)))]
+    [_ static-info]))
+
+(define-for-syntax (get-string-locale-static-infos)
+  (make-get-veneer-like-static-infos get-string-static-infos
+                                     convert-string-locale-compare-static-info))
+
+(define-for-syntax (get-readable-string-locale-static-infos)
+  (make-get-veneer-like-static-infos get-readable-string-static-infos
+                                     convert-string-locale-compare-static-info))
+
+(define-for-syntax (convert-string-locale-ci-compare-static-info static-info)
+  (syntax-parse static-info
+    #:datum-literals (#%compare)
+    [(#%compare . _) #'(#%compare ((< string-locale-ci<?)
+                                   (<= string-locale-ci<=?)
+                                   (= string-locale-ci=?)
+                                   (!= string-locale-ci!=?)
+                                   (>= string-locale-ci>=?)
+                                   (> string-locale-ci>?)))]
+    [_ static-info]))
+
+(define-for-syntax (get-string-locale-ci-static-infos)
+  (make-get-veneer-like-static-infos get-string-static-infos
+                                     convert-string-locale-compare-static-info))
+
+(define-for-syntax (get-readable-string-locale-ci-static-infos)
+  (make-get-veneer-like-static-infos get-readable-string-static-infos
+                                     convert-string-locale-ci-compare-static-info))
+
+(define-annotation-syntax StringLocale
+  (identifier-annotation immutable-string? #,(get-string-locale-static-infos) #:static-only))
+(define-annotation-syntax ReadableStringLocale
+  (identifier-annotation string? #,(get-readable-string-locale-static-infos) #:static-only))
+(define-annotation-syntax StringLocaleCI
+  (identifier-annotation immutable-string? #,(get-string-locale-ci-static-infos) #:static-only))
+(define-annotation-syntax ReadableStringLocaleCI
+  (identifier-annotation string? #,(get-readable-string-locale-ci-static-infos) #:static-only))
 
 (define-infix +& append-as-strings
   #:stronger-than (== ===)
@@ -234,10 +306,75 @@
   (check-readable-string who s)
   (string->number s))
 
+(define/method (String.find s1 s2)
+  (check-readable-string who s1)
+  (check-readable-string who s2)
+  (meta-if-version-at-least
+   "8.15.0.7"
+   (string-find s1 s2)
+   (and (string-contains? s1 s2)
+        ;; find position the slow way:
+        (for/or ([i (in-range 0 (string-length s1))])
+          (and (string-prefix? s1 s2) i)))))
+
 (define/method (String.contains s1 s2)
   (check-readable-string who s1)
   (check-readable-string who s2)
   (string-contains? s1 s2))
+
+(define/method (String.starts_with s1 s2)
+  (check-readable-string who s1)
+  (check-readable-string who s2)
+  (string-prefix? s1 s2))
+
+(define/method (String.ends_with s1 s2)
+  (check-readable-string who s1)
+  (check-readable-string who s2)
+  (string-suffix? s1 s2))
+
+(define/method (String.trim s1 [sep unsafe-undefined]
+                            #:start [start? #t]
+                            #:end [end? #t]
+                            #:repeat [repeat? #f])
+  #:static-infos ((#%call-result #,(get-string-static-infos)))
+  (check-readable-string who s1)
+  (string->immutable-string
+   (cond
+     [(eq? sep unsafe-undefined)
+      (string-trim s1 #:left? start? #:right? end? #:repeat? repeat?)]
+     [else
+      (unless (or (string? sep) (rx? sep))
+        (raise-annotation-failure who sep "ReadableString || RX"))
+      (string-trim s1 (if (string? sep) sep (rx-regexp sep))
+                   #:left? start? #:right? end? #:repeat? repeat?)])))
+
+(define/method (String.split s1 [sep unsafe-undefined]
+                             #:trim [trim? #t]
+                             #:repeat [repeat? #f])
+  #:static-infos ((#%call-result ((#%index-result #,(get-string-static-infos))
+                                  #,@(get-list-static-infos))))
+  (check-readable-string who s1)
+  (define l
+    (cond
+      [(eq? sep unsafe-undefined)
+       (string-split s1 #:trim? trim? #:repeat? repeat?)]
+      [else
+       (unless (or (string? sep) (rx? sep))
+         (raise-annotation-failure who sep "ReadableString || RX"))
+       (string-split s1 (if (string? sep) sep (rx-regexp sep))
+                     #:trim? trim? #:repeat? repeat?)]))
+  (for/treelist ([s (in-list l)])
+    (string->immutable-string s)))
+
+(define/method (String.replace s1 from to
+                               #:all [all? #f])
+  #:static-infos ((#%call-result #,(get-string-static-infos)))
+  (check-readable-string who s1)
+  (unless (or (string? from) (rx? from))
+    (raise-annotation-failure who from "ReadableString || RX"))
+  (check-readable-string who to)
+  (string->immutable-string
+   (string-replace s1 from to #:all? all?)))
 
 (define/method (String.copy s)
   #:primitive (string-copy)
@@ -273,11 +410,11 @@
 
 (define-syntax (define-upcase stx)
   (syntax-parse stx
-    [(_ upcase)
-     #:do [(define (format-name fmt)
-             (datum->syntax #'upcase (string->symbol (format fmt (syntax-e #'upcase)))))]
-     #:with method-name (format-name "String.~a")
-     #:with fn-name (format-name "string-~a")
+    [(_ upcase (~optional rkt-upcase))
+     #:do [(define (format-name fmt upcase-stx)
+             (datum->syntax upcase-stx (string->symbol (format fmt (syntax-e upcase-stx)))))]
+     #:with method-name (format-name "String.~a" #'upcase)
+     #:with fn-name (format-name "string-~a" (or (attribute rkt-upcase) #'upcase))
      #'(define/method (method-name s)
          #:primitive (fn-name)
          #:static-infos ((#%call-result #,(get-string-static-infos)))
@@ -287,6 +424,8 @@
 (define-upcase downcase)
 (define-upcase titlecase)
 (define-upcase foldcase)
+(define-upcase locale_upcase locale-upcase)
+(define-upcase locale_downcase locale-downcase)
 
 (define-syntax (define-normalize stx)
   (syntax-parse stx
@@ -353,15 +492,48 @@
   #:static-infos ((#%call-result ((#%sequence-constructor #t))))
   (in-string str))
 
+(define (raise-string-comp-failure who a b)
+  (raise-annotation-failure '!= (if (string? a) b a) "ReadableString"))
+
 (define (string!=? a b)
   (if (and (string? a) (string? b))
       (not (string=? a b))
-      (raise-annotation-failure '!= (if (string? a) b a) "String")))
+      (raise-string-comp-failure '!= a b)))
 
 (define (string-ci!=? a b)
   (if (and (string? a) (string? b))
       (not (string-ci=? a b))
-      (raise-annotation-failure '!= (if (string? a) b a) "String")))
+      (raise-string-comp-failure '!= a b)))
+
+(define (string-locale!=? a b)
+  (if (and (string? a) (string? b))
+      (not (string-locale=? a b))
+      (raise-string-comp-failure '!= a b)))
+
+(define (string-locale<=? a b)
+  (if (and (string? a) (string? b))
+      (not (string-locale>? a b))
+      (raise-string-comp-failure '!= a b)))
+
+(define (string-locale>=? a b)
+  (if (and (string? a) (string? b))
+      (not (string-locale<? a b))
+      (raise-string-comp-failure '!= a b)))
+
+(define (string-locale-ci!=? a b)
+  (if (and (string? a) (string? b))
+      (not (string-locale-ci=? a b))
+      (raise-string-comp-failure '!= a b)))
+
+(define (string-locale-ci<=? a b)
+  (if (and (string? a) (string? b))
+      (not (string-locale-ci>? a b))
+      (raise-string-comp-failure '!= a b)))
+
+(define (string-locale-ci>=? a b)
+  (if (and (string? a) (string? b))
+      (not (string-locale-ci<? a b))
+      (raise-string-comp-failure '!= a b)))
 
 (begin-for-syntax
   (install-get-literal-static-infos! 'string get-string-static-infos))

--- a/rhombus/rhombus/scribblings/reference/string.scrbl
+++ b/rhombus/rhombus/scribblings/reference/string.scrbl
@@ -1,6 +1,9 @@
 #lang rhombus/scribble/manual
 @(import:
-    "common.rhm" open)
+    "common.rhm" open
+    scribble/rx open
+    meta_label:
+      rhombus/rx open)
 
 @title{Strings}
 
@@ -130,25 +133,6 @@ Strings are @tech{comparable}, which means that generic operations like
 
 
 @doc(
-  method String.contains(str :: ReadableString,
-                         substr :: ReadableString)
-    :: Boolean
-){
-
- Checks whether @rhombus(str) contains @rhombus(substr) as a
- substring.
-
-@examples(
-  String.contains("howdy", "how")
-  "howdy".contains("how")
-  String.contains("howdy", "nope")
-  "howdy".contains("nope")
-)
-
-}
-
-
-@doc(
   method String.get(str :: ReadableString, n :: NonnegInt) :: Char
 ){
 
@@ -176,6 +160,127 @@ Strings are @tech{comparable}, which means that generic operations like
 @examples(
   String.substring("hello", 2, 4)
   String.substring("hello", 2)
+)
+
+}
+
+
+@doc(
+  method String.find(str :: ReadableString,
+                     substr :: ReadableString)
+    :: maybe(NonnegInt)
+  method String.contains(str :: ReadableString,
+                         substr :: ReadableString)
+    :: Boolean
+  method String.starts_with(str :: ReadableString,
+                            substr :: ReadableString)
+    :: Boolean
+  method String.ends_with(str :: ReadableString,
+                          substr :: ReadableString)
+    :: Boolean
+){
+
+ Checks whether @rhombus(str) contains @rhombus(substr) as a substring.
+ The @rhombus(String.find) function reports the first position in
+ @rhombus(str) where @rhombus(substr) starts, if @rhombus(substr) is
+ found. The @rhombus(String.starts_with) and @rhombus(String.ends_with)
+ functions return @rhombus(#true) only when @rhombus(substr) is at the
+ start or end of @rhombus(str), respectively.
+
+@examples(
+  String.contains("howdy", "how")
+  "howdy".contains("how")
+  "howdy".contains("nope")
+  "say howdy".find("how")
+  "say howdy".find("nope")
+  "say howdy".starts_with("say")
+  "say howdy".ends_with("dy")
+)
+
+}
+
+
+@doc(
+  method String.replace(str :: ReadableString,
+                        from :: ReadableString || RX,
+                        to :: ReadableString,
+                        ~all: all = #false)
+    :: String
+){
+
+ Replaces either the first or every (depending on the @rhombus(all)
+ argument) non-overlapping instance of @rhombus(from) in @rhombus(str)
+ with @rhombus(to).
+
+@examples(
+  String.replace("Hello", "l", "x")
+  String.replace("Hello", "l", "x", ~all: #true)
+)
+
+}
+
+
+@doc(
+  method String.split(str :: ReadableString,
+                      sep :: ReadableString || RX = rx'space+',
+                      ~trim: trim = #true,
+                      ~repeat: repeat = #false)
+    :: List.of(String)
+){
+
+ Finds non-overlapping instances of @rhombus(sep) in @rhombus(str)
+ and returns a list of substrings that appear between the @rhombus(sep)
+ instances.
+
+ If @rhombus(trim) is true, then the result list never starts or ends
+ with an empty string. Otherwise, an instance of @rhombus(sep) at the
+ start or end of @rhombus(str) implies an empty-string result.
+
+ The @rhombus(repeat) argument is relevant only when @rhombus(sep) is a
+ string instead of a @tech{regexp}. When @rhombus(repeat) is true, then
+ @rhombus(sep) is converted to a pattern that matches one or more
+ consecutive instances of @rhombus(sep).
+
+@examples(
+  ~hidden:
+    import rhombus/rx open
+  ~repl:
+    "Hello  World".split()
+    "Hello  World".split(" ")
+    "Hello  World".split(" ", ~repeat: #true)
+    "Hello  World".split(rx'upper')
+    "Hello  World".split(rx'upper', ~trim: #false)
+)
+
+}
+
+
+@doc(
+  method String.trim(str :: ReadableString,
+                     sep :: ReadableString || RX = rx'space+',
+                     ~start: start = #true,
+                     ~end: end = #true,
+                     ~repeat: repeat = #false)
+    :: List.of(String)
+){
+
+ Removes @rhombus(sep) from the start (when @rhombus(start) is true) and
+ end (when @rhombus(end) is true) of @rhombus(str).
+
+ The @rhombus(repeat) argument is relevant only when @rhombus(sep) is a
+ string instead of a @tech{regexp}. When @rhombus(repeat) is true, then
+ @rhombus(sep) is converted to a pattern that matches one or more
+ consecutive instances of @rhombus(sep).
+
+@examples(
+  ~hidden:
+    import rhombus/rx open
+  ~repl:
+    "  Hello World  ".trim()
+    "  Hello World  ".trim(~start: #false)
+    "  Hello World  ".trim(~end: #false)
+    "_Hello World__".trim("_")
+    "_Hello World__".trim("_", ~repeat: #true)
 )
 
 }
@@ -273,9 +378,14 @@ Strings are @tech{comparable}, which means that generic operations like
   method String.downcase(str :: ReadableString) :: String
   method String.foldcase(str :: ReadableString) :: String
   method String.titlecase(str :: ReadableString) :: String
+  method String.locale_upcase(str :: ReadableString) :: String
+  method String.locale_downcase(str :: ReadableString) :: String
 ){
 
- Case-conversion functions.
+ Case-conversion functions. The @rhombus(locale_upcase) and
+ @rhombus(locale_downcase) functions are sensitive to the current locale,
+ but the other functions are locale-independent conversions defined by
+ the Unicode standard.
 
 }
 
@@ -387,5 +497,19 @@ Strings are @tech{comparable}, which means that generic operations like
     "apple" < "BANANA"
     ("apple" :: StringCI) < ("BANANA" :: StringCI)
 )
+
+}
+
+
+@doc(
+  annot.macro 'StringLocale'
+  annot.macro 'ReadableStringLocale'
+  annot.macro 'StringLocaleCI'
+  annot.macro 'ReadableStringLocaleCI'
+){
+
+ Like @rhombus(StringCI, ~annot) and @rhombus(ReadableStringCI, ~annot),
+ but for locale-sensitive case-sensitive and case-insensitive
+ comparisons.
 
 }

--- a/rhombus/rhombus/tests/string.rhm
+++ b/rhombus/rhombus/tests/string.rhm
@@ -9,13 +9,23 @@ block:
     String.make(n, char)
     String.length(str) ~method ReadableString
     String.get(str, i) ~method ReadableString
+    String.find(str, substr) ~method ReadableString
     String.contains(str, substr) ~method ReadableString
+    String.starts_with(str, substr) ~method ReadableString
+    String.ends_with(str, substr) ~method ReadableString
     String.to_string(str) ~method ReadableString
     ReadableString.to_string(str) ~method
     String.to_int(str) ~method ReadableString
     String.to_number(str) ~method ReadableString
     String.substring(str, start, [end]) ~method ReadableString
     String.append(str, ...) ~method ReadableString
+    String.replace(str, from, to) ~method ReadableString
+    String.trim(str, [sep]) ~method ReadableString
+    String.split(str, [sep]) ~method ReadableString
+    String.upcase(str) ~method ReadableString
+    String.downcase(str) ~method ReadableString
+    String.locale_upcase(str) ~method ReadableString
+    String.locale_downcase(str) ~method ReadableString
     String.normalize_nfd(str) ~method ReadableString
     String.normalize_nfkd(str) ~method ReadableString
     String.normalize_nfc(str) ~method ReadableString
@@ -60,6 +70,8 @@ block:
     "Hello".downcase() ~is "hello"
     "Hello".foldcase() ~is "hello"
     "hello".titlecase() ~is "Hello"
+    "hello".locale_upcase() ~is_a String
+    "Hello".locale_downcase() ~is_a String
     "hello".substring(1) ~is "ello"
     "hello".substring(1, 3) ~is "el"
     "hÉllo".utf8_bytes() ~is #"h\303\211llo"
@@ -75,8 +87,28 @@ block:
     "Hello".grapheme_count(2) ~is 3
     "Hello".grapheme_span(2, 4) ~is 1
     "Hello".grapheme_count(2, 4) ~is 2
+    "Hello".find("ello") ~is 1
+    "Hello".find("howdy") ~is #false
     "Hello".contains("ello") ~is #true
     "Hello".contains("howdy") ~is #false
+    "Hello".starts_with("ello") ~is #false
+    "Hello".ends_with("ello") ~is #true
+    "Hello".starts_with("Hel") ~is #true
+    "Hello".ends_with("hel") ~is #false
+    "Hello".replace("l", "x") ~is "Hexlo"
+    "Hello".replace("l", "x", ~all: #true) ~is "Hexxo"
+    "Hello World".split() ~is ["Hello", "World"]
+    "Hello World".split("l") ~is ["He", "", "o Wor", "d"]
+    "Hello World".split("l", ~repeat: #true) ~is ["He", "o Wor", "d"]
+    "Hello".split("H") ~is ["ello"]
+    "Hello".split("H", ~trim: #false) ~is ["", "ello"]
+    " Hello  ".trim() ~is "Hello"
+    " Hello  ".trim(~start: #false) ~is " Hello"
+    " Hello  ".trim(~end: #false) ~is "Hello  "
+    "_Hello__".trim("_") ~is "Hello_"
+    "_Hello__".trim("_", ~repeat: #true) ~is "Hello"
+    "_Hello__".trim("_", ~start: #false) ~is "_Hello_"
+    "_Hello__".trim("_", ~end: #false) ~is "Hello__"
     "Hello".copy() ~is_now "Hello"
     "Hello".copy() == "Hello" ~is #false
     "Hello".snapshot() ~is_now "Hello"
@@ -97,6 +129,8 @@ check:
   dynamic("4.35").to_number() ~is 4.35
   dynamic("hello").upcase() ~is "HELLO"
   dynamic("Hello").downcase() ~is "hello"
+  dynamic("hello").locale_upcase() ~is_a String
+  dynamic("Hello").locale_downcase() ~is_a String
   dynamic("Hello").foldcase() ~is "hello"
   dynamic("hello").titlecase() ~is "Hello"
   dynamic("hello").substring(1) ~is "ello"
@@ -113,8 +147,17 @@ check:
   dynamic("Hello").grapheme_count(2) ~is 3
   dynamic("Hello").grapheme_span(2, 4) ~is 1
   dynamic("Hello").grapheme_count(2, 4) ~is 2
+  dynamic("Hello").find("ello") ~is 1
   dynamic("Hello").contains("ello") ~is #true
   dynamic("Hello").contains("howdy") ~is #false
+  dynamic("Hello").ends_with("ello") ~is #true
+  dynamic("Hello").starts_with("Hel") ~is #true
+  dynamic("Hello").replace("l", "x") ~is "Hexlo"
+  dynamic("Hello").replace("l", "x", ~all: #true) ~is "Hexxo"
+  dynamic("Hello World").split() ~is ["Hello", "World"]
+  dynamic("Hello World").split("l", ~repeat: #true) ~is ["He", "o Wor", "d"]
+  dynamic(" Hello  ").trim() ~is "Hello"
+  dynamic("_Hello__").trim("_", ~start: #false) ~is "_Hello_"
   dynamic("Hello").copy() ~is_now "Hello"
   dynamic("Hello").snapshot() ~is_now "Hello"
 
@@ -215,6 +258,64 @@ block:
     a compares_unequal a ~is #false
     a compares_unequal A ~is #false
     a compares_unequal B ~is #true
+
+check:
+  ~eval
+  "a" :: StringLocale
+  ~throws "not allowed in a dynamic context"
+
+check:
+  ~eval
+  def s :: StringLocale = "a"
+  ~throws "not allowed in a dynamic context"
+
+block:
+  use_static
+  let a :: StringLocale = "a"
+  let also_a :: StringLocale = "a"
+  check:
+    a < also_a ~is #false
+    a <= also_a ~is #true
+    a > also_a ~is #false
+    a >= also_a ~is #true
+    a compares_equal also_a ~is #true
+    a compares_unequal also_a ~is #false
+
+block:
+  use_static
+  let a :: ReadableStringLocale = "a"
+  let also_a :: ReadableStringLocale = "a"
+  check:
+    a < also_a ~is #false
+    a <= also_a ~is #true
+    a > also_a ~is #false
+    a >= also_a ~is #true
+    a compares_equal also_a ~is #true
+    a compares_unequal also_a ~is #false
+
+block:
+  use_static
+  let a :: StringLocaleCI = "a"
+  let also_a :: StringLocaleCI = "a"
+  check:
+    a < also_a ~is #false
+    a <= also_a ~is #true
+    a > also_a ~is #false
+    a >= also_a ~is #true
+    a compares_equal also_a ~is #true
+    a compares_unequal also_a ~is #false
+
+block:
+  use_static
+  let a :: ReadableStringLocaleCI = "a"
+  let also_a :: ReadableStringLocaleCI = "a"
+  check:
+    a < also_a ~is #false
+    a <= also_a ~is #true
+    a > also_a ~is #false
+    a >= also_a ~is #true
+    a compares_equal also_a ~is #true
+    a compares_unequal also_a ~is #false
 
 block:
   use_static


### PR DESCRIPTION
Add missing operations from `racket` and `racket/string`:
* `String.find`, `String.starts_with` (= `string-prefix?`), and `String.ends_with` (= `string-suffix?`)
* `String.replace`
* `String.trim` and `String.split`
* `String.locale_upcase` and `String.locale_downcase`
* `StringLocale`, `ReadableStringLocale`, `StringCILocale`, `ReadableStringCILocale`

Initially, I wasn't sure whether everything in `racket` and `racket/string` should be kept, but it's not too much, and the added functions are widely used in Racket packages (except `string-find`, which is a fresh Racket PR).

I also considered moving locale support to a separate library, since it's rarely used. I left it for now, because it's simplest to have operations as `String` methods, and veneers like `StringLocale` pack the functionality into short names. I'm still not certain of that choice.

Along similar lines, I considered whether the finding, replacing, trimming, and splitting functions should be in a separate module. I left them in `String`, because they're used often (based on grepping Racket packages), and because Rhombus already depends on `racket/string` transitively. I feel relatively certain about that choice, so far.