### PR TITLE
export namespace extension static-info

### DIFF
--- a/rhombus/rhombus/tests/class-extend-namespace/import.rhm
+++ b/rhombus/rhombus/tests/class-extend-namespace/import.rhm
@@ -6,6 +6,11 @@ check:
   prefix.something
   ~is "yes"
 
+block:
+  use_static
+  check: prefix.something.contains("y") ~is #true
+  check: prefix.something.contains("n") ~is #false
+
 check:
   prefix.Something.x(prefix.Something(13))
   ~is 13


### PR DESCRIPTION
If I have this in a `def.rhm`:
```
#lang rhombus/static
export: MyNamespace
namespace MyNamespace
def MyNamespace.l :: List: []
```
And this in a `use.rhm`:
```
#lang rhombus/static
import: "def.rhm".MyNamespace
for (e: MyNamespace.l):
  println(e)
```
Before this PR, it gives me an error about about not enough static information. After this PR, the error goes away.

- [x] Tests