### PR TITLE
add `definitely` epression and binding form

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annot-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annot-macro.rkt
@@ -177,11 +177,11 @@
     (check-syntax who static-infos)
     (syntax-parse binding
       #:datum-literals (parsed)
-      [(parsed #:rhombus/bind _::binding-form)
+      [(parsed #:rhombus/bind b::binding-form)
        (no-srcloc
         #`(parsed #:rhombus/annot
                   #,(annotation-binding-form
-                     binding
+                     #'b
                      (wrap-expression body)
                      (pack-static-infos who (unpack-term static-infos who #f)))))]
       [_ (raise-arguments-error* who rhombus-realm

--- a/rhombus-lib/rhombus/private/amalgam/arithmetic.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/arithmetic.rkt
@@ -28,7 +28,7 @@
                      mod
                      rem
 
-                     !
+                     ! ;; replaced by `!?` in "maybe.rhm"
                      &&
                      \|\|
 

--- a/rhombus-lib/rhombus/private/amalgam/macro-rhs.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/macro-rhs.rkt
@@ -85,7 +85,7 @@
                      (_::alts . _)))
          ;; a block or alts simiarly must end a group
          (values tail-pattern-in #f)]
-        [(pat ... _::$-bind _:identifier _::...-bind)
+        [(pat ... _::$-bind _:identifier _::...-bind (~or (~seq) (~seq #:nonempty)))
          ;; recognize where a tail match would be redundant and always be empty;
          ;; this is kind of an optimization, but one that's intended to be guaranteed;
          ;; note that this enables returning two values from the macro, instead

--- a/rhombus-lib/rhombus/private/amalgam/maybe-key.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/maybe-key.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt")
+
+(define-static-info-key-syntax/provide #%maybe
+  (static-info-key static-infos-result-union
+                   static-infos-result-intersect))

--- a/rhombus-lib/rhombus/private/amalgam/maybe.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/maybe.rhm
@@ -6,6 +6,117 @@ use_static
 
 export:
   maybe
+  !!
+  ?
 
 annot.macro 'maybe($(ann :: annot_meta.Parsed))':
-  'False || $ann'
+  ~all_stx: stx
+  if annot_meta.is_predicate(ann)
+  | let (pred, statinfos) = annot_meta.unpack_predicate(ann)
+    annot_meta.pack_predicate('block:
+                                 let p = $pred
+                                 fun (v): !v || p(v)',
+                              '(($statinfo_meta.maybe_key,
+                                 $(statinfo_meta.pack(statinfos))))').relocate_span([stx])
+  | let (_, _, statinfos) = annot_meta.unpack_converter(ann)
+    let '$(f_ann :: annot_meta.Parsed)' = 'False || $ann'
+    let (bind, body, _) = annot_meta.unpack_converter('$f_ann')
+    annot_meta.pack_converter(bind,
+                              body,
+                              '(($statinfo_meta.maybe_key,
+                                 $(statinfo_meta.pack(statinfos))))')
+
+meta:
+  fun demaybe_statinfos(statinfos):
+    let maybe_statinfos = statinfo_meta.find(statinfos, statinfo_meta.maybe_key)
+    if maybe_statinfos
+    | statinfo_meta.union(statinfos,
+                          statinfo_meta.unpack(maybe_statinfos))
+    | statinfos
+
+expr.macro '$e !!':
+  ~op_stx: self
+  let statinfos = statinfo_meta.gather(e)
+  statinfo_meta.replace('match $(statinfo_meta.replace(e, '()'))
+                         | #false: definitely_failed(#' $(Symbol.from_string(self.to_source_string())))
+                         | v: v',
+                        demaybe_statinfos(statinfos))
+
+repet.macro '$e !!':
+  ~op_stx: self
+  ~all_stx: stx
+  let '($_, $expr, $depth, $use_depth, $statinfos)' = repet_meta.unpack_list(e)
+  repet_meta.pack_list('($stx,
+                         'check_definitely_at_depth(#' $(Symbol.from_string(self.to_source_string())),
+                                                    $expr,
+                                                    $depth - $use_depth)',
+                         $depth,
+                         $use_depth,
+                         $(demaybe_statinfos(statinfos)))')
+
+expr.macro '$e ? $tail ... ~nonempty':
+  ~weaker_than: ~other
+  let statinfos = statinfo_meta.gather(e)
+  let id = 'v'
+  let id_expr = statinfo_meta.replace(expr_meta.pack_s_exp(id), // packing can avoid an unbound-identifier error
+                                      demaybe_statinfos(statinfos))
+  let '$(v_finish :: expr_meta.AfterInfixParsed('?'))' = '$id_expr $tail ...'
+  let finish_statinfos = statinfo_meta.gather(v_finish)
+  values(
+    statinfo_meta.replace(
+      'block:
+         def $id = $(statinfo_meta.replace(e, '()'))
+         if $id
+         | $v_finish
+         | #false',
+      '(($statinfo_meta.maybe_key, $(statinfo_meta.pack(finish_statinfos))))'
+      ),
+    '$v_finish.tail ...'
+  )
+
+fun definitely_failed(who):
+  throw Exn.Fail.Annot(who +& ": claimed not false, but actual value is false",
+                       Continuation.Marks.current())
+
+fun check_definitey_at_depth(who, v, depth):
+  if depth == 0
+  | v || definitely_failed(who)
+  | for (e: (v :~ List)):
+      check_definitey_at_depth(who, e, depth-1)
+
+bind.macro '$b !!':
+  ~op_stx: self
+  bind_meta.pack('(definitely_infoer,
+                   $b)')
+
+bind.infoer 'definitely_infoer($statinfos, $b)':
+  let b_info = bind_meta.get_info(b, demaybe_statinfos(statinfos))
+  let '($b_ann, $b_name, $b_s_infos, $b_var_infos,
+        $b_matcher, $b_evidence, $b_committer, $b_binder, $b_data)':
+    bind_meta.unpack_info(b_info)
+  let b_ann_str :~ String = b_ann.unwrap()
+  let ann:
+    if b_ann_str.starts_with("matching(") && b_ann_str.ends_with(")")
+    | "matching((" ++ b_ann_str.substring(9, b_ann_str.length() - 1) ++ ")!!)"
+    | "matching((_ :: " ++ b_ann_str ++ ") !!)"
+  '($ann,
+    $b_name,
+    $b_s_infos,
+    $b_var_infos,
+    definitely_matcher,
+    $b_evidence,
+    definitely_committer,
+    definitely_binder,
+    ($b_matcher, $b_committer, $b_binder, $b_data))'
+
+bind.matcher 'definitely_matcher($in_id, ($b_matcher, $_, $_, $b_data),
+                                 $IF, $success, $failure)':
+  '$IF $in_id
+   | $b_matcher($in_id, $b_data, $IF, $success, $failure)
+   | $failure'
+
+bind.committer 'definitely_committer($in_id, $evidence, ($_, $b_committer, $_, $b_data))':
+  '$b_committer($in_id, $evidence, $b_data)'
+
+bind.binder 'definitely_binder($in_id, $evidence, ($_, $_, $b_binder, $b_data))':
+  '$b_binder($in_id, $evidence, $b_data)'

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -10,6 +10,7 @@
          "define-arity.rkt"
          "compare-key.rkt"
          "index-result-key.rkt"
+         "maybe-key.rkt"
          "static-info.rkt"
          "annotation-failure.rkt"
          "enum.rkt"
@@ -265,6 +266,7 @@
   (bytes->path-element bstr))
 
 (define/arity (Path.Element.maybe bstr)
+  #:static-infos ((#%call-result ((#%maybe #,(get-path-static-infos)))))
   (unless (bytes? bstr) (raise-annotation-failure who bstr "Bytes"))
   (bytes->path-element bstr (system-path-convention-type) #t))
 
@@ -327,6 +329,7 @@
 
 (define/method (Path.suffix p)
   #:primitive (path-get-extension)
+  #:static-infos ((#%call-result ((#%maybe #,(get-path-static-infos)))))
   (define maybe-bstr (path-get-extension p))
   (and maybe-bstr (bytes->immutable-bytes maybe-bstr)))
 

--- a/rhombus-lib/rhombus/private/amalgam/pipeline.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/pipeline.rhm
@@ -1,6 +1,7 @@
 #lang rhombus/private/amalgam/core
 import:
   "core-meta.rkt" open
+  "maybe.rhm".(?)
 
 use_static
 
@@ -10,6 +11,7 @@ export:
 expr.macro '$arg |> $tail ...':
   ~op_stx: self
   ~weaker_than: ~other
+  ~stronger_than: ?
   // Convert to a dynamic or static call:
   let call:
     if statinfo_meta.is_static(self)

--- a/rhombus-lib/rhombus/private/amalgam/quasiquote.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/quasiquote.rkt
@@ -1098,7 +1098,7 @@
                (free-identifier=? #'repack #'repack-as-multi)])])))
      (relocate+reraw
       (respan stx)
-      #`(syntax-parse (#,(if repack-multi? #'repack-as-multi #'repack-as-term) #,in-expr)
+      #`(syntax-parse (#,(if repack-multi? #'repack-as-multi #'repack-as-term) (rhombus-expression #,in-expr))
           #:disable-colon-notation
           #:context '#,who
           #,@(for/list ([bind (in-list binds)]

--- a/rhombus-lib/rhombus/private/amalgam/srcloc-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/srcloc-object.rkt
@@ -6,9 +6,11 @@
          "dot-parse.rkt"
          "function-arity-key.rkt"
          "call-result-key.rkt"
+         "maybe-key.rkt"
          "define-arity.rkt"
          "realm.rkt"
-         (submod "string.rkt" static-infos))
+         (submod "string.rkt" static-infos)
+         (submod "arithmetic.rkt" static-infos))
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -28,10 +30,10 @@
   #:transparent
   #:fields
   ([(source)]
-   [(line)]
-   [(column)]
-   [(position)]
-   [(span)])
+   [(line) ((#%maybe #,(get-int-static-infos)))]
+   [(column) ((#%maybe #,(get-int-static-infos)))]
+   [(position) ((#%maybe #,(get-int-static-infos)))]
+   [(span) ((#%maybe #,(get-int-static-infos)))])
   #:properties
   ()
   #:methods

--- a/rhombus-lib/rhombus/private/amalgam/static-info-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/static-info-macro.rkt
@@ -37,6 +37,7 @@
          "sequence-constructor-key.rkt"
          "sequence-element-key.rkt"
          "list-bounds-key.rkt"
+         "maybe-key.rkt"
          "values-key.rkt"
          "indirect-static-info-key.rkt"
          "is-static.rkt"
@@ -62,6 +63,7 @@
      [wrap statinfo_meta.wrap]
      [lookup statinfo_meta.lookup]
      [gather statinfo_meta.gather]
+     [replace statinfo_meta.replace]
      [find statinfo_meta.find]
      [union statinfo_meta.union]
      [intersect statinfo_meta.intersect]
@@ -84,6 +86,7 @@
      sequence_element_key
      list_bounds_key
      pairlist_bounds_key
+     maybe_key
      values_key
      indirect_key)))
 
@@ -255,6 +258,7 @@
     (pack-term (relocate+reraw e #`(parsed #:rhombus/expr #,e))))
 
   (define/arity (statinfo_meta.lookup form key-in)
+    #:static-infos ((#%call-result ((#%maybe #,(get-syntax-static-infos)))))
     (check-syntax who form)
     (define key (unpack-identifier who key-in))
     (define si (extract-expr-static-infos who form))
@@ -266,7 +270,17 @@
     (define si (extract-expr-static-infos who form))
     (unpack-static-infos who (or si #'())))
 
+  (define/arity (statinfo_meta.replace form statinfos)
+    #:static-infos ((#%call-result #,(get-syntax-static-infos)))
+    (check-syntax who form)
+    (check-syntax who statinfos)
+    (define e
+      (wrap-static-info* (discard-static-infos (wrap-expression form))
+                         (pack-static-infos who statinfos)))
+    (pack-term (relocate+reraw e #`(parsed #:rhombus/expr #,e))))
+
   (define/arity (statinfo_meta.find si-stx key-in)
+    #:static-infos ((#%call-result ((#%maybe #,(get-syntax-static-infos)))))
     (define si (pack-static-infos who si-stx))
     (define key (unpack-identifier who key-in))
     (static-info-lookup si key))
@@ -299,5 +313,6 @@
 (define-key sequence_element_key #%sequence-element)
 (define-key list_bounds_key #%treelist-bounds)
 (define-key pairlist_bounds_key #%list-bounds)
+(define-key maybe_key #%maybe)
 (define-key values_key #%values)
 (define-key indirect_key #%indirect-static-info)

--- a/rhombus-lib/rhombus/private/amalgam/static-info-pack.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/static-info-pack.rkt
@@ -16,9 +16,11 @@
 
 (define (pack-static-infos who stx)
   (syntax-parse stx
-    #:datum-literals (group)
+    #:datum-literals (group multi)
     [(_::parens (group (_::parens (group key) (group val))) ...)
      #'((key val) ...)]
+    [(group t) (pack-static-infos who #'t)]
+    [(multi (group t)) (pack-static-infos who #'t)]
     [_ (raise-arguments-error* who rhombus-realm
                                "ill-formed unpacked static infos"
                                "syntax object" stx)]))

--- a/rhombus-lib/rhombus/private/amalgam/string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/string.rkt
@@ -295,18 +295,19 @@
   (string->immutable-string s))
 
 (define/method (String.to_int s)
-  #:static-infos ((#%call-result #,(get-int-static-infos)))
+  #:static-infos ((#%call-result ((#%maybe #,(get-int-static-infos)))))
   (check-readable-string who s)
   (define n (string->number s))
   (and (exact-integer? n)
        n))
 
 (define/method (String.to_number s)
-  #:static-infos ((#%call-result #,(get-number-static-infos)))
+  #:static-infos ((#%call-result ((#%maybe #,(get-number-static-infos)))))
   (check-readable-string who s)
   (string->number s))
 
 (define/method (String.find s1 s2)
+  #:static-infos ((#%call-result ((#%maybe #,(get-int-static-infos)))))
   (check-readable-string who s1)
   (check-readable-string who s2)
   (meta-if-version-at-least

--- a/rhombus-lib/rhombus/private/amalgam/syntax-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/syntax-object.rkt
@@ -22,6 +22,8 @@
          "srcloc.rkt"
          "call-result-key.rkt"
          "index-result-key.rkt"
+         "index-result-key.rkt"
+         "maybe-key.rkt"
          (submod "srcloc-object.rkt" for-static-info)
          (submod "string.rkt" static-infos)
          (submod "list.rkt" for-compound-repetition)
@@ -825,9 +827,9 @@
                                                       #:inner? inner?)))
 
 (define/method (Syntax.srcloc stx)
+  #:static-infos ((#%call-result ((#%maybe #,(get-srcloc-static-infos)))))
   (check-syntax who stx)
-  (or (syntax-srcloc (maybe-respan stx))
-      (srcloc #f #f #f #f #f)))
+  (syntax-srcloc (maybe-respan stx)))
 
 (define/method (Syntax.is_original v)
   (syntax-original? (extract-ctx who v #:false-ok? #f)))

--- a/rhombus-scribble-lib/rhombus/scribble/private/rhombus.rhm
+++ b/rhombus-scribble-lib/rhombus/scribble/private/rhombus.rhm
@@ -2,15 +2,17 @@
 import:
   shrubbery/render/define  
   "typeset-rhombus.rkt" open
-  lib("scribble/base.rkt").elem
+  lib("scribble/base.rkt")
+  "element.rhm".elem
 
 export:
   rhombus
   rhombusblock
   rhombusblock_etc  
+  rhombuslink
 
 fun escape(who, v):
-  elem(v)
+  base.elem(v)
 
 define.macros (rhombus,
                rhombusblock,
@@ -19,3 +21,14 @@ define.macros (rhombus,
   ~render_block: #{typeset-rhombusblock}
   ~escape: escape
   ~result: Any
+
+expr.macro
+| 'rhombuslink($(name :: Name), $(kw :: Keyword), $content, ... ~nonempty)':
+    '#{typeset-rhombus}(Syntax.literal '$name', ~space: #'$kw, ~content: elem([$content, ...]))'
+| 'rhombuslink($(name :: Name),
+               ~at: $(sp && ('$(sp :: Identifier)' || '$(sp :: Identifier)')) ...,
+               $content, ... ~nonempty)':
+    let space = Symbol.from_string(String.append(to_string(sp), ...))
+    '#{typeset-rhombus}(Syntax.literal '$name', ~space: #'$space, ~content: elem([$content, ...]))'
+| 'rhombuslink($(name :: Name), $content, ... ~nonempty)':
+    '#{typeset-rhombus}(Syntax.literal '$name', ~content: elem([$content, ...]))'

--- a/rhombus-scribble-lib/rhombus/scribble/private/typeset-rhombus.rkt
+++ b/rhombus-scribble-lib/rhombus/scribble/private/typeset-rhombus.rkt
@@ -10,6 +10,7 @@
                   delayed-element-plain
                   content?
                   content-width
+                  content->string
                   paragraph
                   table
                   style
@@ -147,7 +148,8 @@
                                                     (find-via-annot-spacer-binding fallback-annot more-rators)
                                                     default)]
                                                [else default]))
-                                           (define p (and ns-id (identifier-binding-portal-syntax ns-id 0)))
+                                           (define p (and ns-id (with-handlers ([exn:fail? (lambda (x) #f)])
+                                                                  (identifier-binding-portal-syntax ns-id 0))))
                                            (define lookup (and p (portal-syntax->lookup p (lambda (self-id lookup) lookup) #f)))
                                            (define next-field (if (null? more-rators)
                                                                   field
@@ -218,8 +220,10 @@
    #:is_rendered element*?))
 
 (define (typeset-rhombus stx
-                         #:space [space-name-in #f])
-  (render_code stx #:space space-name-in))
+                         #:space [space-name-in #f]
+                         #:content [content #f])
+  (render_code stx #:space space-name-in #:content (and content
+                                                        (content->string content))))
 
 (define (typeset-rhombusblock stx
                               #:inset [inset? #t]

--- a/rhombus-scribble/rhombus/scribble/scribblings/rhombus.scrbl
+++ b/rhombus-scribble/rhombus/scribble/scribblings/rhombus.scrbl
@@ -72,6 +72,18 @@
 }
 
 @doc(
+  expr.macro 'rhombuslink($name, $content, ... ~nonempty)'
+  expr.macro 'rhombuslink($name, $builtin_space, $content, ... ~nonempty)'
+  expr.macro 'rhombuslink($name, ~at $space_name, $content, ... ~nonempty)'
+){
+
+ Link @rhombus(rhombus), but uses the text of
+ @rhombus(elem([content, ...])) preserving the hyperlink (if any) of
+ @rhombus(name).
+
+}
+
+@doc(
   expr.macro 'rhombusblock($group, ...)'
 ){
 

--- a/rhombus/rhombus/scribblings/reference/annotation.scrbl
+++ b/rhombus/rhombus/scribblings/reference/annotation.scrbl
@@ -226,11 +226,85 @@
  @rhombus(annot). If @rhombus(annot) is a @tech(~doc: guide_doc){converter annotation},
  its conversion applies to a non-@rhombus(#false) value.
 
+ See also @rhombus(definitely).
+
 @examples(
   #false :: maybe(String)
   "string" :: maybe(String)
   ~error:
     #true :: maybe(String)
+)
+
+}
+
+@doc(
+  expr.macro '$expr !!'
+  bind.macro '$bind !!'
+){
+
+ An an expression, @rhombus(expr!!) ensures that the result of
+ @rhombus(expr) is not @rhombus(#false) by throwing an exception if the
+ result is @rhombus(#false). If @rhombus(expr) has static information
+ from @rhombus(maybe(#,(@nontermref(annot))), ~annot), then the overall
+ @rhombus(!!) expression gets the static information of
+ @nontermref(annot).
+
+ As a binding, @rhombus(bind!!) matches non-@rhombus(#false) values that
+ match @rhombus(bind). Similar to the @rhombus(!!) expression form, when
+ static information for the input to @rhombus(bind!!) is
+ @rhombus(maybe(#,(@nontermref(annot))), ~annot), then @rhombus(bind)
+ more specifically starts with the static information of
+ @nontermref(annot).
+
+ See also @rhombus(?)
+
+@examples(
+  ~repl:
+    ~error:
+      definitely(#false)
+    ~error:
+      #false!!
+  ~defn:
+    fun len(str :: maybe(String)):
+      use_static
+      match str
+      | s!!: s.length()
+      | ~else: 0
+  ~repl:
+    len("apple")
+    len(#false)
+    ~error:
+      len(1)
+)
+
+}
+
+
+@doc(
+  expr.macro '$expr ? $infix_op_and_tail'
+){
+
+ If @rhombus(expr) produces @rhombus(#false), then the result of a
+ @rhombus(?) expression is @rhombus(#false). Otherwise,
+ @rhombus(infix_op_and_tail) is expected to continue with an infix
+ operator, such as @rhombus(.), and the result of @rhombus(expr) is used
+ as the left argument to that operator.
+
+ When @rhombus(expr) has static information from
+ @rhombus(maybe(#,(@nontermref(annot))), ~annot), then the argument to
+ the infix operator has static information of @nontermref(annot). If the
+ result in the non-@rhombus(#false) case has static information like
+ @nontermref(annot), then the overall @rhombus(?) expression has static
+ information like @rhombus(maybe(#,(@nontermref(annot))), ~annot).
+
+@examples(
+  ~defn:
+    fun len(str :: maybe(String)):
+      use_static
+      str?.length() || 0
+  ~repl:
+    len("apple")
+    len(#false)
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/boolean.scrbl
+++ b/rhombus/rhombus/scribblings/reference/boolean.scrbl
@@ -252,8 +252,8 @@
   operator (! (v :: Any)) :: Boolean
 ){
 
- Returns @rhombus(#true) if @rhombus(v) is @rhombus(#false),
- @rhombus(#false) otherwise.
+ As a prefix operator, returns @rhombus(#true) if @rhombus(v) is
+ @rhombus(#false), @rhombus(#false) otherwise.
 
 @examples(
   !#false
@@ -267,8 +267,8 @@
   bind.macro '! $bind'
 ){
 
- Matches if @rhombus(bind) does not match. Because @rhombus(bind) does
- not match, no identifiers are bound.
+ As a prefix operator, matches if @rhombus(bind) does not match. Because
+ @rhombus(bind) does not match, no identifiers are bound.
 
 @examples(
   fun

--- a/rhombus/rhombus/scribblings/reference/match.scrbl
+++ b/rhombus/rhombus/scribblings/reference/match.scrbl
@@ -53,21 +53,6 @@
  The set of @rhombus(bind) forms is extensible, so it cannot be
  completely enumerated here.
 
- If no @rhombus(target_expr) produces a true value and there is no
- @rhombus(~else) clause, a run-time exception is thrown. In that case,
- when all of the @rhombus(bind) forms are syntax-object patterns, the
- generated exception's message may be specialized to report the expected
- pattern, instead of just reporting that no cases matched.
-
- If an initial segment of @rhombus(bind) patterns are ``literal-like''
- or combinations of such patterns with @rhombus(||, ~bind), then the
- match is implemented as a case dispatch, and a match is found with
- logarithmic rather than linear time complexity in the number of
- literals. ``Literal-like'' patterns include (usually implicitly used)
- @rhombus(#%literal, ~bind), @rhombus(#', ~bind),
- @rhombus(Char, ~bind), and @rhombus(Byte, ~bind). The remaining
- patterns are handled as usual.
-
 @examples(
   match 1+2
   | 3: "three"
@@ -84,6 +69,50 @@
     match 1+2
     | n when n > 4: "ok"
 )
+
+ If no @rhombus(target_expr) produces a true value and there is no
+ @rhombus(~else) clause, a run-time exception is thrown. In that case,
+ when all of the @rhombus(bind) forms are syntax-object patterns, the
+ generated exception's message may be specialized to report the expected
+ pattern, instead of just reporting that no cases matched.
+
+@examples(
+  ~error:
+    match 1+2
+    | 4: "four"
+  ~error:
+    match '1+2'
+    | '4': "four"
+)
+
+ If an initial segment of @rhombus(bind) patterns are ``literal-like''
+ or combinations of such patterns with @rhombus(||, ~bind), then the
+ match is implemented as a case dispatch, and a match is found with
+ logarithmic rather than linear time complexity in the number of
+ literals. ``Literal-like'' patterns include (usually implicitly used)
+ @rhombus(#%literal, ~bind), @rhombus(#', ~bind),
+ @rhombus(Char, ~bind), and @rhombus(Byte, ~bind). The remaining
+ patterns are handled as usual.
+
+@examples(
+  ~defn:
+    fun classify_efficiently(n):
+      match n
+      | 1: "one"
+      | 2: "two"
+      | 3 || 4: "some"
+      | ~else: "more"
+)
+
+ Static information for @rhombus(target_expr) is propagated to each
+ @rhombus(bind).
+
+@examples(
+  use_static
+  match (["apple", "banana"] :: List.of(String))
+  | [s, ...]: [s.length(), ...]
+)
+
 }
 
 

--- a/rhombus/rhombus/scribblings/reference/repet-macro.scrbl
+++ b/rhombus/rhombus/scribblings/reference/repet-macro.scrbl
@@ -65,11 +65,12 @@
  The syntax object @rhombus(stx) must have the following shape:
 
  @rhombusblock(
-  '(#,(@rhombus(source_form, ~var)),
-    #,(@rhombus(list_expr, ~var)),
-    #,(@rhombus(depth, ~var)),
-    #,(@rhombus(use_depth, ~var)),
-    ((#,(@rhombus(static_key, ~var)), #,(@rhombus(static_value, ~var))), ...)
+  '(
+     #,(@rhombus(source_form, ~var)),
+     #,(@rhombus(list_expr, ~var)),
+     #,(@rhombus(depth, ~var)),
+     #,(@rhombus(use_depth, ~var)),
+     ((#,(@rhombus(static_key, ~var)), #,(@rhombus(static_value, ~var))), ...)
    )'
  )
 

--- a/rhombus/rhombus/tests/match.rhm
+++ b/rhombus/rhombus/tests/match.rhm
@@ -69,3 +69,17 @@ check:
   0 matches (i :: Int when i mod 3 == 0) ~is #true
   1 matches (i :: Int unless i mod 3 == 0) ~is #true
   [1, 2, 3] matches ([x, ...] when math.sum(x, ...) == 6) ~is #true
+
+// make sure static info propagates
+block:
+  use_static
+  check:
+    match "s"
+    | s: s.length()
+    ~is 1
+  check:
+    use_static
+    match "s"
+    | _ :: Int: "can't happen"
+    | s: s.length()
+    ~is 1

--- a/rhombus/rhombus/tests/maybe.rhm
+++ b/rhombus/rhombus/tests/maybe.rhm
@@ -1,0 +1,55 @@
+#lang rhombus
+
+def fail_msg = "claimed not false, but actual value is false"
+
+check:
+  1 :: maybe(Int) ~is 1
+  #false :: maybe(Int) ~is #false
+  "x" :: maybe(Int) ~throws error.annot_msg()
+  0!! ~is 0
+  #false!! ~throws fail_msg
+  #false!! || #true ~throws fail_msg
+  #false!!.m() ~throws fail_msg
+  (1 :: maybe(Int))? + 10 ~is 11
+  (#false :: maybe(Int))? + 10 ~is #false
+  1? || 2 ~is 1
+  #false? || 2 ~is #false
+
+check:
+  ~eval
+  use_static
+  (dynamic("s") :: maybe(String)).length()
+  ~throws values("no such field or method",
+                 "based on static information")
+
+block:
+  use_static
+  check ("s" :: maybe(String))!!.length() ~is 1
+  check (dynamic("s") :: maybe(String))!!.length() ~is 1
+  check (#false :: maybe(String))!!.length() ~throws fail_msg
+  let s :: maybe(String) = dynamic("s")
+  check: match s
+         | s!!: s.length()
+         ~is 1
+  check: match (#false :: maybe(String))
+         | s!!: s.length()
+         | ~else: "no"
+         ~is "no"
+  check: []!!.length()
+         ~is 0
+  check: s?.length()
+         ~is 1
+  check: s?.copy().length()
+         ~is 1
+  check: (#false :: maybe(String))?.copy().length()
+         ~is #false
+  check: (#false :: maybe(String))?.copy()?.length()
+         ~is #false
+  check: 1 ? |> List
+         ~is [1]
+  check: #false ? |> List
+         ~is #false
+  check: #false ? |> List |> List
+         ~is #false
+  check: (#false ? |> List) |> List
+         ~is [#false]

--- a/rhombus/rhombus/tests/srcloc.rhm
+++ b/rhombus/rhombus/tests/srcloc.rhm
@@ -16,3 +16,11 @@ check:
   def s = dynamic(Srcloc("here", 1, 2, 3, 4))
   [s.source, s.line, s.column, s.position, s.span]
   ~is ["here", 1, 2, 3, 4]
+
+block:
+  use_static
+  let s = Srcloc("src", 1, 2, #false, 3)
+  check s.line!! < dynamic(0) ~is #false
+  check s.column!! < dynamic(0) ~is #false
+  check s.position!! < dynamic(0) ~throws "actual value is false"
+  check s.span!! < dynamic(0) ~is #false

--- a/rhombus/rhombus/tests/syntax-object.rhm
+++ b/rhombus/rhombus/tests/syntax-object.rhm
@@ -245,6 +245,10 @@ check:
   ~completes
 
 block:
+  use_static
+  check 'x'.srcloc()?.line ~is_a Int
+
+block:
   import:
     meta -1: rhombus/meta open
     lib("racket/base.rkt")


### PR DESCRIPTION
The `definitely` form is a destructor to go with the `maybe` constructor. As an expression, `definitely(expr)` produces the same result as `expr`, except that it errors if that result is `#false`. And if `expr` has static information from `maybe(annot)`, then `definitely(expr)` has the static information of `annot`. The `definitely(bind)` binding form matches only non-`#false` values that match `bind`. Using `definitely` is the same as writing `expr :: annot` or `bind :: annot`, except that you don't have to write out `annot`.

The commit also adjusts `match` to propagate static information from the target expression to binding patterns, which it should have done anyway, but is especially needed to make `definitely` work as intended.