### PR TITLE
Repair `RX.match_range` with missing captures

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/rx_object.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx_object.rhm
@@ -85,14 +85,14 @@ class RX(private _rkt_partial_rx,
 
   match_method match_range(input, start_pos, end_pos, output_port, input_prefix):
     MATCH base.#{regexp-match-positions}(_rkt_rx, input, start_pos, end_pos, output_port, input_prefix)
-    | PairList[Pair(s0, e0), Pair(s, e), ...]:
-        RXMatch(s0 .. e0, [Range.from_to(s, e), ...], _vars)
+    | PairList[Pair(s0, e0), maybe_pr, ...]:
+        RXMatch(s0 .. e0, [maybe_range(maybe_pr), ...], _vars)
     | ~else: #false
 
   match_method match_range_in(input, start_pos, end_pos, output_port, input_prefix):
     MATCH base.#{regexp-match-positions}(_rkt_partial_rx, input, start_pos, end_pos, output_port, input_prefix)
-    | PairList[Pair(s0, e0), Pair(s, e), ...]:
-        RXMatch(s0 .. e0, [Range.from_to(s, e), ...], _vars)
+    | PairList[Pair(s0, e0), maybe_pr, ...]:
+        RXMatch(s0 .. e0, [maybe_range(maybe_pr), ...], _vars)
     | ~else: #false
 
   match_method is_match(input, start_pos, end_pos, output_port, input_prefix):
@@ -171,6 +171,11 @@ fun from_handles(rx,
   unless base.#{regexp?}(partial_rx)
   | bad("partial-match")
   _RX(partial_rx, rx, num_captures, vars, has_backref, source)
+
+fun maybe_range(maybe_pr):
+  MATCH maybe_pr
+  | Pair(s, e): s .. e
+  | ~else: #false
 
 fun freeze(elem):
   match elem

--- a/rhombus/rhombus/tests/rx.rhm
+++ b/rhombus/rhombus/tests/rx.rhm
@@ -485,6 +485,11 @@ block:
   check r3.num_captures ~is 3
   check r3.capture_names ~is { #'a: 1, #'b: 3 }
 
+  let r4 = rx'"x" || "y" ~~ digit'
+  check tl(r4.match_range_in("y42")) ~is [0..2, 1..2]
+  check tl(r4.match_range_in("x")) ~is [0..1, #false]
+  check tl(r4.match_range_in("__x__")) ~is [2..3, #false]
+
 // Examples from Cooper Coradeschi's thesis
 block:
   // Cooper's original example:


### PR DESCRIPTION
If a capture is missing when performing one of the range matches the result will be `#false`.  This repairs that.