### PR TITLE
add `List.index`, `List.filter`, `List.partition`, and `random.shuffle`

### DIFF
--- a/rhombus-lib/rhombus/random.rhm
+++ b/rhombus-lib/rhombus/random.rhm
@@ -3,10 +3,13 @@ import:
   lib("racket/base.rkt") as rkt
   "private/amalgam/realm.rkt".#{rhombus-realm}
 
+use_static
+
 export:
   Random:
     only_space namespace annot expr
   RandomState
+  shuffle
 
 annot.macro 'RandomState':
   annot_meta.pack_predicate('rkt.#{pseudo-random-generator-vector?}', '()')
@@ -61,3 +64,14 @@ statinfo.macro 'current':
      )'
   let (_, _, statinfo) = annot_meta.unpack_converter(a)
   statinfo
+
+fun shuffle(l :: List, rnd :: Random = current()) :~ List:
+  // Fisher-Yates shuffle
+  let a = Array.make(l.length())
+  for (x: l,
+       i: 0..):
+    let j = rnd.random(i+1)
+    unless j == i
+    | a[i] := a[j]
+    a[j] := x
+  a.to_list()

--- a/rhombus/rhombus/scribblings/reference/list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/list.scrbl
@@ -534,17 +534,25 @@ it supplies its elements in order.
 
 
 @doc(
-  method (lst :: List).find(pred :: Function.of_arity(1)) :: Any
+  method (lst :: List).find(pred :: Function.of_arity(1))
+    :: Any
+  method (lst :: List).index(pred :: Function.of_arity(1))
+    :: maybe(NonnegInt)
 ){
 
- Returns the first element of @rhombus(lst) for which @rhombus(pred)
- returns true, @rhombus(#false) otherwise. Searching the list
- takes @math{O(N)} time (multiplied by the cost of @rhombus(pred))
- to find an element as position @math{N}.
+ The @rhombus(List.find) function finds the first element of
+ @rhombus(lst) for which @rhombus(pred) returns a true value, or it
+ returns @rhombus(#false) if no such element is found. The
+ @rhombus(List.find) function is similar, but it returns the index of the
+ found element instead of the element. Searching the list takes
+ @math{O(N)} time (multiplied by the cost of @rhombus(pred)) to find an
+ element as position @math{N}.
 
 @examples(
   [1, 2, 3].find((_ mod 2 .= 0))
   [1, 2, 3].find((_ mod 10 .= 9))
+  [1, 2, 3].index((_ mod 2 .= 0))
+  [1, 2, 3].index((_ mod 10 .= 9))
 )
 
 }
@@ -577,6 +585,37 @@ it supplies its elements in order.
   List.map([1, 2, 3], (_ + 1))
   [1, 2, 3].map((_ + 1))
   [1, 2, 3].for_each(println)
+)
+
+}
+
+
+@doc(
+  method (lst :: List).filter(
+    ~keep: keep_pred :: Function.of_arity(1),
+    ~skip: skip_pred :: Function.of_arity(1)
+  ) :: List,
+  method (lst :: List).partition(pred :: Function.of_arity(1))
+    :: values(List, List)
+){
+
+ The @rhombus(List.filter) function returns a list that is like
+ @rhombus(lst), but drops any element for which @rhombus(keep_pred)
+ returns @rhombus(#false) or @rhombus(skip_pred) returns a true value. If
+ @rhombus(keep_pred) returns @rhombus(#false) for a value, then
+ @rhombus(skip_pred) is not called for that value.
+
+ The @rhombus(List.partition) function returns two lists that are like
+ @rhombus(lst), but with complementary elements: the first result list
+ has elements for which @rhombus(pred) returns a true value, and the
+ second result list has elements for which @rhombus(pred) returns
+ @rhombus(#false).
+
+@examples(
+  [1, -1, -2, 2].filter(~keep: (_ > 0))
+  [1, -1, -2, 2].filter(~skip: (_ > 0))
+  [1, -1, -2, 2].filter(~keep: (_ != -2), ~skip: (_ > 0))
+  [1, -1, -2, 2].partition((_ > 0))
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/mutable-list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/mutable-list.scrbl
@@ -370,26 +370,32 @@ and it is not managed by a lock.
  cost of @rhombus(eqls)) to find an element as position @math{N}.
 
 @examples(
-  [1, 2, 3].has_element(2)
-  [1, 2, 3].has_element(200)
+  def l = MutableList[1, 2, 3]
+  l.has_element(2)
+  l.has_element(200)
 )
 
 }
 
 
 @doc(
-  method (mlst :: MutableList).find(pred :: Function.of_arity(1))
+  method (lst :: MutableList).find(pred :: Function.of_arity(1))
     :: Any
+  method (lst :: MutableList).index(pred :: Function.of_arity(1))
+    :: maybe(NonnegInt)
 ){
 
- Returns the first element of @rhombus(mlst) for which @rhombus(pred)
- returns true, @rhombus(#false) otherwise. Searching the list
- takes @math{O(N)} time (multiplied by the cost of @rhombus(pred))
- to find an element as position @math{N}.
+ Like @rhombus(List.find) and @rhombus(List.find) , but for
+ @tech{mutable lists}. Searching the list takes @math{O(N)} time
+ (multiplied by the cost of @rhombus(pred)) to find an element as
+ position @math{N}.
 
 @examples(
-  [1, 2, 3].find((_ mod 2 .= 0))
-  [1, 2, 3].find((_ mod 10 .= 9))
+  def l = MutableList[1, 2, 3]
+  l.find((_ mod 2 .= 0))
+  l.find((_ mod 10 .= 9))
+  l.index((_ mod 2 .= 0))
+  l.index((_ mod 10 .= 9))
 )
 
 }
@@ -425,6 +431,35 @@ and it is not managed by a lock.
   MutableList.map(l, (_ + 1))
   l
   l.for_each(println)
+)
+
+}
+
+
+@doc(
+  method (mlst :: MutableList).filter(
+    ~keep: keep_pred :: Function.of_arity(1),
+    ~skip: skip_pred :: Function.of_arity(1)
+  ) :: Void
+){
+
+ Like @rhombus(List.filter), but modifies @rhombus(mlst) by dropping
+ each element for which @rhombus(keep_pred) returns @rhombus(#false) or
+ @rhombus(skip_pred) returns a true value.
+
+@examples(
+  ~repl:
+    def l = MutableList[1, -1, -2, 2]
+    l.filter(~keep: (_ > 0))
+    l
+  ~repl:
+    def l = MutableList[1, -1, -2, 2]
+    l.filter(~skip: (_ > 0))
+    l
+  ~repl:
+    def l = MutableList[1, -1, -2, 2]
+    l.filter(~keep: (_ != -2), ~skip: (_ > 0))
+    l
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/pair.scrbl
+++ b/rhombus/rhombus/scribblings/reference/pair.scrbl
@@ -442,17 +442,21 @@ list is a pair, a pair is a pair list only if its ``rest'' is a list.
 
 
 @doc(
-  method (lst :: PairList).find(pred :: Function.of_arity(1)) :: Any
+  method (lst :: PairList).find(pred :: Function.of_arity(1))
+    :: Any
+  method (lst :: PairList).index(pred :: Function.of_arity(1))
+    :: maybe(NonnegInt)
 ){
 
- Returns the first element of @rhombus(lst) for which @rhombus(pred)
- return true, @rhombus(#false) otherwise. Searching the list
- takes @math{O(N)} time (multiplied by the cost of @rhombus(pred))
- to find an element as position @math{N}.
+ Like @rhombus(List.find) and @rhombus(List.find) , but for @tech{pair
+  lists}. Searching the list takes @math{O(N)} time (multiplied by the
+ cost of @rhombus(pred)) to find an element as position @math{N}.
 
 @examples(
   PairList[1, 2, 3].find((_ mod 2 .= 0))
   PairList[1, 2, 3].find((_ mod 10 .= 9))
+  PairList[1, 2, 3].index((_ mod 2 .= 0))
+  PairList[1, 2, 3].index((_ mod 10 .= 9))
 )
 
 }
@@ -485,6 +489,28 @@ list is a pair, a pair is a pair list only if its ``rest'' is a list.
   PairList.map(PairList[1, 2, 3], (_ + 1))
   PairList[1, 2, 3].map((_ + 1))
   PairList[1, 2, 3].for_each(println)
+)
+
+}
+
+
+@doc(
+  method (lst :: PairList).filter(
+    ~keep: keep_pred :: Function.of_arity(1),
+    ~skip: skip_pred :: Function.of_arity(1)
+  ) :: PairList,
+  method (lst :: PairList).partition(pred :: Function.of_arity(1))
+    :: values(PairList, PairList)
+){
+
+ List @rhombus(List.filter) and @rhombus(List.partition), but for
+ @tech{pair lists}.
+
+@examples(
+  PairList[1, -1, -2, 2].filter(~keep: (_ > 0))
+  PairList[1, -1, -2, 2].filter(~skip: (_ > 0))
+  PairList[1, -1, -2, 2].filter(~keep: (_ != -2), ~skip: (_ > 0))
+  PairList[1, -1, -2, 2].partition((_ > 0))
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/random.scrbl
+++ b/rhombus/rhombus/scribblings/reference/random.scrbl
@@ -64,3 +64,22 @@
  @rhombus(4294944442), inclusive.
 
 }
+
+@doc(
+  fun shuffle(lst :: List, rnd :: Random = Random.current())
+    :: List
+){
+
+ Returns a list with the same elements as @rhombus(lst), but in a random
+ order, where @rhombus(rnd) is used for randomization.
+
+@examples(
+  ~hidden:
+    import rhombus/random open
+    // make result deterministic
+    Random.current(Random(Array(1, 2, 3, 4, 5, 6)))
+  ~repl:
+    shuffle([1, 2, 3, 4])
+)
+
+}

--- a/rhombus/rhombus/tests/list.rhm
+++ b/rhombus/rhombus/tests/list.rhm
@@ -16,8 +16,11 @@ block:
     List.rest(lst)
     List.map(lst, proc) ~method
     List.for_each(lst, proc) ~method
+    List.filter(lst) ~method
+    List.partition(lst, proc) ~method
     List.has_element(lst, val, [eql]) ~method
     List.find(lst, pred) ~method
+    List.index(lst, pred) ~method
     List.remove(lst, val) ~method
     List.delete(lst, i) ~method
     List.insert(lst, i, val) ~method
@@ -323,11 +326,21 @@ check:
   ~is [1, 2]
 
 block:
+  use_static
   check [1, 2].map(fun (x): x + 1).reverse() ~is [3, 2]
   block:
     def mutable sum = 0
     check [1, 2].for_each(fun (x): sum := sum + x) ~is #void
     check sum ~is 3
+  check [1, 3, 2, 4].filter(~keep: (_ > 2)) ~is [3, 4]
+  check [1, 3, 2, 4].filter(~skip: (_ > 2)) ~is [1, 2]
+  check [1, 3, 2, 4].filter(~keep: (_ > 1), ~skip: (_ > 3)) ~is [3, 2]
+  check [1, 3, 2, 4].filter(~keep: (_ > 2)).length() ~is 2
+  check [1, 3, 2, 4].partition((_ > 2)) ~is values([3, 4], [1, 2])
+  check:
+    let (a, b) = [1, 3, 2, 4].partition((_ > 2))
+    [a.length(), b.length()]
+    ~is [2, 2]
 
 check:
   List.append(& [[1, 2], [3], [4, 5]]) ~is [1, 2, 3, 4, 5]
@@ -358,6 +371,9 @@ check:
   [1, 2, 3].find(fun (x): x > 1) ~is 2
   [1, 2, 3].find(fun (x): x > 10) ~is #false
   dynamic([1, 2, 3]).find(fun (x): x > 1) ~is 2
+  [1, 2, 3].index(fun (x): x > 1) ~is 1
+  [1, 2, 3].index(fun (x): x > 10) ~is #false
+  dynamic([1, 2, 3]).index(fun (x): x > 1) ~is 1
 
 check:
   [1, 2, 3].remove(2) ~is [1, 3]

--- a/rhombus/rhombus/tests/mutable-list.rhm
+++ b/rhombus/rhombus/tests/mutable-list.rhm
@@ -12,8 +12,10 @@ block:
     MutableList.set(lst, i, v) ~method
     MutableList.map(lst, proc) ~method
     MutableList.for_each(lst, proc) ~method
+    MutableList.filter(lst) ~method
     MutableList.has_element(lst, val, [eql]) ~method
     MutableList.find(lst, pred) ~method
+    MutableList.index(lst, pred) ~method
     MutableList.remove(lst, val) ~method
     MutableList.delete(lst, i) ~method
     MutableList.insert(lst, i, val) ~method
@@ -180,6 +182,18 @@ block:
     def mutable sum = 0
     check l.for_each(fun (x): sum := sum + x) ~is #void
     check sum ~is 5
+  block:
+    let l = MutableList[1, 3, 2, 4]
+    l.filter(~keep: (_ > 2))
+    check l ~is_now MutableList[3, 4]
+  block:
+    let l = MutableList[1, 3, 2, 4]
+    l.filter(~skip: (_ > 2))
+    check l ~is_now MutableList[1, 2]
+  block:
+    let l = MutableList[1, 3, 2, 4]
+    l.filter(~keep: (_ > 1), ~skip: (_ > 3))
+    check l ~is_now MutableList[3, 2]
 
 check:
   MutableList[1, 2, 3].has_element(2) ~is #true
@@ -193,6 +207,9 @@ check:
   MutableList[1, 2, 3].find(fun (x): x > 1) ~is 2
   MutableList[1, 2, 3].find(fun (x): x > 10) ~is #false
   dynamic(MutableList[1, 2, 3]).find(fun (x): x > 1) ~is 2
+  MutableList[1, 2, 3].index(fun (x): x > 1) ~is 1
+  MutableList[1, 2, 3].index(fun (x): x > 10) ~is #false
+  dynamic(MutableList[1, 2, 3]).index(fun (x): x > 1) ~is 1
 
 check:
   (block: let l = MutableList[1, 2, 3]; l.remove(2); l) ~is_now MutableList[1, 3]

--- a/rhombus/rhombus/tests/pairlist.rhm
+++ b/rhombus/rhombus/tests/pairlist.rhm
@@ -14,8 +14,11 @@ block:
     PairList.rest(lst)
     PairList.map(lst, proc) ~method
     PairList.for_each(lst, proc) ~method
+    List.filter(lst) ~method
+    List.partition(lst, proc) ~method
     PairList.has_element(lst, val, [eql]) ~method
     PairList.find(lst, pred) ~method
+    PairList.index(lst, pred) ~method
     PairList.remove(lst, val) ~method
     PairList.reverse(lst) ~method
     PairList.append(lst, ...) ~method
@@ -276,11 +279,21 @@ check:
   ~is PairList[1, 2]
 
 block:
+  use_static
   check PairList[1, 2].map(fun (x): x + 1).reverse() ~is PairList[3, 2]
   block:
     def mutable sum = 0
     check PairList[1, 2].for_each(fun (x): sum := sum + x) ~is #void
     check sum ~is 3
+  check PairList[1, 3, 2, 4].filter(~keep: (_ > 2)) ~is PairList[3, 4]
+  check PairList[1, 3, 2, 4].filter(~skip: (_ > 2)) ~is PairList[1, 2]
+  check PairList[1, 3, 2, 4].filter(~keep: (_ > 1), ~skip: (_ > 3)) ~is PairList[3, 2]
+  check PairList[1, 3, 2, 4].filter(~keep: (_ > 2)).length() ~is 2
+  check PairList[1, 3, 2, 4].partition((_ > 2)) ~is values(PairList[3, 4], PairList[1, 2])
+  check:
+    let (a, b) = PairList[1, 3, 2, 4].partition((_ > 2))
+    [a.length(), b.length()]
+    ~is [2, 2]
 
 check:
   PairList.append(& PairList[PairList[1, 2], PairList[3], PairList[4, 5]]) ~is PairList[1, 2, 3, 4, 5]
@@ -311,6 +324,9 @@ check:
   PairList[1, 2, 3].find(fun (x): x > 1) ~is 2
   PairList[1, 2, 3].find(fun (x): x > 10) ~is #false
   dynamic(PairList[1, 2, 3]).find(fun (x): x > 1) ~is 2
+  PairList[1, 2, 3].index(fun (x): x > 1) ~is 1
+  PairList[1, 2, 3].index(fun (x): x > 10) ~is #false
+  dynamic(PairList[1, 2, 3]).index(fun (x): x > 1) ~is 1
 
 check:
   PairList[1, 2, 3].remove(2) ~is PairList[1, 3]

--- a/rhombus/rhombus/tests/random.rhm
+++ b/rhombus/rhombus/tests/random.rhm
@@ -88,3 +88,10 @@ check:
       when v < 50 || v > 150
       | error("bad sample")
   ~completes
+
+block:
+  use_static
+  let l = [1, 2, 3, 4, 5]
+  check shuffle(l) ~is_a List
+  check shuffle(l).length() ~is 5
+  check Set(& shuffle(l)) ~is Set(& l)


### PR DESCRIPTION
Include similar methods for `PairList` and `MutableList`, but not `MutableList.partition`.

See also racket/racket#5106.