### PR TITLE
fill out `Port` API

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/builtin-dot.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/builtin-dot.rkt
@@ -2,6 +2,7 @@
 (require "mutability.rkt"
          "treelist.rkt"
          "mutable-treelist.rkt"
+         "port-pipe.rkt"
          (submod "dot.rkt" for-builtin)
          (submod "map.rkt" for-builtin)
          (submod "set.rkt" for-builtin)
@@ -18,6 +19,13 @@
          (submod "srcloc-object.rkt" for-builtin)
          (submod "port.rkt" for-builtin)
          (submod "exn-object.rkt" for-builtin))
+
+(define (merge ht ht2)
+  (if ht
+      (if ht2
+          (cons ht ht2)
+          ht)
+      ht2))
 
 (define (builtin->accessor-ref v)
   (cond
@@ -39,10 +47,22 @@
     [(path? v) path-method-table]
     [(srcloc? v) srcloc-method-table]
     [(exn? v) (get-exn-method-table v)]
-    [(input-port? v) input-port-method-table]
-    [(output-port? v) (if (string-port? v)
-                          output-string-port-method-table
-                          output-port-method-table)]
+    [(input-port? v) (merge
+                      (if (port-provides-progress-evts? v)
+                          input-progress-port-method-table
+                          input-port-method-table)
+                      (merge
+                       (and (port-pipe? v) port-pipe-method-table)
+                       (and (file-stream-port? v) file-stream-port-method-table)))]
+    [(output-port? v) (merge
+                       (if (string-port? v)
+                           output-string-port-method-table
+                           (if (port-writes-special? v)
+                               output-special-port-method-table
+                               output-port-method-table))
+                       (merge
+                        (and (port-pipe? v) port-pipe-method-table)
+                        (and (file-stream-port? v) file-stream-port-method-table)))]
     [(box? v) box-method-table]
     [(mutable-treelist? v) mutable-treelist-method-table]
     [else #f]))

--- a/rhombus-lib/rhombus/private/amalgam/dot-provider-key.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/dot-provider-key.rkt
@@ -3,49 +3,103 @@
          "static-info.rkt"
          "dot-space.rkt")
 
-(provide (for-syntax extract-dot-provider-id))
+(provide (for-syntax extract-dot-provider-ids))
+
+;; A `#%dot-provider` value is either
+;;  * identifier      ; equivalent to (list identifier)
+;;  * (alts alts ...) ; search just first `alts`; rest are "supertypes" for finding common on intersection
+;;
+;; A alts is
+;;  * identifer             ; equivakent to (list identifier)
+;;  * (list identifier ...) ; created by union; try each `identifier` until success
+;;
+;; It's possible for the search through on alts list to be ambigious, especially
+;; if a non-checking `:~` is used with a `&&` annotation. Absent a good idea on
+;; how to check that, the strategy here is to just try left-to-right.
 
 (define-static-info-key-syntax/provide #%dot-provider
   (static-info-key (lambda (a b)
-                     (cond
-                       [(and (identifier? a) (identifier? b))
-                        (static-info-identifier-union a b)]
-                       [else
-                        ;; use `b` if it's more information than `a`, otherwise use `a`:
-                        (let ([as (if (identifier? a) (list a) (syntax->list a))]
-                              [bs (if (identifier? b) (list b) (syntax->list b))])
-                          (or (and as
-                                   bs
-                                   (let ([a-len (length as)]
-                                         [b-len (length bs)])
-                                     (and (> b-len a-len)
-                                          (for/or ([a (in-list as)]
-                                                   [b (in-list (list-tail bs (- b-len a-len)))])
-                                            (free-identifier=? (in-dot-provider-space a)
-                                                               (in-dot-provider-space b)))))
-                                   b)
-                              a))]))
+                     (merge-lists a b))
                    (lambda (a b)
-                     (let ([as (if (identifier? a) (list a) (syntax->list a))]
-                           [bs (if (identifier? b) (list b) (syntax->list b))])
-                       (and as
-                            bs
-                            (let ([a-len (length as)]
-                                  [b-len (length bs)])
-                              (for/fold ([common '()]
-                                         #:result (and (pair? common)
-                                                       (if (null? (cdr common))
-                                                           (car common)
-                                                           common)))
-                                        ([a (in-list (reverse (list-tail as (max 0 (- a-len b-len)))))]
-                                         [b (in-list (reverse (list-tail bs (max 0 (- b-len a-len)))))])
-                                #:break (not (free-identifier=? (in-dot-provider-space a)
-                                                                (in-dot-provider-space b)))
-                                (cons a common))))))))
+                     (common-tail a b))))
 
