### PR TITLE
generalize group positions in a syntax pattern

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/macro-rhs.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/macro-rhs.rkt
@@ -81,6 +81,10 @@
          #:when (free-identifier=? (in-unquote-binding-space (datum->syntax #'tag '#%parens))
                                    (unquote-bind-quote #%parens))
          (values #'(pat ...) #f)]
+        [(_ ... (~or (_::block . _)
+                     (_::alts . _)))
+         ;; a block or alts simiarly must end a group
+         (values tail-pattern-in #f)]
         [(pat ... _::$-bind _:identifier _::...-bind)
          ;; recognize where a tail match would be redundant and always be empty;
          ;; this is kind of an optimization, but one that's intended to be guaranteed;
@@ -142,7 +146,7 @@
                     #`((define #,all*-id
                          #,(if implicit-tail?
                                #`(make-all (list* left-id ... self (unpack-tail (rhombus-expression (group all_tail)) #f #f)))
-                               #`(make-all (list* left-id ... self tail))))
+                               #`(make-all (list* left-id ... self (unpack-tail tail #f #f)))))
                        (define-static-info-syntax #,all*-id #:getter get-syntax-static-infos))
                     '())
              #,body))]))
@@ -257,7 +261,7 @@
                    #`[#t
                       (let ([self-id self])
                         (define-static-info-syntax self-id #:getter get-syntax-static-infos)
-                        #,@(maybe-bind-all all*-id #'self-id #'make-all #'tail-pattern #'tail)
+                        #,@(maybe-bind-all all*-id #'self-id #'make-all #'tail-pattern #'(unpack-tail tail #f #f))
                         #,@(maybe-bind-tail #'tail-pattern #'tail)
                         #,(maybe-return-tail
                            (let ([body (if (eq? kind 'rule)

--- a/rhombus/rhombus/scribblings/reference/expr-macro.scrbl
+++ b/rhombus/rhombus/scribblings/reference/expr-macro.scrbl
@@ -67,8 +67,9 @@
  body after each @rhombus(macro_pattern).
 
  If a @rhombus(macro_pattern) ends with
- @rhombus(#,(@rhombus($, ~bind))()) or
- @rhombus(#,(@rhombus($, ~bind))#,(@rhombus(id, ~var)) #,(@rhombus(..., ~bind))), then a match
+ @rhombus(#,(@rhombus($, ~bind))()),
+ @rhombus(#,(@rhombus($, ~bind))#,(@rhombus(id, ~var)) #,(@rhombus(..., ~bind))),
+ a block pattern, or an alternatives pattern, then a match
  covers all subsequent terms in the enclosing group of a use of the
  macro. In that case, the @rhombus(body) after the pattern can return two
  values: an expansion for the consumed part of the input match, and a

--- a/rhombus/rhombus/scribblings/reference/macro.scrbl
+++ b/rhombus/rhombus/scribblings/reference/macro.scrbl
@@ -120,8 +120,10 @@
  @item{Otherwise, the right-hand side is an arbitrary pattern that is
   matched to a sequence of terms after the macro name in its enclosing
   group. Unless the pattern ends with @rhombus(#,(@rhombus($, ~bind))()),
+  a block pattern, or an alternatives pattern,
   the use of the macro can be followed by additional terms in the same
-  group. If the pattern ends with @rhombus(#,(@rhombus($, ~bind))()), then
+  group. If the pattern ends with @rhombus(#,(@rhombus($, ~bind))()),
+  a block pattern, or an alternatives pattern, then
   all terms after the macro operator must match the right-hand pattern.
   The position before @rhombus(#,(@rhombus($, ~bind))()) is itself treated
   as a group position.}

--- a/rhombus/rhombus/scribblings/reference/macro.scrbl
+++ b/rhombus/rhombus/scribblings/reference/macro.scrbl
@@ -9,8 +9,8 @@
 
 @doc(
   ~nonterminal:
-    right_parsed_id: block id
-    left_parsed_id: block id
+    right_parsed_id: macro parsed_id ~defn
+    left_parsed_id: macro parsed_id ~defn
 
   defn.macro 'macro $macro_case'
   defn.macro 'macro
@@ -102,7 +102,7 @@
  term is a single @rhombus($, ~bind) escape followed by a
  @rhombus(defined_name) to be defined as an infix macro.
 
- In the case of a prefix macro, the left-hand @rhombus($, ~bind) escape
+ In the case of an infix macro, the left-hand @rhombus($, ~bind) escape
  must be an identifier. It stands for a match to preceding terms that
  have been parsed as an expression, and the identifier is bound to an
  opaque representation of the expression. The right-hand side of the

--- a/rhombus/rhombus/scribblings/reference/stxobj.scrbl
+++ b/rhombus/rhombus/scribblings/reference/stxobj.scrbl
@@ -143,7 +143,7 @@ suffix corresponds to text after the closer.
  binding), and other atomic terms are matched using @rhombus(==) on
  unwrapped syntax objects.
 
- A @rhombus($, ~bind) within @rhombus(term)
+ A @rhombus($, ~bind) as a @rhombus(term)
  escapes to a subsequent unquoted binding that is matched against the corresponding
  portion of a candidate syntax object.
  A @dots in @rhombus(term, ~var) following a subpattern matches any number
@@ -155,20 +155,6 @@ suffix corresponds to text after the closer.
  @dots can appear within a sequence; when matching
  is ambiguous, matching prefers earlier @dots repetitions to
  later ones.
-
- A @rhombus($, ~bind) or @dots as the only @rhombus(term) matches
- each of those literally. To match @rhombus($, ~datum) or
- @rhombus(..., ~datum) literally within a larger sequence of @rhombus(term)s,
- use @rhombus($, ~bind) to escape to a nested pattern, such as
- @rhombus(#,(@rhombus($, ~bind))('#,(@rhombus($))')). Simialrly,
- to match a literal @rhombus(~nonempty) or @rhombus(~once) after a @dots repetition, use
- @rhombus(#,(@rhombus($, ~bind))('~nonempty')) or @rhombus(#,(@rhombus($, ~bind))('~once')).
-
- To match identifier or operators based on binding instead of
- symbolically, use @rhombus($, ~bind) to escape, and then use
- @rhombus(bound_as, ~unquote_bind) within the escape.
-
- @see_implicit(@rhombus(#%quotes, ~bind), @quotes, "binding")
 
 @examples(
   match '1 + 2'
@@ -186,6 +172,48 @@ suffix corresponds to text after the closer.
   match '1 = 3'
   | '$x $(n && '!') ... ~once = $y': [x, [n, ...], y]
 )
+
+ Each @rhombus($, ~bind) escape is in either a term, group, or
+ multi-group context. A @rhombus($, ~bind) escape is in a term context if
+ it is followed by another escape within the same group. A
+ @rhombus($, ~bind) escape is a multi-group context when it is alone
+ within its group and when the group is last in its enclosing group
+ sequence. All other escapes are in a group context. An escape may impose
+ constraints mor elimiting than its context, such as using
+ @rhombus(Term, ~stxclass) within an escape in a group context. Escaping
+ to a group pattern in a term context is a syntax error, as is using a
+ multi-group pattern in a group or term context. A sequence escape (such
+ as a use of a @tech{syntax class} of kind @rhombus(~sequence)) can be
+ used in a term context.
+
+@examples(
+  ~error:
+    match '1 + 2'
+    | '$(a :: Group) + $b': a
+  match '1 + 2 + 3 + 4'
+  | '$(a :: Sequence) + $b': a
+  match '1 + 2 + 3'
+  | '$a + $(b :: Group)': b
+)
+
+ A @rhombus($, ~bind) or @dots as the only @rhombus(term) matches
+ each of those literally. To match @rhombus($, ~datum) or
+ @rhombus(..., ~datum) literally within a larger sequence of @rhombus(term)s,
+ use @rhombus($, ~bind) to escape to a nested pattern, such as
+ @rhombus(#,(@rhombus($, ~bind))('#,(@rhombus($))')). Simialrly,
+ to match a literal @rhombus(~nonempty) or @rhombus(~once) after a @dots repetition, use
+ @rhombus(#,(@rhombus($, ~bind))('~nonempty')) or @rhombus(#,(@rhombus($, ~bind))('~once')).
+
+@examples(
+  match Syntax.literal '1 $ 2'
+  | '$n $('$') $m': [n, m]
+)
+
+ To match identifier or operators based on binding instead of
+ symbolically, use @rhombus($, ~bind) to escape, and then use
+ @rhombus(bound_as, ~unquote_bind) within the escape.
+
+ @see_implicit(@rhombus(#%quotes, ~bind), @quotes, "binding")
 
 }
 
@@ -407,7 +435,7 @@ suffix corresponds to text after the closer.
   def '$(!'2') ...' = '1 3 5 7 9'
   def '$(!'($_)') ...' = '[] {}'
   ~error:
-    def '$(b && '$_ $_ $_') done' = '1 2 3 done' // b in term context
+    def '$(b && '$_ $_ $_') $end' = '1 2 3 done' // b in term context
 )
 
 }

--- a/rhombus/rhombus/tests/expr-macro.rhm
+++ b/rhombus/rhombus/tests/expr-macro.rhm
@@ -356,3 +356,28 @@ check:
       ex:
         "ok"
   ~completes
+
+check:
+  expr.macro 'm0 $a $()':
+    ~all_stx: stx
+    '('$stx')'
+  m0 10 11 12
+  ~matches 'm0 10 11 12'
+
+check:
+  expr.macro '$left m1 $a $()':
+    ~all_stx: stx
+    let '$_ $after_left' = stx
+    '('$after_left')'
+  1 m1 10 11 12
+  ~matches 'm1 10 11 12'
+
+check:
+  expr.macro 'with_options $term ...:
+                $options':
+    let '$(e :: expr_meta.Parsed)' = '$term ...'
+    e
+  with_options 1 + 3:
+    ~more
+  ~is 4
+

--- a/rhombus/rhombus/tests/quasiquote.rhm
+++ b/rhombus/rhombus/tests/quasiquote.rhm
@@ -195,7 +195,7 @@ check:
 check:
   ~eval
   def '0 $('1; 2') 3' = '0 1; 2'
-  ~throws "multi-group pattern incompatible with term context"
+  ~throws "multi-group pattern incompatible with group context"
 
 check:
   ~eval

--- a/rhombus/rhombus/tests/syntax-class.rhm
+++ b/rhombus/rhombus/tests/syntax-class.rhm
@@ -279,12 +279,21 @@ block:
 
 block:
   check:
-    ~eval
     syntax_class Foo:
       kind: ~group
     | '$x + $y'
     match '0 + 1 + 2 + 3'
     | '0 + $(f :: Foo) + 3': [f.x, f.y]
+    ~matches ['1', '2']
+
+block:
+  check:
+    ~eval
+    syntax_class Foo:
+      kind: ~group
+    | '$x + $y'
+    match '0 + 1 + 2 + 3'
+    | '0 + $(f :: Foo) + $z': [f.x, f.y]
     ~throws "syntax class incompatible with this context"
 
 block:


### PR DESCRIPTION
Instead of allowing only an escape at the end of a group to serve as a group escape, allow any escape within a group that is not followed by an escape to be a group position.

The intent is to allow something like

```
expr.macro 'with_options $(e :: expr_meta.Parsed):
  $options':
  ....
```

instead of requiring that to be written as

```
expr.macro 'with_options $term ...:
  $options':
  let '$(e :: expr_meta.Parsed)' = '$term ...'
  ....
```

This changs is not backward-compatible, because it can change the meaning of existing syntax patterns. However, nothing in this repo (or the Shplait repo) seems to be broken by the change. The revised rule seems no more difficult to explain, and it seems in line with other conventions in Rhombus to make patterns work as expected.