-(define-for-syntax (extract-dot-provider-id dp-id/s)
+(define-for-syntax (merge-lists a b)
+  (let ([as (if (identifier? a) (list a) (syntax->list a))]
+        [bs (if (identifier? b) (list b) (syntax->list b))])
+    (cond
+      [(not (pair? as)) b] ; defensive check: use other if one is ill-formed or empty
+      [(not (pair? bs)) a] ; ditto
+      [else
+       ;; both lists are non-empty, so we can pad by duplicating the first
+       (define a-len (length as))
+       (define b-len (length bs))
+       (map union-alts-ids
+            (pad as (- b-len a-len))
+            (pad bs (- a-len b-len)))])))
+
+(define-for-syntax (union-alts-ids a b)
+  (let ([as (if (identifier? a) (list a) (syntax->list a))]
+        [bs (if (identifier? b) (list b) (syntax->list b))])
+    (cond
+      [(not as) b]
+      [(not bs) a]
+      [else
+       (append
+        (for/list ([a (in-list as)]
+                   #:unless (for/or ([b (in-list bs)])
+                              (free-identifier=? (in-dot-provider-space a)
+                                                 (in-dot-provider-space b))))
+          a)
+        bs)])))
+
+(define-for-syntax (common-tail a b)
+  (let ([as (if (identifier? a) (list a) (syntax->list a))]
+        [bs (if (identifier? b) (list b) (syntax->list b))])
+    (and as ; defensive check
+         bs ; ditto
+         (let ([a-len (length as)]
+               [b-len (length bs)])
+           (for/fold ([common '()]
+                      #:result (and (pair? common)
+                                    (if (and (null? (cdr common))
+                                             (identifier? (car common)))
+                                        (car common)
+                                        common)))
+                     ([a (in-list (reverse (list-tail as (max 0 (- a-len b-len)))))]
+                      [b (in-list (reverse (list-tail bs (max 0 (- b-len a-len)))))])
+             (define sames (common-alts-ids a b))
+             #:break (null? sames)
+             (if (null? (cdr sames))
+                 (cons (car sames) common)
+                 (cons sames common)))))))
+
+(define-for-syntax (common-alts-ids a b)
+  (let ([as (if (identifier? a) (list a) (syntax->list a))]
+        [bs (if (identifier? b) (list b) (syntax->list b))])
+    (cond
+      [(not as) null]
+      [(not bs) null]
+      [else
+       (for/list ([a (in-list as)]
+                  #:when (for/or ([b (in-list bs)])
+                           (free-identifier=? (in-dot-provider-space a)
+                                              (in-dot-provider-space b))))
+         a)])))
+
+(define-for-syntax (pad l n)
+  (if (n . > . 0)
+      (append
+       (for/list ([i (in-range n)]) (car l))
+       l)
+      l))
+
+(define-for-syntax (extract-dot-provider-ids dp-id/s)
   (cond
-    [(not dp-id/s) #false]
-    [(identifier? dp-id/s) dp-id/s]
-    [(pair? (syntax-e dp-id/s)) (car (syntax-e dp-id/s))]
-    [else #f]))
+    [(not dp-id/s) null]
+    [(identifier? dp-id/s) (list dp-id/s)]
+    [(pair? (syntax-e dp-id/s))
+     (let ([id/s (car (syntax-e dp-id/s))])
+       (if (identifier? id/s)
+           (list id/s)
+           (or (syntax->list id/s) null)))]
+    [else null]))

--- a/rhombus-lib/rhombus/private/amalgam/filesystem.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/filesystem.rhm
@@ -413,12 +413,12 @@ namespace filesystem:
     read([])
 
   fun read_lines(path :: PathString,
-                 ~mode: mode :: Port.ReadLineMode = #'any) :: List.of(String):
+                 ~mode: mode :: Port.Input.ReadLineMode = #'any) :: List.of(String):
     ~who: who
     content_lines(who, path, mode, Port.Input.read_line)
 
   fun read_bytes_lines(path :: PathString,
-                       ~mode: mode :: Port.ReadLineMode = #'any) :: List.of(Bytes):
+                       ~mode: mode :: Port.Input.ReadLineMode = #'any) :: List.of(Bytes):
     ~who: who
     content_lines(who, path, mode, Port.Input.read_bytes_line)
 
@@ -426,6 +426,7 @@ namespace filesystem:
     Closeable.let out = (rkt_error.local_error_adjust { #'#{open-output-file}: who }:
                            rkt.#{open-output-file}(path, ~mode: mode, ~exists: exists))
     write(out, s)
+    #void
 
   fun write_string(path :: PathString,
                    str :: String,

--- a/rhombus-lib/rhombus/private/amalgam/port-pipe.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port-pipe.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+(provide port-pipe?)
+
+(define (port-pipe? v)
+  (and (port? v)
+       (with-handlers ([exn:fail? (lambda (x) #f)])
+         (pipe-content-length v))))
+

--- a/rhombus-lib/rhombus/private/amalgam/port-using.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port-using.rkt
@@ -1,0 +1,86 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre)
+         "expression.rkt"
+         "parse.rkt"
+         "parens.rkt"
+         "annotation-failure.rkt"
+         "error-adjust.rkt")
+
+(provide Port.Input.using
+         Port.Output.using)
+
+(define-for-syntax (build-using who what port? close param pre e blk)
+  (syntax-parse blk
+    [(tag::block body ...+)
+     (values
+      #`(call-with-continuation-barrier
+         (lambda ()
+           (let ([p #f]
+                 [pre #,pre])
+             (#||# dynamic-wind
+              (lambda ()
+                (set! p #,e)
+                (unless (#,port? p)
+                  (raise-annotation-failure '#,who '#,what p)))
+              (lambda ()
+                (parameterize ([#,param p])
+                  (rhombus-body-at tag body ...)))
+              (lambda ()
+                (#,close p))))))
+      #'())]
+    [(tag::block)
+     (raise-syntax-error who "empty body" blk)]))
+
+(define-syntax Port.Input.using
+  (expression-transformer
+   (lambda (stx)
+     (define (build pre e blk pred)
+       (build-using 'Port.Input.using "Port.Input" pred #'close-input-port #'current-input-port pre e blk))
+     (syntax-parse stx
+       #:datum-literals (group)
+       [(_ #:file t ... (~and blk (_::block . _)))
+        #:with e::expression #'(group t ...)
+        (build #'e.parsed #'(open-input-file* pre) #'blk #'(lambda (x) #t))]
+       [(_ t ... (~and blk (_::block body . _)))
+        #:with e::expression #'(group t ...)
+        (build #'#f #'e.parsed #'blk #'input-port?)]))))
+
+(define-syntax Port.Output.using
+  (expression-transformer
+   (lambda (stx)
+     (define (build pre e blk pred)
+       (build-using 'Port.Output.using "Port.Output" pred #'close-output-port #'current-output-port pre e blk))
+     (syntax-parse stx
+       #:datum-literals (group)
+       [(_ #:file t ... (tag::block
+                         (group #:exists (xtag::block xbody ...+))
+                         body ...))
+        #:with e::expression #'(group t ...)
+        (build #'(rhombus-body-at xtag xbody ...)
+               #'(open-output-file* e.parsed pre)
+               (datum->syntax #f (syntax-e #'(tag body ...)))
+               #'(lambda (x) #t))]
+       [(_ #:file t ... (tag::block
+                         (group #:exists tx ...+)
+                         body ...))
+        #:with e::expression #'(group t ...)
+        #:with ex::expression #'(group tx ...)
+        (build #'(cons e.parsed ex.parsed)
+               #'(open-output-file* (car pre) (cdr pre))
+               (datum->syntax #f (syntax-e #'(tag body ...)))
+                #'(lambda (x) #t))]
+       [(_ #:file t ... (~and blk (_::block . _)))
+        #:with e::expression #'(group t ...)
+        (build #'e.parsed #'(open-output-file* pre 'error) #'blk #'(lambda (x) #t))]
+       [(_ t ... (~and blk (_::block . _)))
+        #:with e::expression #'(group t ...)
+        (build #'#f #'e.parsed #'blk #'output-port?)]))))
+
+(define (open-input-file* p)
+  (with-error-adjust-primitive ([open-input-file Port.Input.using])
+    (open-input-file p)))
+
+(define (open-output-file* p exists)
+  (with-error-adjust-primitive ([open-input-file Port.Output.using])
+    (open-output-file p #:exists exists)))

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -2,6 +2,9 @@
 (require (for-syntax racket/base
                      syntax/parse/pre
                      shrubbery/print)
+         racket/private/port
+         "expression.rkt"
+         "port-pipe.rkt"
          "provide.rkt"
          (submod "annotation.rkt" for-class)
          "call-result-key.rkt"
@@ -11,70 +14,118 @@
          "static-info.rkt"
          "define-arity.rkt"
          (submod "function.rkt" for-info)
+         (submod "map.rkt" for-info)
          "class-primitive.rkt"
          "realm.rkt"
          "enum.rkt"
          "binding.rkt"
          "literal.rkt"
          (submod "print.rkt" for-port)
+         "port-using.rkt"
          "rename-parameter.rkt"
-         "rhombus-primitive.rkt")
+         "rhombus-primitive.rkt"
+         "error-adjust.rkt")
 
 (provide (for-spaces (rhombus/annot
                       rhombus/namespace)
-                     Port))
+                     Port)
+         stdin
+         stdout
+         stderr)
 
 (module+ for-builtin
   (provide input-port-method-table
            output-port-method-table
-           output-string-port-method-table))
+           output-string-port-method-table
+           file-stream-port-method-table
+           port-pipe-method-table
+           input-progress-port-method-table
+           output-special-port-method-table))
 
 (define-primitive-class Port port
+  #:lift-declaration
   #:existing
   #:just-annot
   #:fields ()
   #:namespace-fields
   ([Input Port.Input]
    [Output Port.Output]
+   [FileStream Port.FileStream]
+   [Pipe Port.Pipe]
    EOF
    [eof Port.eof]
+   [open_input_output_file Port.open_input_output_file]
+   [current_enable_locations Port.current_enable_locations]
    Mode
-   ReadLineMode)
+   BufferMode
+   WaitMode)
   #:properties ()
-  #:methods ())
+  #:methods
+  (close
+   is_closed
+   buffer
+   position
+   locations_enabled
+   next_location))
 
 (define-primitive-class Port.Input input-port
   #:lift-declaration
   #:existing
   #:just-annot
+  #:parent Port port
   #:fields ()
   #:namespace-fields
   ([String Port.Input.String]
+   [Progress Port.Input.Progress]
    [current Port.Input.current]
    [open_bytes Port.Input.open_bytes]
    [open_file Port.Input.open_file]
-   [open_string Port.Input.open_string])
+   [open_string Port.Input.open_string]
+   [open_nowhere Port.Input.open_nowhere]
+   [using Port.Input.using]
+   ReadLineMode)
   #:properties ()
   #:methods
   ([close Port.Input.close]
    [peek_byte Port.Input.peek_byte]
    [peek_bytes Port.Input.peek_bytes]
+   [peek_bytes_to Port.Input.peek_bytes_to]
    [peek_char Port.Input.peek_char]
    [peek_string Port.Input.peek_string]
+   [peek_string_to Port.Input.peek_string_to]
    [read_byte Port.Input.read_byte]
    [read_bytes Port.Input.read_bytes]
+   [read_bytes_to Port.Input.read_bytes_to]
    [read_char Port.Input.read_char]
    [read_line Port.Input.read_line]
    [read_bytes_line Port.Input.read_bytes_line]
-   [read_string Port.Input.read_string]))
+   [read_string Port.Input.read_string]
+   [read_string_to Port.Input.read_string_to]
+   [copy_to Port.Input.copy_to]))
+
+(define-primitive-class Port.Input.Progress input-progress-port
+  #:lift-declaration
+  #:existing
+  #:just-annot
+  #:parent Input.Port input-port
+  #:fields ()
+  #:namespace-fields
+  ()
+  #:properties ()
+  #:methods
+  ([evt Port.Input.Progress.evt]
+   [is_evt Port.Input.Progress.is_evt]
+   [commit Port.Input.Progress.commit]))
 
 (define-primitive-class Port.Output output-port
   #:lift-declaration
   #:existing
   #:just-annot
+  #:parent Port port
   #:fields ()
   #:namespace-fields
   ([String Port.Output.String]
+   [Special Port.Output.Special]
    [current Port.Output.current]
    [current_error Port.Output.current_error]
    [open_bytes Port.Output.open_bytes]
@@ -82,11 +133,15 @@
    [open_string Port.Output.open_string]
    [get_bytes Port.Output.String.get_bytes]    ;; temporary: to be removed
    [get_string Port.Output.String.get_string]  ;; temporary: to be removed
-   ExistsMode)
+   [open_nowhere Port.Output.open_nowhere]
+   ExistsMode
+   [using Port.Output.using])
   #:properties ()
   #:methods
   ([close Port.Output.close]
    [flush Port.Output.flush]
+   [write_byte Port.Output.write_byte]
+   [write_char Port.Output.write_char]
    [write_bytes Port.Output.write_bytes]
    [write_string Port.Output.write_string]
    [print Port.Output.print]
@@ -94,12 +149,68 @@
    [show Port.Output.show]
    [showln Port.Output.showln]))
 
+(define-primitive-class Port.Output.Special output-special-port
+  #:lift-declaration
+  #:existing
+  #:just-annot
+  #:parent Output.Port output-port
+  #:fields ()
+  #:namespace-fields
+  ()
+  #:properties ()
+  #:methods
+  ([write Port.Output.Special.write]))
+
+(define-primitive-class Port.FileStream file-stream-port
+  #:lift-declaration
+  #:existing
+  #:just-annot
+  #:parent Port port
+  #:fields ()
+  #:namespace-fields
+  ([Terminal Port.FileStream.Terminal]
+   LockMode)
+  #:properties ()
+  #:methods
+  (identity
+   stat
+   truncate
+   is_waiting_on_peer
+   try_lock
+   unlock))
+
+(define-primitive-class Port.Pipe port-pipe
+  #:lift-declaration
+  #:existing
+  #:just-annot
+  #:parent Port port
+  #:fields ()
+  #:namespace-fields
+  ([make Port.Pipe.make])
+  #:properties ()
+  #:methods
+  (content_length))
+
 (define (input-string-port? v)
   (and (input-port? v)
        (string-port? v)))
 
+(define (input-progress-port? p)
+  (and (input-port? p)
+       (port-provides-progress-evts? p)))
+
+(define (output-special-port? p)
+  (and (output-port? p)
+       (port-writes-special? p)))
+
 (define-annotation-syntax Port.Input.String
   (identifier-annotation input-string-port? #,(get-input-port-static-infos)))
+
+(define-annotation-syntax Port.FileStream.Terminal
+  (identifier-annotation terminal-port? #,(get-port-static-infos)))
+
+(define-annotation-syntax Port.Output.Atomic
+  (identifier-annotation output-atomic-port? #,(get-output-port-static-infos)))
 
 (define (output-string-port? v)
   (and (output-port? v)
@@ -125,6 +236,9 @@
 (set-primitive-who! 'current-output-port 'Port.Output.current)
 (define Port.Output.current_error (rename-parameter current-error-port 'Port.Output.current_error))
 (set-primitive-who! 'current-error-port 'Port.Output.current_error)
+
+(define Port.current_enable_locations
+  (rename-parameter port-count-lines-enabled 'Port.current_enable_locations))
 
 (define-static-info-syntax Port.Input.current
   (#%function-arity 3)
@@ -169,6 +283,25 @@
   [can_update can-update]
   append)
 
+(define-simple-symbol-enum BufferMode
+  none
+  line
+  block)
+
+(define-simple-symbol-enum LockMode
+  shared
+  exclusive)
+
+(define-simple-symbol-enum WaitMode
+  all
+  some
+  none
+  enable_break)
+
+(define (check-port who op)
+  (unless (port? op)
+    (raise-annotation-failure who op "Port")))
+
 (define (check-input-port who ip)
   (unless (input-port? ip)
     (raise-annotation-failure who ip "Port.Input")))
@@ -187,7 +320,9 @@
 (define/arity (Port.Input.open_file path
                                     #:mode [mode 'binary])
   #:primitive (open-input-file)
-  #:static-infos ((#%call-result #,(get-input-port-static-infos)))
+  #:static-infos ((#%call-result #,(static-infos-union
+                                    (get-input-port-static-infos)
+                                    (get-file-stream-port-static-infos))))
   (open-input-file path #:mode mode))
 
 (define/arity Port.Input.open_string
@@ -204,13 +339,19 @@
     [() (open-output-bytes)]
     [(name) (open-output-bytes name)]))
 
+(define/arity (Port.Input.open_nowhere #:name [name 'nowhere])
+  #:static-infos ((#%call-result #,(get-input-port-static-infos)))
+  (open-input-nowhere name))
+
 (define/arity (Port.Output.open_file path
                                      #:exists [exists-in 'error]
                                      #:mode [mode 'binary]
                                      #:permissions [permissions #o666]
                                      #:replace_permissions [replace-permissions? #f])
   #:primitive (open-output-file)
-  #:static-infos ((#%call-result #,(get-output-port-static-infos)))
+  #:static-infos ((#%call-result #,(static-infos-union
+                                    (get-output-port-static-infos)
+                                    (get-file-stream-port-static-infos))))
   (define exists (->ExistsMode exists-in))
   (unless exists
     (raise-annotation-failure who exists-in "Port.Output.ExistsMode"))
@@ -227,6 +368,117 @@
     [() (open-output-string)]
     [(name) (open-output-string name)]))
 
+(define/arity (Port.Output.open_nowhere #:name [name 'nowhere])
+  #:static-infos ((#%call-result #,(get-output-port-static-infos)))
+  (open-output-nowhere name))
+
+(define/arity (Port.open_input_output_file path
+                                           #:exists [exists-in 'error]
+                                           #:mode [mode 'binary]
+                                           #:permissions [permissions #o666]
+                                           #:replace_permissions [replace-permissions? #f])
+  #:primitive (open-input-output-file)
+  #:static-infos ((#%call-result ((#%values (#,(get-input-port-static-infos)
+                                             #,(get-output-port-static-infos))))))
+  (define exists (->ExistsMode exists-in))
+  (unless exists
+    (raise-annotation-failure who exists-in "Port.Output.ExistsMode"))
+  (open-input-output-file path
+                          #:exists exists
+                          #:mode mode
+                          #:permissions permissions
+                          #:replace-permissions? replace-permissions?))
+
+(define/arity (Port.Pipe.make #:limit [limit #f]
+                              #:input_name [input-name 'pipe]
+                              #:output_name [output-name 'pipe])
+  #:primitive (make-pipe)
+  #:static-infos ((#%call-result ((#%values (#,(static-infos-union
+                                                (get-input-port-static-infos)
+                                                (get-port-pipe-static-infos))
+                                             #,(static-infos-union
+                                                (get-output-port-static-infos)
+                                                (get-port-pipe-static-infos)))))))
+  (make-pipe limit input-name output-name))
+
+(define/method (Port.Pipe.content_length p)
+  #:primitive (pipe-content-length)
+  (pipe-content-length p))
+
+(define/method (Port.is_closed p)
+  #:primitive (port-closed?)
+  (port-closed? p))
+
+(define/method (Port.close port)
+  (cond
+    [(input-port? port) (close-input-port port)]
+    [(output-port? port) (close-output-port port)]
+    [else (raise-annotation-failure who port "Port")]))
+
+(define/method Port.buffer
+  #:primitive (file-stream-buffer-mode)
+  (case-lambda
+    [(p)
+     (check-port who p)
+     (file-stream-buffer-mode p)]
+    [(p m)
+     (check-port who p)
+     (unless (BufferMode? m) (raise-annotation-failure who m "BufferMode"))
+     (file-stream-buffer-mode p m)]))
+
+(define/method Port.position
+  #:primitive (port-position)
+  (case-lambda
+    [(p)
+     (check-port who p)
+     (file-position p)]
+    [(p pos)
+     (check-port who p)
+     (unless (exact-nonnegative-integer? pos) (raise-annotation-failure who pos "NonnegInt"))
+     (file-position p pos)]))
+
+(define/method Port.locations_enabled
+  #:primitive (port-count-lines! port-counts-lines?)
+  (case-lambda
+    [(p) (port-counts-lines? p)]
+    [(p on?) (when on? (port-count-lines! p))]))
+
+(define/method Port.next_location
+  #:primitive (port-next-location)
+  (case-lambda
+    [(p) (port-next-location p)]
+    [(p line col offset)
+     (with-error-adjust-primitive ([set-port-next-location! Port.next_location])
+       (set-port-next-location! p line col offset))]))
+
+(define/method (Port.FileStream.identity p)
+  #:primitive (port-file-identity)
+  (port-file-identity p))
+
+(define/method (Port.FileStream.stat p)
+  #:primitive (port-file-stat)
+  #:static-infos ((#%call-result #,(get-map-static-infos)))
+  (port-file-stat p))
+
+(define/method (Port.FileStream.truncate p size)
+  #:primitive (file-truncate)
+  (file-truncate p size))
+
+(define/method (Port.FileStream.is_waiting_on_peer p)
+  #:primitive (file-truncate)
+  (unless (file-stream-port? p) (raise-annotation-failure who p "Port.FileStream"))
+  (port-waiting-peer? p))
+
+(define/method (Port.FileStream.try_lock p mode)
+  #:primitive (port-try-file-lock?)
+  (unless (file-stream-port? p) (raise-annotation-failure who p "Port.FileStream"))
+  (unless (LockMode? mode) (raise-annotation-failure who mode "Port.FileStream.LockMode"))
+  (port-try-file-lock? p mode))
+
+(define/method (Port.FileStream.unlock p)
+  #:primitive (port-file-unlock)
+  (port-file-unlock p))
+
 (define (coerce-read-result v)
   (cond
     [(string? v) (string->immutable-string v)]
@@ -236,34 +488,99 @@
   #:primitive (close-input-port)
   (close-input-port port))
 
-(define/method (Port.Input.peek_byte port #:skip_bytes [skip 0])
-  #:primitive (peek-byte)
-  (peek-byte port skip))
+(define/method (Port.Input.peek_byte port
+                                     #:skip_bytes [skip 0]
+                                     #:special_wrap [special-wrap #f]
+                                     #:source_name [source-name #f])
+  #:primitive (peek-byte peek-byte-or-special)
+  (if special-wrap
+      (peek-byte-or-special port skip (if (eq? special-wrap values) #f special-wrap) source-name)
+      (peek-byte port skip)))
 
-(define/method (Port.Input.peek_bytes port amt #:skip_bytes [skip 0])
+(define (check-wait who wait)
+  (unless (or (eq? wait 'all) (eq? wait 'some) (eq? wait 'none) (eq? wait 'enable_break))
+    (raise-annotation-failure who wait "Port.WaitMode")))
+
+(define/method (Port.Input.peek_bytes port amt
+                                      #:skip_bytes [skip 0])
   #:primitive (peek-bytes)
   (peek-bytes amt skip port))
 
-(define/method (Port.Input.peek_char port #:skip_bytes [skip 0])
-  #:primitive (peek-char)
-  (peek-char port skip))
+(define/method (Port.Input.peek_bytes_to port bstr
+                                         #:start [start 0]
+                                         #:end [end (and (bytes? bstr) (bytes-length bstr))]
+                                         #:skip_bytes [skip 0]
+                                         #:wait [wait 'all]
+                                         #:progress [progress #f])
+  #:primitive (peek-bytes! peek-bytes-avail! peek-bytes-avail!* peek-bytes-avail!/enable-break)
+  (cond
+    [(eq? wait 'all)
+     (when progress (raise-arguments-error who "progress evt not supported in wait mode" "wait mode" wait))
+     (peek-bytes! bstr skip port start end)]
+    [(eq? wait 'some)
+     (peek-bytes-avail! bstr skip progress port start end)]
+    [(eq? wait 'none)
+     (peek-bytes-avail!* bstr skip progress port start end)]
+    [(eq? wait 'enable_break)
+     (peek-bytes-avail!* bstr skip progress port start end)]
+    [else (check-wait who wait)]))
+
+(define/method (Port.Input.peek_char port
+                                     #:skip_bytes [skip 0]
+                                     #:special_wrap [special-wrap #f]
+                                     #:source_name [source-name #f])
+  #:primitive (peek-char peek-char-or-special)
+  (if special-wrap
+      (peek-char-or-special port skip (if (eq? special-wrap values) #f special-wrap) source-name)
+      (peek-char port skip)))
 
 (define/method (Port.Input.peek_string port amt #:skip_bytes [skip 0])
   #:primitive (peek-bytes)
   (coerce-read-result
    (peek-string amt skip port)))
 
-(define/method (Port.Input.read_byte port)
-  #:primitive (read-byte)
-  (read-byte port))
+(define/method (Port.Input.peek_string_to port str
+                                          #:start [start 0]
+                                          #:end [end (and (string? str) (string-length str))]
+                                          #:skip_bytes [skip 0])
+  #:primitive (peek-string!)
+  (peek-string! str skip port start end))
+
+(define/method (Port.Input.read_byte port
+                                     #:special_wrap [special-wrap #f]
+                                     #:source_name [source-name #f])
+  #:primitive (read-byte read-byte-or-special)
+  (if special-wrap
+      (read-byte-or-special port (if (eq? special-wrap values) #f special-wrap) source-name)
+      (read-byte port)))
 
 (define/method (Port.Input.read_bytes port amt)
   #:primitive (read-bytes)
   (read-bytes amt port))
 
-(define/method (Port.Input.read_char port)
-  #:primitive (read-char)
-  (read-char port))
+(define/method (Port.Input.read_bytes_to port bstr
+                                         #:start [start 0]
+                                         #:end [end (and (bytes? bstr) (bytes-length bstr))]
+                                         #:wait [wait 'all])
+  #:primitive (read-bytes! read-bytes-avail! read-bytes-avail!* read-bytes-avail!/enable-break)
+  (cond
+    [(eq? wait 'all)
+     (read-bytes! bstr port start end)]
+    [(eq? wait 'some)
+     (read-bytes-avail! bstr port start end)]
+    [(eq? wait 'none)
+     (read-bytes-avail!* bstr port start end)]
+    [(eq? wait 'enable_break)
+     (read-bytes-avail!* bstr port start end)]
+    [else (check-wait who wait)]))
+
+(define/method (Port.Input.read_char port
+                                     #:special_wrap [special-wrap #f]
+                                     #:source_name [source-name #f])
+  #:primitive (read-char read-char-or-special)
+  (if special-wrap
+      (read-char-or-special port (if (eq? special-wrap values) #f special-wrap) source-name)
+      (read-char port)))
 
 (define/method (Port.Input.read_line port
                                      #:mode [mode-in 'any])
@@ -290,6 +607,31 @@
   #:primitive (read-string)
   (coerce-read-result (read-string amt port)))
 
+(define/method (Port.Input.read_string_to port str
+                                          #:start [start 0]
+                                          #:end [end (and (string? str) (string-length str))])
+  #:primitive (read-string!)
+  (read-string! str port start end))
+
+(define/method (Port.Input.copy_to p . outs)
+  #:primitive (copy-port)
+  (apply copy-port p outs))
+
+(define/method (Port.Input.Progress.evt port)
+  (unless (input-progress-port? port)
+    (raise-annotation-failure who port "Input.Port.Progress"))
+  (port-progress-evt port))
+
+(define/method (Port.Input.Progress.commit port amt progress evt)
+  #:primitive (port-commit-peeked)
+  (unless (input-progress-port? port)
+    (raise-annotation-failure who port "Input.Port.Progress"))
+  (port-commit-peeked amt progress evt port))
+
+(define/method (Port.Input.Progress.is_evt port evt)
+  #:primitive (progress-evt?)
+  (progress-evt? evt port))
+
 (define/method (Port.Output.close port)
   #:primitive (close-output-port)
   (close-output-port port))
@@ -308,15 +650,45 @@
   (check-output-port who p)
   (flush-output p))
 
-(define/method (Port.Output.write_bytes port bstr [start 0] [end (and (bytes? bstr) (bytes-length bstr))])
-  #:primitive (write-bytes)
-  (unless (output-port? port) (raise-annotation-failure who port "Port.Output"))
-  (write-bytes bstr port start end)
-  (void))
+(define/method (Port.Output.write_byte port b)
+  #:primitive (write-byte)
+  (write-byte b port))
 
-(define/method (Port.Output.write_string port str [start 0] [end (and (string? str) (string-length str))])
+(define/method (Port.Output.write_char port ch)
+  #:primitive (write-char)
+  (write-byte ch port))
+
+(define/method (Port.Output.Special.write port v
+                                          #:wait [wait 'all])
+  #:primitive (write-special write-special-avail*)
+  (cond
+    [(eq? wait 'all)
+     (write-special v port)]
+    [(eq? wait 'none)
+     (write-special-avail* v port)]
+    [else
+     (raise-annotation-failure who wait "Any.of(#'all, #'none)")]))
+
+(define/method (Port.Output.write_bytes port bstr
+                                        #:wait [wait 'all]
+                                        #:start [start 0]
+                                        #:end [end (and (bytes? bstr) (bytes-length bstr))])
+  #:primitive (write-bytes write-bytes-avail write-bytes-avail* write-bytes-avail/enable-break)
+  (cond
+    [(eq? wait 'all)
+     (write-bytes bstr port start end)]
+    [(eq? wait 'some)
+     (write-bytes-avail bstr port start end)]
+    [(eq? wait 'none)
+     (write-bytes-avail* bstr port start end)]
+    [(eq? wait 'enable_break)
+     (write-bytes-avail/enable-break bstr port start end)]
+    [else (check-wait who wait)]))
+
+(define/method (Port.Output.write_string port str
+                                         #:start [start 0]
+                                         #:end [end (and (string? str) (string-length str))])
   #:primitive (write-string)
-  (unless (output-port? port) (raise-annotation-failure who port "Port.Output"))
   (write-string str port start end)
   (void))
 
@@ -343,5 +715,32 @@
                                    . vs)
   (do-print* who vs port 'expr pretty?)
   (newline port))
+
+(define-syntax stdin
+  (expression-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       [(_ . tail)
+        (values (wrap-static-info* #'(current-input-port)
+                                   (get-input-port-static-infos))
+                #'tail)]))))
+
+(define-syntax stdout
+  (expression-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       [(_ . tail)
+        (values (wrap-static-info* #'(current-output-port)
+                                   (get-output-port-static-infos))
+                #'tail)]))))
+
+(define-syntax stderr
+  (expression-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       [(_ . tail)
+        (values (wrap-static-info* #'(current-error-port)
+                                   (get-output-port-static-infos))
+                #'tail)]))))
 
 (void (set-primitive-contract! '(or/c 'binary 'text) "Port.Mode"))

--- a/rhombus-lib/rhombus/private/amalgam/print.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/print.rkt
@@ -437,8 +437,10 @@
          (output-port? v))
      (pretty-listlike
       (pretty-text (if (input-port? v)
-                       "Port.Input("
-                       "Port.output("))
+                       (if (output-port? v)
+                           "Port("
+                           "Port.Input(")
+                       "Port.Output("))
       (let ([n (object-name v)])
         (if n
             (list (print n))

--- a/rhombus-lib/rhombus/private/amalgam/string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/string.rkt
@@ -47,6 +47,7 @@
                      String)
          (for-space rhombus/annot
                     ReadableString
+                    MutableString
                     StringCI
                     ReadableStringCI
                     StringLocale
@@ -186,6 +187,9 @@
 (define-for-syntax (get-readable-string-ci-static-infos)
   (make-get-veneer-like-static-infos get-readable-string-static-infos
                                      convert-string-ci-compare-static-info))
+
+(define-annotation-syntax MutableString
+  (identifier-annotation mutable-string? #,(get-readable-string-static-infos)))
 
 (define-annotation-syntax StringCI
   (identifier-annotation immutable-string? #,(get-string-ci-static-infos) #:static-only))

--- a/rhombus-lib/rhombus/private/amalgam/with.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/with.rkt
@@ -47,10 +47,11 @@
             (syntax-parse form1
               [dp::update-provider #'dp.id]
               [_ #f]))
-          (define update-id (extract-dot-provider-id update-id/s))
+          (define update-ids (extract-dot-provider-ids update-id/s))
           (define updater
-            (and update-id
-                 (syntax-local-value* (in-update-space update-id) update-transformer-ref)))
+            (and (pair? update-ids)
+                 (null? (cdr update-ids))
+                 (syntax-local-value* (in-update-space (car update-ids)) update-transformer-ref)))
           (when (and more-static? (not updater))
             (raise-syntax-error #f
                                 (string-append "no update implementation available" statically-str)

--- a/rhombus-lib/rhombus/subprocess.rhm
+++ b/rhombus-lib/rhombus/subprocess.rhm
@@ -39,13 +39,13 @@ class Subprocess(hand, output, input, error_output, desc, is_new):
   private override method describe(mode, recur):
     PrintDesc.concat("Subprocess(", repr(to_string(desc)), ")")
   property handle: hand
-  property maybe_in :~ maybe(Port.Output): input is_a Port.Output && input
-  property maybe_out :~ maybe(Port.Input): output is_a Port.Input && output
-  property maybe_err :~ maybe(Port.Input): error_output is_a Port.Input && error_output
+  property maybe_in :~ maybe(Port.Output && Port.FileStream): input is_a Port.Output && input
+  property maybe_out :~ maybe(Port.Input && Port.FileStream): output is_a Port.Input && output
+  property maybe_err :~ maybe(Port.Input && Port.FileStream): error_output is_a Port.Input && error_output
   fun not_available(who): error(~who: who, "pipe not available")
-  property in :~ Port.Output: maybe_in || not_available(#'in)
-  property out :~ Port.Input: maybe_out || not_available(#'out)
-  property err :~ Port.Input: maybe_err || not_available(#'err)
+  property in :~ Port.Output && Port.FileStream: maybe_in || not_available(#'in)
+  property out :~ Port.Input && Port.FileStream: maybe_out || not_available(#'out)
+  property err :~ Port.Input && Port.FileStream: maybe_err || not_available(#'err)
   property pid: rkt.#{subprocess-pid}(hand)
   override method close():
     when input is_a Port.Output | Port.Output.close(input)

--- a/rhombus/rhombus/scribblings/reference/file_stream_port.scrbl
+++ b/rhombus/rhombus/scribblings/reference/file_stream_port.scrbl
@@ -1,0 +1,140 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open)
+
+@title{File/Stream Ports}
+
+@doc(
+  annot.macro 'Port.FileStream'
+  annot.macro 'Port.FileStream.Terminal'
+){
+
+ The @rhombus(Port.FileStream, ~annot) annotation recognizes
+ @tech{ports} that correspond to operating-system resources such as files
+ and pipes for interprocess communication. The
+ @rhombus(Port.FileStream.Terminal, ~annot) annotation recognizes ports that
+ represent to interactive terminals.
+
+}
+
+
+@doc(
+   method (port :: Port.FileStream).truncate(
+     size :: NonegInt
+   ) :: Void
+){
+
+ When @rhombus(port) represents a file,
+ @rhombus(Port.FileStream.truncate) sets the file's size. The
+ @rhombus(Port.position) function can be used to make a file larger,
+ but @rhombus(Port.FileStream.truncate) can make a file smaller.
+
+}
+
+
+@doc(
+   method (port :: Port.FileStream).try_lock(
+     mode :: Port.FileStream.LockMode
+   ) :: Boolean
+   method (port :: Port.FileStream).unlock() :: Void
+){
+
+ The @rhombus(Port.FileStream.try_lock) function attempts to acquire a
+ filesystem lock on the file that @rhombus(port) represents using the
+ operating systems’s facilities for file locking. The result is
+ @rhombus(#true) if the lock acquisition succeeds, @rhombus(#false)
+ otherwise.
+
+ The @rhombus(mode) argument can be @rhombus(#'shared) or
+ @rhombus(#'exclusive). Multiple processes can acquire a
+ @rhombus(#'shared) lock on a file, but at most one process can hold an
+ @rhombus(#'exclusive) lock, and @rhombus(#'shared) and
+ @rhombus(#'exclusive) locks are mutually exclusive. When mode is
+ @rhombus(#'shared), then port must be an input port; when mode is
+ @rhombus(#'exclusive), then port must be an output port.
+
+ The result is @rhombus(#true) if the requested lock is acquired,
+ @rhombus(#false) otherwise. When a lock is acquired, it is held until
+ either it is released with @rhombus(Port.FileStream.unlock) or the port
+ is closed (perhaps because the process terminates).
+
+ Depending on the platform, locks may be merely advisory (i.e., locks
+ affect only the ability of processes to acquire locks) or they may
+ correspond to mandatory locks that prevent reads and writes to the
+ locked file. Specifically, locks are mandatory on Windows and advisory
+ on other platforms. Multiple tries for a @rhombus(#'shared) lock on a
+ single port can succeed; on Unix and Mac OS, a single
+ @rhombus(Port.FileStream.unlock) releases the lock, while on other
+ Windows, a @rhombus(Port.FileStream.unlock) is needed for each
+ successful @rhombus(Port.FileStream.try_lock). On Unix and Mac OS,
+ multiple tries for a @rhombus(#'exclusive) lock can succeed and a single
+ @rhombus(Port.FileStream.unlock) releases the lock, while on Windows, a
+ try for an @rhombus(#'exclusive) lock fails for a given port if the port
+ already holds the lock.
+
+ A lock acquired for an input port from
+ @rhombus(Port.open_input_output_file) can be released through
+ @rhombus(Port.FileStream.unlock) on the corresponding output port, and
+ vice versa. If the output port from
+ @rhombus(Port.open_input_output_file) holds an @rhombus(#'exclusive)
+ lock, the corresponding input port can still acquire a
+ @rhombus(#'shared) lock, even multiple times; on Windows, a
+ @rhombus(Port.open_input_output_file) is needed for each successful lock
+ try, while a single @rhombus(Port.open_input_output_file) balances the
+ lock tries on Unix and Mac OS. A @rhombus(#'shared) lock on an input
+ port can be upgraded to an @rhombus(#'exclusive) lock through the
+ corresponding output port on Unix and Mac OS, in which case a single
+ @rhombus(Port.open_input_output_file) (on either port) releases the
+ lock, while such upgrades are not allowed on Windows.
+
+ Locking is normally supported only for file ports, and attempting to
+ acquire a lock with other kinds of file-stream ports throws an
+ @rhombus(Exn.Fail.Filesystem) exception.
+
+}
+
+@doc(
+   method (port :: Port.FileStream).identity() :: PosInt
+   method (port :: Port.FileStream).stat() :: Map
+){
+
+ The @rhombus(Port.FileStream.identity) method returns an integer that
+ represents a file's identity on the filesystem. When multiple ports read
+ and write to the same file, they have he same identity. A port that
+ refers to the same as a path will have the same identity as
+ @rhombus(filesystem.identity) produces for the path.
+
+ The @rhombus(Port.FileStream.stat) function similarly corresponds to
+ @rhombus(filesystem.stat).
+
+}
+
+
+@doc(
+   method (port :: Port.FileStream).is_waiting_on_peer()
+     :: Boolean
+){
+
+ Returns @rhombus(#true) if @rhombus(port) is not ready for reading or
+ writing because it is waiting for a peer process to complete a stream
+ construction, @rhombus(#false) otherwise.
+
+ On Unix and Mac OS, opening a fifo for output creates a peer-waiting
+ port if no reader for the same fifo is already opened. In that case, the
+ output port is not ready for writing until a reader is opened; that is,
+ write operations will block. Use @rhombus(sync) if necessary to wait
+ until writing will not block---that is, until the read end of the fifo
+ is opened.
+
+}
+
+
+@doc(
+  enum Port.FileStream.LockMode:
+    shared
+    exclusive
+){
+
+ Lock modes for @rhombus(Port.FileStream.try_lock).
+
+}

--- a/rhombus/rhombus/scribblings/reference/filesystem.scrbl
+++ b/rhombus/rhombus/scribblings/reference/filesystem.scrbl
@@ -391,11 +391,11 @@
 @doc(
   fun filesystem.read_bytes_lines(
     path :: PathString,
-    ~mode: mode :: Port.ReadLineMode = #'any
+    ~mode: mode :: Port.Input.ReadLineMode = #'any
   ) :: List.of(String)
   fun filesystem.read_lines(
     path :: PathString,
-    ~mode: mode :: Port.ReadLineMode = #'any
+    ~mode: mode :: Port.Input.ReadLineMode = #'any
   ) :: List.of(String)
 ){
 

--- a/rhombus/rhombus/scribblings/reference/input_port.scrbl
+++ b/rhombus/rhombus/scribblings/reference/input_port.scrbl
@@ -11,21 +11,52 @@ Moreover, an @deftech{input string port} reads from a @tech{byte
 @doc(
   annot.macro 'Port.Input'
   annot.macro 'Port.Input.String'
+  annot.macro 'Port.Input.Progress'
 ){
 
  The @rhombus(Port.Input, ~annot) annotation
  recognizes @tech{input ports}.
  The @rhombus(Port.Input.String, ~annot) annotation recognizes
  @tech{input string ports}.
+ The @rhombus(Port.Input.Progresse, ~annot) annotation recognizes
+ input ports that can provide a progress event via @rhombus(Port.Input.Progress.evt).
+
 }
+
 
 @doc(
+  ~nonterminal:
+    port_expr: block expr
+    path_expr: block expr
+
   Parameter.def Port.Input.current :: Port.Input
+
+  expr.macro 'stdin'
+
+  expr.macro 'Port.Input.using $port_expr:
+                $body
+                ...'
+  expr.macro 'Port.Input.using ~file $path_expr:
+                $body
+                ...'
 ){
 
- A @tech{context parameter} for the default port to use when reading.
+ The @rhombus(Port.Input.current) @tech{context parameter} determines a
+ default port to use when reading. The @rhombus(stdin) form is a
+ shorthand for @rhombus(Port.Input.current()) to get that default port.
+
+ The @rhombus(Port.Input.using) form sets @rhombus(Port.Input.current)
+ while evaluating the @rhombus(body) result. If @rhombus(~file) is not
+ supplied, then @rhombus(port_expr) must produce a
+ @rhombus(Port.Input, ~annot), otherwise @rhombus(path_expr) must produce
+ a @rhombus(PathString). Breaks are disabled during the evaluation of
+ @rhombus(port_expr) or opening the file indicated by
+ @rhombus(path_expr), the same as for @rhombus(Closeable.def), and the
+ port is similarly closed on return or escape from the @rhombus(body)
+ sequence.
 
 }
+
 
 @doc(
   fun Port.Input.open_bytes(bstr :: Bytes,
@@ -39,15 +70,17 @@ Moreover, an @deftech{input string port} reads from a @tech{byte
 
 }
 
+
 @doc(
   fun Port.Input.open_file(file :: PathString,
                            ~mode: mode :: Port.Mode = #'binary)
-    :: Port.Input
+    :: Port.Input && Port.FileStream
 ){
 
  Creates an @tech{input port} that reads from the @tech{path} @rhombus(file).
 
 }
+
 
 @doc(
   fun Port.Input.open_string(str :: ReadableString,
@@ -61,61 +94,38 @@ Moreover, an @deftech{input string port} reads from a @tech{byte
 
 }
 
+
 @doc(
-  method (in :: Port.Input).peek_byte(
-    ~skip_bytes: skip :: NonnegInt = 0
-  ):: Byte || Port.EOF
+  fun Port.Input.open_nowhere(name :: Symbol = #'string)
+    :: Port.Input
 ){
 
- Like @rhombus(Port.Input.read_byte), but peeks instead of reading, and skips
- @rhombus(skip) bytes at the start of the port.
+ Creates an @tech{input port} that is empty. The optional @rhombus(name)
+ is used as the name for the returned port.
 
 }
 
+
 @doc(
-  method (in :: Port.Input).peek_bytes(
-    amount :: NonnegInt,
-    ~skip_bytes: skip :: NonnegInt = 0
-  ) :: Bytes || Port.EOF
+  method (in :: Port.Input).read_byte(
+    ~special_wrap: special_wrap :: maybe(Any -> Any) = #false,
+    ~source_name: source_name :: Any = #false
+  ) :: Byte || Port.EOF || Any
 ){
 
- Like @rhombus(Port.Input.read_bytes), but peeks instead of reading, and skips
- @rhombus(skip) bytes at the start of the port.
+ Normally reads a single byte from @rhombus(in). If no bytes are
+ available before an end-of-file, then @rhombus(Port.eof) is returned.
+
+ If @rhombus(special_wrap) is not @rhombus(#false) and if the port can
+ supply ``special'' non-byte results, then the result can be
+ @rhombus(special_wrap) applied to the special result. Supply
+ @rhombus(values) as @rhombus(special_wrap) to enable special results
+ without extra treatment. The @rhombus(source_name) argument can be
+ anything, and it is delivered to the port's implementation to
+ potentially specialize its behavior.
 
 }
 
-@doc(
-  method (in :: Port.Input).peek_char(
-    ~skip_bytes: skip :: NonnegInt = 0
-  ) :: Char || Port.EOF
-){
-
- Like @rhombus(Port.Input.read_char), but peeks instead of reading, and skips
- @rhombus(skip) bytes (not characters) at the start of the port.
-
-}
-
-@doc(
-  method (in :: Port.Input).peek_string(
-    amount :: NonnegInt,
-    ~skip_bytes: skip :: NonnegInt = 0
-  ) :: String || Port.EOF
-){
-
- Like @rhombus(Port.Input.read_string), but peeks instead of reading, and skips
- @rhombus(skip) bytes at the start of the port.
-
-}
-
-@doc(
-  method (in :: Port.Input).read_byte()
-    :: Byte || Port.EOF
-){
-
- Reads a single byte from @rhombus(in). If no bytes are available before and
- end-of-file, then @rhombus(Port.eof) is returned.
-
-}
 
 @doc(
   method (in :: Port.Input).read_bytes(amount :: NonnegInt)
@@ -123,7 +133,7 @@ Moreover, an @deftech{input string port} reads from a @tech{byte
 ){
 
  Reads a @tech{byte string} containing the next @rhombus(amount) bytes from
- @rhombus(in). If @rhombus(amount) is 0, then an empty byte string is returned.
+ @rhombus(in). If @rhombus(amount) is @rhombus(0), then an empty byte string is returned.
  Otherwise if fewer than @rhombus(amount) bytes are available before an
  end-of-file is encountered, then the returned byte string will contain only
  those bytes before the end-of-file; that is, the returned byte string's length
@@ -132,9 +142,43 @@ Moreover, an @deftech{input string port} reads from a @tech{byte
 
 }
 
+
 @doc(
-  method (in :: Port.Input).read_char()
-    :: Char || Port.EOF
+  method (in :: Port.Input).read_bytes_to(
+    bytes :: MutableBytes,
+    ~start: start :: NonnegInt = 0,
+    ~end: end :: NonnegInt = bytes.length(),
+    ~wait: wait :: Port.WaitMode = #'all
+  ) :: NonnegInt || Port.EOF
+){
+
+ Like @rhombus(Port.Input.read_bytes), but delivering the read bytes to
+ a mutable byte string, @rhombus(bytes). The read bytes are written to
+ the @rhombus(start) through @rhombus(end) substring of @rhombus(bytes).
+ The result is the number of bytes written to @rhombus(bytes); the result
+ is @rhombus(0) only when @rhombus(start == end), otherwise
+ @rhombus(Port.eof) is returned if no bytes are read due to an
+ end-of-file.
+
+ If @rhombus(wait) is @rhombus(#'all), then @rhombus(end-start) bytes
+ are written to @rhombus(bytes) unless an end-of-file is found in the
+ input. If @rhombus(wait) is @rhombus(#'some), then the number of read
+ bytes may be fewer, but reading will wait until at least one byte is
+ read or an end-of-file is found. If @rhombus(wait) is @rhombus(#'none),
+ then reading will always return without waiting, even if no bytes are
+ immediately available. If @rhombus(wait) is @rhombus(#'enable_break),
+ then waiting is like @rhombus(#'some), but asynchronously break
+ exceptions are enabled during the wait; in that case, either some bytes
+ will be read or a break exception will be thrown, but not both.
+
+}
+
+
+@doc(
+  method (in :: Port.Input).read_char(
+    ~special_wrap: special_wrap :: maybe(Any -> Any) = #false,
+    ~source_name: source_name :: Any = #false
+  ) :: Char || Port.EOF || Any
 ){
 
  Reads a single character from @rhombus(in) --- which may involve reading
@@ -142,17 +186,64 @@ Moreover, an @deftech{input string port} reads from a @tech{byte
  bytes are read/peeked to perform the decoding. If no bytes are available
  before an end-of-file, then @rhombus(Port.eof) is returned.
 
+ The result can be a non-@rhombus(Char), non-@rhombus(Port.eof) value if
+ @rhombus(special_wrap) is not @rhombus(#false). The
+ @rhombus(special_wrap) and @rhombus(source_name) argument as used as by
+ @rhombus(Port.peek_byte).
+
 }
 
+
 @doc(
+  method (in :: Port.Input).read_string(amount :: NonnegInt)
+    :: String || Port.EOF
+){
+
+ Returns a string containing the next @rhombus(amount) characters from
+ @rhombus(in).
+
+ If @rhombus(amount) is @rhombus(0), then the empty string is
+ returned. Otherwise, if fewer than @rhombus(amount) characters are
+ available before an end-of-file is encountered, then the returned
+ string will contain only those characters before the end-of-file; that
+ is, the returned string's length will be less than @rhombus(amount). (A
+ temporary string of size @rhombus(amount) is allocated while reading the
+ input, even if the size of the result is less than @rhombus(amount)
+ characters.) If no characters are available before an end-of-file,
+ then @rhombus(Port.eof) is returned.
+
+}
+
+
+@doc(
+  method (in :: Port.Input).read_string_to(
+    str :: String,
+    ~start: start :: NonnegInt = 0,
+    ~end: end :: NonnegInt = str.length()
+  ) :: NonnegInt || Port.EOF
+){
+
+
+ Like @rhombus(Port.Input.read_bytes_to), but delivering decoded
+ characters to a mutable string, @rhombus(str) in its @rhombus(start)
+ through @rhombus(end) substring.
+
+}
+
+
+@doc(
+  method (in :: Port.Input).read_bytes_line(
+    ~mode: mode :: Port.Input.ReadLineMode = #'any
+  ) :: Bytes || Port.EOF
   method (in :: Port.Input).read_line(
-    ~mode: mode :: Port.ReadLineMode = #'any
+    ~mode: mode :: Port.Input.ReadLineMode = #'any
   ) :: String || Port.EOF
 ){
 
- Returns a string containing the next line of characters from @rhombus(in).
+ Returns a byte string or string containing the next line of bytes or
+ characters from @rhombus(in).
 
- Characters are read from @rhombus(in) until a line separator or an
+ Bytes are read from @rhombus(in) until a line separator or an
  end-of-file is read. The line separator is not included in the result
  string (but it is removed from the port's stream). If no characters
  are read before an end-of-file is encountered, @rhombus(Port.eof) is
@@ -191,28 +282,168 @@ Moreover, an @deftech{input string port} reads from a @tech{byte
 
 }
 
+
 @doc(
-  method (in :: Port.Input).read_string(amount :: NonnegInt)
-    :: String || Port.EOF
+  method (in :: Port.Input).peek_byte(
+    ~skip_bytes: skip :: NonnegInt = 0,
+    ~special_wrap: special_wrap :: maybe(Any -> Any) = #false,
+    ~source_name: source_name :: Any = #false
+  ):: Byte || Port.EOF
 ){
 
- Returns a string containing the next @rhombus(amount) characters from
- @rhombus(in).
-
- If @rhombus(amount) is @rhombus(0), then the empty string is
- returned. Otherwise, if fewer than @rhombus(amount) characters are
- available before an end-of-file is encountered, then the returned
- string will contain only those characters before the end-of-file; that
- is, the returned string's length will be less than @rhombus(amount). (A
- temporary string of size @rhombus(amount) is allocated while reading the
- input, even if the size of the result is less than @rhombus(amount)
- characters.) If no characters are available before an end-of-file,
- then @rhombus(Port.eof) is returned.
+ Like @rhombus(Port.Input.read_byte), but peeks instead of reading, and skips
+ @rhombus(skip) bytes at the start of the port.
 
 }
 
 @doc(
-  enum Port.ReadLineMode:
+  method (in :: Port.Input).peek_bytes(
+    amount :: NonnegInt,
+    ~skip_bytes: skip :: NonnegInt = 0
+  ) :: Bytes || Port.EOF
+){
+
+ Like @rhombus(Port.Input.read_bytes), but peeks instead of reading, and skips
+ @rhombus(skip) bytes at the start of the port.
+
+}
+
+
+@doc(
+  method (in :: Port.Input).peek_bytes_to(
+    bytes :: MutableBytes,
+    ~start: start :: NonnegInt = 0,
+    ~end: end :: NonnegInt = bytes.length(),
+    ~skip_bytes: skip :: NonnegInt = 0,
+    ~wait: wait :: Port.WaitMode = #'all,
+    ~progress: progress :: maybe(Evt) = #false
+  ) :: NonnegInt || Port.EOF
+){
+
+ Like @rhombus(Port.Input.peek_bytes), but delivering the read bytes to
+ a mutable byte string, @rhombus(bytes). The read bytes are written to
+ the @rhombus(start) through @rhombus(end) substring of @rhombus(bytes).
+ The result is the number of bytes written to @rhombus(bytes).
+
+ If @rhombus(wait) is not @rhombus(#'all), then @rhombus(progress) can
+ be an event produced by @rhombus(Port.Input.Progress.evt(port)). Bytes
+ are peeked only when @rhombus(progress) is not ready for
+ synchronization, otherwise the result is @rhombus(0).
+
+}
+
+
+@doc(
+  method (in :: Port.Input).peek_char(
+    ~skip_bytes: skip :: NonnegInt = 0,
+    ~special_wrap: special_wrap :: maybe(Any -> Any) = #false,
+    ~source_name: source_name :: Any = #false
+  ) :: Char || Port.EOF
+){
+
+ Like @rhombus(Port.Input.read_char), but peeks instead of reading, and skips
+ @rhombus(skip) bytes (not characters) at the start of the port.
+
+}
+
+
+@doc(
+  method (in :: Port.Input).peek_string(
+    amount :: NonnegInt,
+    ~skip_bytes: skip :: NonnegInt = 0
+  ) :: String || Port.EOF
+){
+
+ Like @rhombus(Port.Input.read_string), but peeks instead of reading, and skips
+ @rhombus(skip) bytes at the start of the port.
+
+}
+
+
+@doc(
+  method (in :: Port.Input).peek_string_to(
+    str :: MutableString,
+    ~start: start :: NonnegInt = 0,
+    ~end: end :: NonnegInt = str.length(),
+    ~skip_bytes: skip :: NonnegInt = 0
+  ) :: NonnegInt || Port.EOF
+){
+
+ Like @rhombus(Port.Input.peek_string), but delivering decoded
+ characters to a mutable string, @rhombus(str) in its @rhombus(start)
+ through @rhombus(end) substring.
+
+}
+
+
+@doc(
+  method (in :: Port.Input).copy_to(out :: Port.Output, ...) :: Void
+){
+
+ Read from @rhombus(in) until an end-of-file and writes all read content
+ to @rhombus(out). Bytes are read from @rhombus(in) as available and
+ written to each @rhombus(out) before continuing (as opposed to waiting
+ until all data can be read from @rhombus(in)).
+
+}
+
+@doc(
+  method (port :: Port.Input.Progress).evt() :: Evt
+  method (port :: Port.Input.Progress).is_evt(e :: Evt) :: Boolean
+){
+
+ The @rhombus(Port.Input.Progress.evt) method returns a a synchronizable
+ evt that becomes ready for synchronization when data is read from
+ @rhombus(port). The @rhombus(Port.Input.Progress.evt) method check whether
+ @rhombus(e) belongs to @rhombus(port).
+
+}
+
+
+@doc(
+  method (port :: Port.Input.Progress).commit(
+    amt :: NonnegInt,
+    progress :: Evt,
+    evt :: Evt
+  ) :: Boolean
+){
+
+ Attempts to commit as read the first @rhombus(amt) previously peeked
+ bytes, non-byte specials, and @rhombus(Port.eof)s from @rhombus(port),
+ or the first @rhombus(Port.eof) or special value peeked from
+ @rhombus(post). Mid-stream @rhombus(Port.eof)s can be committed, but a
+ @rhombus(Port.eof) when the port is exhausted does not necessarily
+ commit, since it does not correspond to data in the stream.
+
+ The read commits only if @rhombus(progress) does not become ready first
+ (i.e., if no other process reads from @rhombus(port) first), and only if
+ @rhombus(evt) is chosen by a sync within port-commit-peeked (in which
+ case the event result is ignored); the @rhombus(evt) must be either a
+ channel-put event, channel, semaphore, semaphore-peek event, ``always''
+ event, or ``never'' event. Suspending the thread that calls
+ @rhombus(Port.Input.Progress.commit) may or may not prevent the commit
+ from proceeding.
+
+ The result is @rhombus(#true) if data has been committed, and
+ @rhombus(#false) otherwise.
+
+ If no data has been peeked from @rhombus(port) and @rhombus(progress)
+ is not ready, then an @rhombus(Exn.Fail.Annot) exception is thrown. If
+ fewer than @rhombus(amt) items have been peeked at the current start of
+ @rhombus(port)'s stream, then only the peeked items are committed as
+ read. If @rhombus(port)'s stream currently starts at a
+ @rhombus(Port.eof) or a non-byte special value, then only the
+ @rhombus(Port.eof) or special value is committed as read.
+
+ If @rhombus(progress) is not a result of
+ @rhombus(Port.Input.Progress.evt(port)), then an
+ @rhombus(Exn.Fail.Annot) exception is thrown.
+
+}
+
+
+@doc(
+  enum Port.Input.ReadLineMode:
     linefeed
     return
     return_linefeed

--- a/rhombus/rhombus/scribblings/reference/io.scrbl
+++ b/rhombus/rhombus/scribblings/reference/io.scrbl
@@ -9,5 +9,7 @@
 @include_section("port.scrbl")
 @include_section("input_port.scrbl")
 @include_section("output_port.scrbl")
+@include_section("file_stream_port.scrbl")
+@include_section("pipe.scrbl")
 @include_section("printing.scrbl")
 @include_section("shrubbery.scrbl")

--- a/rhombus/rhombus/scribblings/reference/output_port.scrbl
+++ b/rhombus/rhombus/scribblings/reference/output_port.scrbl
@@ -10,31 +10,62 @@ an @deftech{output string port} writes to a @tech{byte string}.
 @doc(
   annot.macro 'Port.Output'
   annot.macro 'Port.Output.String'
+  annot.macro 'Port.Output.Special'
 ){
 
  The @rhombus(Port.Output, ~annot) annotation recognizes @tech{output
-  ports}, and the @rhombus(Port.Output.String, ~annot) annotation
- recognizes @tech{output string ports}.
+  ports}, the @rhombus(Port.Output.String, ~annot) annotation recognizes
+ @tech{output string ports}, and the
+ @rhombus(Port.Output.Special, ~annot) annotation recognizes ports that
+ support @rhombus(Port.Output.Special.write).
 
 }
 
+
 @doc(
+  ~nonterminal:
+    port_expr: block expr
+    path_expr: block expr
+    exists_mode_expr: block expr
+    exists_mode_body: block body
+
   Parameter.def Port.Output.current :: Port.Output
-){
-
- A @tech{context parameter} for the default port to use when printing.
-
-}
-
-
-@doc(
   Parameter.def Port.Output.current_error :: Port.Output
+
+  expr.macro 'stdout'
+  expr.macro 'stderr'
+
+  expr.macro 'Port.Output.using $port_expr:
+                $body
+                ...'
+  expr.macro 'Port.Output.using ~file $path_expr:
+                $option; ...
+                $body
+                ...'
+
+  grammar option:
+    ~exists $exist_mode_expr
+    ~exists: $exist_mode_body; ...
 ){
 
- A @tech{context parameter} for the default port to use when printing
- errors.
+ The @rhombus(Port.Output.current) @tech{context parameter} determines a
+ default port to use when printing, and @rhombus(Port.Output.current)
+ determines the default port to use when printing errors.
+
+ The @rhombus(stdout) form is a shorthand for
+ @rhombus(Port.Output.current()), and the @rhombus(stderr) form is a
+ shorthand for @rhombus(Port.Output.current_error()).
+
+ The @rhombus(Port.Output.using) form is analogous to
+ @rhombus(Port.Input.using), but for setting the current output port
+ while evaluating the @rhombus(body) sequence. When the @rhombus(~file)
+ variant is used, an @rhombus(~exists) option before the @rhombus(body)
+ sequence indicates how to handle the case that a file with the indicated
+ path exists, the same as the @rhombus(~exists) argument to
+ @rhombus(Port.Output.open_file).
 
 }
+
 
 @doc(
   method (out :: Port.Output).print(v :: Any, ...,
@@ -57,6 +88,7 @@ an @deftech{output string port} writes to a @tech{byte string}.
 
 }
 
+
 @doc(
   fun Port.Output.open_file(
     path :: PathString,
@@ -64,7 +96,7 @@ an @deftech{output string port} writes to a @tech{byte string}.
     ~mode: mode :: Port.Mode = #'binary,
     ~permissions: permissions :: Int.in(0, 65535) = 0o666,
     ~replace_permissions: replace_permissions = #false
-  ) :: Port.Output
+  ) :: Port.Output && Port.FileStream
 ){
 
  Creates an @tech{output port} that writes to the @tech{path} @rhombus(file).
@@ -105,6 +137,7 @@ an @deftech{output string port} writes to a @tech{byte string}.
 
 )}
 
+
 @doc(
   fun Port.Output.open_bytes(name :: Symbol = #'string)
     :: Port.Output.String
@@ -121,6 +154,7 @@ an @deftech{output string port} writes to a @tech{byte string}.
  intention together with @rhombus(Port.Output.get_string).
 
 }
+
 
 @doc(
   method (out :: Port.Output.String).get_bytes()
@@ -140,6 +174,7 @@ an @deftech{output string port} writes to a @tech{byte string}.
 
 }
 
+
 @doc(
   method Port.Output.flush(out :: Port.Output = Port.Output.current())
     :: Void
@@ -148,6 +183,17 @@ an @deftech{output string port} writes to a @tech{byte string}.
  Flushes the content of @rhombus(out)'s buffer.
 
 }
+
+
+@doc(
+  method (port :: Port.Output.Special).write(v) :: Void
+){
+
+ Writes an arbitrary ``special'' value to a port that supports content
+ other than just bytes.
+
+}
+
 
 @doc(
   enum Port.Output.ExistsMode:

--- a/rhombus/rhombus/scribblings/reference/pipe.scrbl
+++ b/rhombus/rhombus/scribblings/reference/pipe.scrbl
@@ -1,0 +1,57 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open)
+
+@title(~tag: "pipe"){Pipes}
+
+A Rhombus @deftech{pipe} is internal to Rhombus (and Racket), and not
+related to OS-level pipes for communicating between different processes.
+
+@doc(
+  annot.macro 'Port.Pipe'
+){
+
+ Regonizes pipes created with @rhombus(Port.Pipe.make).
+
+}
+
+
+@doc(
+  fun Port.Pipe.make(
+    ~limit: maybe(PosInt),
+    ~input_name: input_name :: Any = #'pipe,
+    ~input_name: output_name :: Any = #'pipe
+  ) :: values(Port.Input && Port.Pipe,
+              Port.Output && Port.Pipe)
+){
+
+ Returns two port values: the first port is an input port and the second
+ is an output port. Data written to the output port is read from the
+ input port, with no intermediate buffering. Unlike some other kinds of
+ ports, pipe ports do not need to be explicitly closed to be reclaimed by
+ garbage collection.
+
+ If limit is @rhombus(#false), the new pipe holds an unlimited number of
+ unread bytes (i.e., limited only by the available memory). If
+ @rhombus(limit) is a positive number, then the pipe will hold at most
+ @rhombus(limit) unread/unpeeked bytes; writing to the pipe’s output port
+ thereafter will block until a read or peek from the input port makes
+ more space available. (Peeks effectively extend the port’s capacity
+ until the peeked bytes are read.)
+
+ The optional @rhombus(input_name) and @rhombus(output)name) are used as
+ the names for the returned input and output ports, respectively.
+
+}
+
+@doc(
+  method (port :: Port.Pipe).content_length()
+    :: NonnegInt
+){
+
+ Returns the number of bytes contained in a pipe, where @rhombus(port) is
+ either of the pipe’s ports produced by @rhombus(Port.Pipe.make). The pipe’s content
+ length counts all bytes that have been written to the pipe and not yet
+ read (though possibly peeked).
+
+}

--- a/rhombus/rhombus/scribblings/reference/port.scrbl
+++ b/rhombus/rhombus/scribblings/reference/port.scrbl
@@ -11,11 +11,22 @@ output; it is possible for an object to be both an input and output port.
 
 @doc(
   annot.macro 'Port'
-  annot.macro 'Port.EOF'
 ){
 
  The @rhombus(Port, ~annot) annotation is satisfied by a @tech{port}.
  See also @rhombus(Port.Input, ~annot) and @rhombus(Port.Output, ~annot).
+
+}
+
+@doc(
+ def Port.eof :: Port.EOF
+ bind.macro 'Port.eof'
+ annot.macro 'Port.EOF'
+){
+
+ The @rhombus(Port.eof) value represents an end-of-file (distinct from
+ all other values), and the @rhombus(Port.eof) binding match matches that
+ value.
 
  The @rhombus(Port.EOF, ~annot) annotation is satisfied by the
  @rhombus(Port.eof) value.
@@ -23,13 +34,142 @@ output; it is possible for an object to be both an input and output port.
 }
 
 @doc(
- def Port.eof :: Port.EOF
- bind.macro 'Port.eof'
+  method (port :: Port).close() :: Void
+  method (port :: Port).is_closed() :: Boolean
 ){
 
- The @rhombus(Port.eof) value represents an end-of-file (distinct from
- all other values), and the @rhombus(Port.eof) binding match matches that
- value.
+ Closes a port, equivalent to @rhombus(Port.Input.close) or
+ @rhombus(Port.Output.close), or checks whether a port has been closed.
+ Closing an already-closed port has no effect.
+
+}
+
+@doc(
+  method (port :: Port).buffer() :: maybe(Port.BufferMode)
+  method (port :: Port).buffer(mode :: Port.BufferMode) :: Void
+){
+
+ Gets or sets the buffer mode for @rhombus(port) as @rhombus(#'none),
+ @rhombus(#'line) (output only), or @rhombus(#'block). An exception is
+ thrown if a port does not support a provided buffer mode. When no
+ @rhombus(mode) argument is provided, @rhombus(#false) is returned if the
+ buffer mode cannot be determined.
+
+ A port's default buffer mode depends on the communication channel that
+ it represents. A file port is nomrally @rhombus(#'block) buffered. The
+ initial @rhombus(stdin) port is @rhombus(#'block) buffered. The initial
+ @rhombus(stdout) port is @rhombus(#'line) buffered if it writers to a
+ terminal, @rhombus(#'block) buffered otherwise. The initial
+ @rhombus(stderr) port's buffer mode is @rhombus(#'none).
+
+}
+
+
+@doc(
+  method (port :: Port).position() :: NonnegInt
+  method (port :: Port).position(pos :: NonnegInt || Port.EOF) :: Void
+){
+
+ Gets or sets (if supported) a port's position, which represents an
+ offset in bytes.
+
+ Calling @rhombus(Port.position) without @rhombus(pos) on a port other
+ than a @rhombus(Port.FileStream, ~annot),
+ @rhombus(Port.Input.String, ~annot), or
+ @rhombus(Port.Output.String, ~annot) port returns the number of bytes
+ that have been read from that port if the position is known.
+
+ For @rhombus(Port.FileStream, ~annot),
+ @rhombus(Port.Input.String, ~annot), or
+ @rhombus(Port.Output.String, ~annot) ports, providing @rhombus(pos) sets
+ the read/write position relative to the beginning of the file or (byte)
+ string if @rhombus(pos) is a number, or to the current end of the file or
+ (byte) string if @rhombus(pos) is @rhombus(Port.eof). For other kinds of
+ ports, an exception is thrown when @rhombus(pos) is supplied.
+ Furthermore, not all @rhombus(Port.FileStream, ~annot) ports support
+ setting the position; if @rhombus(pos) is supplied for such a port, the
+ @rhombus(Exn.Fail.Filesystem) exception is thrown.
+
+ When file-position sets the position beyond the current size of an
+ output file or (byte) string, the file/string is enlarged to size
+ @rhombus(pos), and the new region is filled with @rhombus(0) bytes in
+ the case of a file. In the case of a file output port, the file might
+ not be enlarged until more data is written to the file; in that case,
+ beware that writing to a file opened in @rhombus(#'append) mode on Unix
+ and Mac OS will reset the file pointer to the end of a file before each
+ write, which defeats file enlargement via @rhombus(Port.position). If
+ @rhombus(pos) is beyond the end of an input file or (byte) string, then
+ reading thereafter returns eof without changing the port’s position.
+
+ When changing the file position for an output port, the port is first
+ flushed if its buffer is not empty. Similarly, setting the position for
+ an input port clears the port’s buffer (even if the new position is the
+ same as the old position). However, although input and output ports
+ produced by open-input-output-file share the file position, setting the
+ position via one port does not flush the other port’s buffer.
+
+}
+
+
+@doc(
+  method (port :: Port).locations_enabled() :: Boolean
+  method (port :: Port).locations_enabled(on) :: Void
+  Parameter.def Port.current_enable_locations
+    :: Any.to_boolean
+  method (port :: Port).next_location()
+    :: values(maybe(PostInt), maybe(NonnegInt), maybe(PosInt))
+  method (port :: Port).next_location(
+    line :: maybe(PostInt),
+    column :: maybe(NonnegInt),
+    offset :: maybe(PosInt)
+  ) :: Void
+){
+
+ The @rhombus(Port.locations_enabled) method checks or turns on whether
+ line, column, and decoded-character offsets are tracked as bytes are
+ read from a port or written to a port. Calling
+ @rhombus(Port.locations_enabled) with one argument attempts to enable or
+ disable his location tracking, but the port's state may not change,
+ either because it does not support tracking or because it does not
+ support disabling tracking after it's enabled. The
+ @rhombus(Port.current_enable_locations) parameter determines whether
+ tracking is enabled by default for a newly opened port, and its initial
+ value is @rhombus(#false).
+
+ The @rhombus(Port.next_location) method with zero arguments reports a
+ line, column, and offset for the next character to be read from the
+ port. If tracking is not enabled, then the first two results will be
+ @rhombus(#false), but @rhombus(port.position()+1) may be returned as an
+ approximation for the last result (i.e., a position measured in bytes
+ used as an approximation of the number of characters read). Calling
+ @rhombus(Port.next_location) with arguments attempts to set the next
+ location, but the attempt is ignored if location tracking has not been
+ enabled or if the port does not support external adjustments.
+
+}
+
+@doc(
+  fun Port.Output.open_input_output_file(
+    path :: PathString,
+    ~exists: exists_flag :: Port.Output.ExistsMode = #'error,
+    ~mode: mode :: Port.Mode = #'binary,
+    ~permissions: permissions :: Int.in(0, 65535) = 0o666,
+    ~replace_permissions: replace_permissions = #false
+  ) :: values(Port.Input, Port.Output)
+){
+
+ Like @rhombus(Port.Output.open_file), but returns both input and output
+ ports.The two ports are connected in that they share the underlying file
+ descriptor.
+
+ This procedure is intended for use with special devices that can be
+ opened by only one process, such as @filepath{COM1} in Windows. For
+ regular files, sharing the file descriptor can be confusing. For
+ example, using one port does not automatically flush the other port’s
+ buffer, and reading or writing in one port moves the file position (if
+ any) for the other port. For regular files, use separate
+ @rhombus(Port.Input.open_file) and @rhombus(Port.Output.open_file) calls
+ to avoid confusion.
 
 }
 
@@ -41,5 +181,31 @@ output; it is possible for an object to be both an input and output port.
 
  Modes for reading and writing files that determine how newlines are
  read and written.
+
+}
+
+@doc(
+ enum Port.BufferMode:
+   none
+   line
+   block
+){
+
+ Buffer modes for input and output ports; see @rhombus(Port.buffer). The
+ @rhombus(#'line) buffer mode is supported only for output ports.
+
+}
+
+@doc(
+ enum Port.WaitMode:
+   all
+   some
+   none
+   enable_break
+){
+
+ Modes used for methods like @rhombus(Port.Input.read_bytes_to) and
+ @rhombus(Port.Output.write_bytes_to) to determine how they block to wait
+ for input or output.
 
 }

--- a/rhombus/rhombus/scribblings/reference/printing.scrbl
+++ b/rhombus/rhombus/scribblings/reference/printing.scrbl
@@ -6,7 +6,7 @@
 
 @doc(
   fun print(v :: Any, ...,
-            ~out: out :: Port.Output = Port.Output.current(),
+            ~out: out :: Port.Output = stdout,
             ~mode: mode :: PrintMode = #'text,
             ~pretty: pretty = Printable.current_pretty())
     :: Void
@@ -44,7 +44,7 @@
 
 @doc(
   fun println(v :: Any, ...,
-              ~out: out :: Port.Output = Port.Output.current(),
+              ~out: out :: Port.Output = stdout,
               ~mode: mode :: PrintMode = #'text,
               ~pretty: pretty = Printable.current_pretty())
     :: Void
@@ -56,11 +56,11 @@
 
 @doc(
   fun show(v :: Any, ...,
-           ~out: out :: Port.Output = Port.Output.current(),
+           ~out: out :: Port.Output = stdout,
            ~pretty: pretty = Printable.current_pretty())
     :: Void
   fun showln(v :: Any, ...,
-             ~out: out :: Port.Output = Port.Output.current(),
+             ~out: out :: Port.Output = stdout,
              ~pretty: pretty = Printable.current_pretty())
     :: Void
 ){

--- a/rhombus/rhombus/scribblings/reference/static-info.scrbl
+++ b/rhombus/rhombus/scribblings/reference/static-info.scrbl
@@ -286,11 +286,14 @@
   @item{@rhombus(statinfo_meta.dot_provider_key): An identifier
         bound by @rhombus(dot.macro) @rhombus(dot.macro_more_static) to
         implement the expression's behavior as a @tech(~doc: guide_doc){dot provider},
-        or a packed sequence of such identifiers. In the case of a sequence, the
-        first identifier is used, but the rest is relevant for an
-        intersection of two sequences, which produces the shared tail,
-        and the union of two sequences, which picks the longer of two
-        sequences when one is a tail of the other.}
+        a packed sequence of such identifiers, or a packed sequence mixing
+        identifiers and packed sequences of identifiers. In the case of an overall
+        sequence, the first element is used to find a dot provider, and if that
+        element is itself a sequence, the dot providers are tried in order.
+        The rest of an overall sequence records progressively less-specific
+        dot providers, such as the dot providers for superclasses of a class
+        or superinterfaces of an interface. Intersection of overall sequences finds
+        a shared tail, while union of overall sequences combines elements pairwise.}
 
   @item{@rhombus(statinfo_meta.sequence_constructor_key): An identifier
         bound as a variable or a macro that is wrapped around an expression

--- a/rhombus/rhombus/scribblings/reference/string.scrbl
+++ b/rhombus/rhombus/scribblings/reference/string.scrbl
@@ -31,10 +31,12 @@ Strings are @tech{comparable}, which means that generic operations like
   annot.macro 'ReadableString':
     ~method_fallback: String
   annot.macro 'ReadableString.to_string'
+  annot.macro 'MutableString'
 ){
 
  Matches strings. The @rhombus(ReadableString, ~annot) annotation allows mutable
- Racket strings as well as immutable Rhombus strings.
+ Racket strings as well as immutable Rhombus strings, while @rhombus(MutableString, ~annot)
+ matches only mutable strings.
  The @rhombus(ReadableString.to_string, ~annot) @tech(~doc: guide_doc){converter annotation}
  allows the same strings as @rhombus(ReadableString, ~annot), but converts
  a mutable Racket string to an immutable Rhombus string, like
@@ -444,7 +446,7 @@ Strings are @tech{comparable}, which means that generic operations like
 }
 
 @doc(
-  method String.copy(str :: ReadableString) :: ReadableString
+  method String.copy(str :: ReadableString) :: MutableString
 ){
 
  Creates a mutable copy of @rhombus(str).

--- a/rhombus/rhombus/tests/port.rhm
+++ b/rhombus/rhombus/tests/port.rhm
@@ -3,32 +3,57 @@
 block:
   import "static_arity.rhm"
   static_arity.check:
+    Port.open_input_output_file(path)
+    Port.buffer(p, [mode])
+    Port.position(p, [mode])
+    Port.locations_enabled(p, [on])
     Port.Input.current([in])
     Port.Input.open_bytes(bstr, [name])
     Port.Input.open_string(str, [name])
+    Port.Input.open_file(path)
+    Port.Input.open_nowhere([name])
     // TODO fix tests for keyword arguments
     Port.Input.peek_byte(in) ~method
     Port.Input.peek_bytes(in, amount) ~method
+    Port.Input.peek_bytes_to(in, bstr) ~method
     Port.Input.peek_char(in) ~method
     Port.Input.peek_string(in, amount) ~method
+    Port.Input.peek_string_to(in, str) ~method
     Port.Input.read_byte(in) ~method
     Port.Input.read_bytes(in, amount) ~method
+    Port.Input.read_bytes_to(in, bstr) ~method
     Port.Input.read_char(in) ~method
     Port.Input.read_line(in) ~method
     Port.Input.read_string(in, amount) ~method
+    Port.Input.read_string_to(in, str) ~method
+    Port.Input.copy_to(p, out, ...)
+    Port.Input.Progress.evt(path)
+    Port.Input.Progress.is_evt(path, v)
+    Port.Input.Progress.commit(path)
     Port.Output.open_bytes([name])
     Port.Output.open_string([name])
+    Port.Output.open_file(path)
+    Port.Output.open_nowhere([name])
     Port.Output.get_bytes(out) ~method Port.Output.String
     Port.Output.get_string(out) ~method Port.Output.String
     Port.Output.flush([out]) ~method
     Port.Output.current([out])
     Port.Output.current_error([out])
-    Port.Output.write_bytes(out, b, [start], [end])
-    Port.Output.write_string(out, s, [start], [end])
+    Port.Output.write_byte(out, b)
+    Port.Output.write_char(out, s)
+    Port.Output.write_bytes(out, b)
+    Port.Output.write_string(out, s)
     Port.Output.print(v, ...) ~method
     Port.Output.println(v, ...) ~method
     Port.Output.show(v, ...) ~method
     Port.Output.showln(v, ...) ~method
+    Port.Output.Special.write(out, s)
+    Port.Output.Special.write(out, s)
+    Port.FileStream.try_lock(p, mode) ~method
+    Port.FileStream.identity(p) ~method
+    Port.FileStream.stat(p) ~method
+    Port.Pipe.make([name])
+    Port.Pipe.content_length(p) ~method
 
 block:
   check Port.eof ~is_a Port.EOF
@@ -43,19 +68,22 @@ block:
     ~is "no"
 
 block:
-  let p = Port.Input.open_string("abλcdefμ")
+  let p = Port.Input.open_string("axbλcdefμ")
   check p is_a Port.Input ~is #true
   check p is_a Port.Input.String ~is #true
   check p.peek_byte() ~is Char"a".to_int()
-  check p.peek_byte(~skip_bytes: 1) ~is Char"b".to_int()
+  check p.peek_byte(~special_wrap: values) ~is Char"a".to_int()
+  check p.peek_byte(~skip_bytes: 2) ~is Char"b".to_int()
   check p.read_byte() ~is Char"a".to_int()
+  check p.read_byte(~special_wrap: values) ~is Char"x".to_int()
   check p.peek_byte(~skip_bytes: 3) ~is Char"c".to_int()
   check p.peek_char() ~is Char"b"
+  check p.peek_char(~special_wrap: values) ~is Char"b"
   check p.peek_char(~skip_bytes: 1) ~is Char"λ"
   check p.peek_char(~skip_bytes: 3) ~is Char"c"
   check p.read_char() ~is Char"b"
   check p.read_char() ~is Char"λ"
-  check p.peek_char() ~is Char"c"
+  check p.peek_char(~special_wrap: values) ~is Char"c"
   check p.read_bytes(2) ~is_now #"cd".copy()
   check p.read_string(3) ~is "efμ"
 
@@ -72,6 +100,61 @@ block:
   check p.read_bytes(4) ~is Port.eof
 
 block:
+  let p = Port.Input.open_string("abcdefg")
+  let bstr = Bytes.make(10)
+  check p ~is_a Port.Input.Progress
+  check p.peek_bytes_to(bstr) ~is 7
+  check bstr[0] ~is Byte#"a"
+  check p.peek_bytes_to(bstr, ~wait: #'some) > 0 ~is #true
+  check bstr[0] ~is Byte#"a"
+  check p.peek_bytes_to(bstr, ~wait: #'none) > 0 ~is #true
+  check bstr[0] ~is Byte#"a"
+  check p.peek_bytes_to(bstr, ~wait: #'enable_break) > 0 ~is #true
+  check bstr[0] ~is Byte#"a"
+  check p.peek_bytes_to(bstr, ~wait: #'oops) ~throws values(error.annot_msg(),
+                                                            error.annot("Port.WaitMode").msg)
+  check p.peek_bytes_to(bstr, ~start: 5) ~is 5
+  check bstr[5] ~is Byte#"a"
+  check p.peek_bytes_to(bstr, ~end: 5) ~is 5
+  check p.peek_bytes_to(bstr, ~start: 1, ~end: 5) ~is 4
+
+  let evt: use_dynamic; p.evt()
+  check (p :: Port.Input.Progress).is_evt(evt) ~is #true
+  check p.peek_bytes_to(bstr, ~wait: #'some, ~progress: evt) ~is 7
+  check bstr[0] ~is Byte#"a"
+  check p.read_bytes_to(bstr, ~end: 1) ~is 1
+  check p.peek_bytes_to(bstr, ~wait: #'some, ~progress: evt) ~is 0
+  check p.peek_bytes_to(bstr) ~is 6
+  check bstr[0] ~is Byte#"b"
+  // Need evts filled in more to test this:
+  #//
+  block:
+    import rhombus/thread
+    check (p :: Port.Input.Progress).commit(3, evt, thread.Semaphore(1)) ~is 3
+
+block:
+  let p = Port.Input.open_string("abcdefg")
+  let bstr = Bytes.make(10)
+  check p ~is_a Port.Input.Progress
+  check p.read_bytes_to(bstr) ~is 7
+  check bstr[0] ~is Byte#"a"
+
+block:
+  let p = Port.Input.open_string("abcdefg")
+  let bstr = Bytes.make(10)
+  check p ~is_a Port.Input.Progress
+  check p.read_bytes_to(bstr, ~wait: #'some, ~end: 1) ~is 1
+  check bstr[0] ~is Byte#"a"
+  check p.read_bytes_to(bstr, ~wait: #'none, ~end: 1) ~is 1
+  check bstr[0] ~is Byte#"b"
+  check p.read_bytes_to(bstr, ~wait: #'enable_break, ~end: 1) ~is 1
+  check bstr[0] ~is Byte#"c"
+  check p.read_bytes_to(bstr, ~wait: #'oops) ~throws values(error.annot_msg(),
+                                                            error.annot("Port.WaitMode").msg)
+  check p.read_bytes_to(bstr, ~start: 5, ~end: 6) ~is 1
+  check bstr[5] ~is Byte#"d"
+  
+block:
   let p = Port.Input.open_string("abλcdefμ")
   check p is_a Port.Input ~is #true
   check p is_a Port.Input.String ~is #true
@@ -79,6 +162,28 @@ block:
   check p.peek_string(~skip_bytes: 2, 1) ~is "λ"
   check p.peek_string(3) ~is "abλ"
   check p.peek_string(1, ~skip_bytes: 4) ~is "c"
+
+block:
+  let p = Port.Input.open_string("abcdefg")
+  let str = String.make(10, Char"\0")
+  check p ~is_a Port.Input.Progress
+  check p.peek_string_to(str) ~is 7
+  check str[0] ~is Char"a"
+  check p.peek_string_to(str, ~start: 5) ~is 5
+  check str[5] ~is Char"a"
+  check p.peek_string_to(str, ~end: 5) ~is 5
+  check p.peek_string_to(str, ~start: 1, ~end: 5) ~is 4
+
+block:
+  let p = Port.Input.open_string("abcdefg")
+  let str = String.make(10, Char"x")
+  check p.read_string_to(str, ~end: 1) ~is 1
+  check str[0] ~is Char"a"
+  check str[1] ~is Char"x"
+  check p.read_string_to(str, ~start: 4, ~end: 6) ~is 2
+  check str[4] ~is Char"b"
+  check str[5] ~is Char"c"
+  check str[1] ~is Char"x"
 
 block:
   def str = "a\nb\rc\r\nd\n\re"
@@ -119,22 +224,22 @@ block:
   let p = Port.Output.open_bytes()
   p.write_bytes(#"apple")
   check p.get_bytes() ~is_now #"apple"
-  p.write_bytes(#"apple", 3)
+  p.write_bytes(#"apple", ~start: 3)
   check p.get_bytes() ~is_now #"applele"
-  p.write_bytes(#"apple", 1, 4)
+  p.write_bytes(#"apple", ~start: 1, ~end: 4)
   check p.get_bytes() ~is_now #"appleleppl"
 
 block:
   let p = Port.Output.open_bytes()
   p.write_string("apple")
   check p.get_bytes() ~is_now #"apple"
-  p.write_string("apple", 3)
+  p.write_string("apple", ~start: 3)
   check p.get_bytes() ~is_now #"applele"
-  p.write_string("apple", 1, 4)
+  p.write_string("apple", ~start: 1, ~end: 4)
   check p.get_bytes() ~is_now #"appleleppl"
   p.write_string("λ")
   check p.get_bytes() ~is_now #"appleleppl\316\273"
-  p.write_string("λλλλ", 1, 3)
+  p.write_string("λλλλ", ~start: 1, ~end: 3)
   check p.get_bytes() ~is_now #"appleleppl\316\273\316\273\316\273"
 
 // make sure `current` functions have static info
@@ -195,3 +300,116 @@ check:
     error.annot("Port.Output.String").msg,
     error.val("oops").msg,
   )
+
+check:
+  stdin ~is_a Port.Input
+  stdout ~is_a Port.Output
+  stderr ~is_a Port.Output
+  stdin.peek_bytes_to(Bytes.make(0)) ~is 0
+  stdout.write_bytes(#"") ~is 0
+  stderr.write_bytes(#"") ~is 0
+
+block:
+  let (in, out) = Port.Pipe.make()
+  check in ~is_a Port.Pipe
+  check out ~is_a Port.Pipe
+  check:
+    Port.Output.using out:
+      stdout.write_bytes(#"abcdef")
+    ~is 6
+  check in.content_length() ~is 6
+  check out.content_length() ~is 6
+  check:
+    Port.Input.using in:
+      stdin.read_bytes(2)
+    ~is_now #"ab"
+  check in.content_length() ~is 4
+
+block:
+  Closeable.let tmp = filesystem.make_temporary()
+  check:
+    Port.Output.using ~file tmp.path:
+      ~exists: #'truncate
+      stdout.write_bytes(#"hi")
+    ~is 2
+  check:
+    Port.Input.using ~file tmp.path:
+      stdin.read_bytes(5)
+    ~is_now #"hi"
+  check:
+    Port.Input.using Port.Input.open_file(tmp.path):
+      stdin.read_bytes(1)
+    ~is_now #"h"
+  block:
+    Closeable.let out = Port.Output.open_file(tmp.path, ~exists: #'update)
+    Closeable.let in = Port.Input.open_file(tmp.path)
+    check in ~is_a Port.FileStream
+    check out ~is_a Port.FileStream
+    check in is_a Port.FileStream.Terminal ~is #false
+    check out is_a Port.FileStream.Terminal ~is #false
+    check in.is_waiting_on_peer() ~is #false
+    check out.is_waiting_on_peer() ~is #false
+    check in.buffer() ~is #'block
+    check in.buffer(#'none) ~is #void
+    check in.buffer() ~is #'none
+    check out.buffer() ~is #'block
+    check out.buffer(#'line) ~is #void
+    check out.buffer() ~is #'line
+    check out.write_bytes(#"bye") ~is 3
+    check in.read_byte() ~is Byte#"h"
+    check out.write_bytes(#"\n") ~is 1
+    check in.read_byte() ~is Byte#"y"
+    check out.truncate(2) ~is #void
+    check in.read_byte() ~is Port.eof
+    check in.position() ~is 2
+    check in.position(0) ~is #void
+    check in.read_byte() ~is Byte#"b"
+    check in.identity() ~is out.identity()
+    check in.stat() ~is_a Map
+    check in.try_lock(#'shared) ~is #true
+    check in.unlock() ~is #void
+
+block:
+  Closeable.let tmp = filesystem.make_temporary()
+  let (in, out) = Port.open_input_output_file(tmp.path,
+                                              ~exists: #'truncate)
+  check out.write_bytes(#"abc") ~is 3
+  check in.position() ~is 0
+  check out.flush() ~is #void
+  check in.position() ~is 3
+  check in.read_bytes(10) ~is Port.eof
+  check in.position(0) ~is #void
+  check in.read_bytes(3) ~is_now #"abc"
+
+block:
+  check Port.Input.open_nowhere() ~is_a Port.Input
+  check Port.Input.open_nowhere().read_char() ~is Port.eof
+
+block:
+  check Port.Output.open_nowhere() ~is_a Port.Output
+  check Port.Output.open_nowhere().write_bytes(#"abc") ~is 3
+
+block:
+  let s = Port.Input.open_string("aλb\nc")
+  check s.locations_enabled() ~is #false
+  check s.locations_enabled(#true) ~is #void
+  check s.locations_enabled() ~is #true
+  check s.next_location() ~is values(1, 0, 1)
+  check s.read_char() ~is Char"a"
+  check s.next_location() ~is values(1, 1, 2)
+  check s.read_char() ~is Char"λ"
+  check s.next_location() ~is values(1, 2, 3)
+  check s.read_string(2) ~is "b\n"
+  check s.next_location() ~is values(2, 0, 5)
+  check s.next_location(10, 100, 1000) ~is #void
+  check s.next_location() ~is values(10, 100, 1000)
+  check s.read_char() ~is Char"c"
+  check s.next_location() ~is values(10, 101, 1001)
+
+block:
+  let s = Port.Input.open_string("aλb\nc")
+  let o1 = Port.Output.open_string()
+  let o2 = Port.Output.open_string()
+  s.copy_to(o1, o2)
+  check o1.get_string() ~is "aλb\nc"
+  check o2.get_string() ~is "aλb\nc"

--- a/rhombus/rhombus/tests/string.rhm
+++ b/rhombus/rhombus/tests/string.rhm
@@ -201,6 +201,10 @@ check:
   to_string("hello".copy(), ~mode: #'expr) ~is "String.copy(\"hello\")"
 
 check:
+  "a" is_a MutableString ~is #false
+  "a".copy() is_a MutableString ~is #true
+
+check:
   ~eval
   "a" :: StringCI
   ~throws "not allowed in a dynamic context"


### PR DESCRIPTION
Add everything from the Racket reference sections 13.1.1 through 13.1.17, except for `byte-ready?` and `char-ready?`.

Add `stdin` as a shorthand for `Port.Input.current()`, and similarly add `stdout` and `stderr`.

Add `Port.Input.using` and `Port.Output.using` forms as a shorthand for `Closeable.let` plus `parameterize` plus sometimes `open_file`:

```
Port.Input.using ~file "/tmp/data.txt":
  stdin.read_line()

Port.Input.using Port.Input.open_string("data"):
  stdin.read_line()

Port.Output.using ~file "/tmp/data.txt":
  ~exists: #'replace
  println("data")
```

Also generalize dot-provider handling so that an annotation like `Port.Input && Port.FileStream` can work and provide static access to all the methods of both `Port.Input` and `Port.FileStream`.