### PR TITLE
add `compose` and `compose_values`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/compose.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/compose.rhm
@@ -1,0 +1,62 @@
+#lang rhombus/private/amalgam/core
+import:
+  "core-meta.rkt" open
+  lib("racket/base.rkt") as rkt
+
+use_static
+
+export:
+  compose
+  rename: compose as ∘
+  compose_values
+
+meta:
+  fun parse_compose(self, left, right, one):
+    when one && syntax_meta.is_static(self)
+    | let left_arity = statinfo_meta.lookup(left, statinfo_meta.function_arity_key)
+      when left_arity
+      | unless statinfo_meta.check_function_arity(left_arity, 1, [])
+        | syntax_meta.error(~who: self,
+                            "function does not accept one argument (based on static information)",
+                            left)
+    let right_arity = statinfo_meta.lookup(right, statinfo_meta.function_arity_key)
+    let ret_mask:
+      if one
+      | 1 bits.(<<) 1
+      | let left_res = statinfo_meta.lookup(left, statinfo_meta.call_result_key)
+        match left_res && statinfo_meta.unpack_call_result(left_res)
+        | [[-1, info], & _]:
+            // result is the same for all argument counts, and
+            // is will indicate either be one or multiple values
+            let vals = statinfo_meta.find(info, statinfo_meta.values_key)
+            if vals
+            | 1 bits.(<<) statinfo_meta.unpack_group(vals).length()
+            | 1 bits.(<<) 1
+        | ~else:
+            // result value count unknown
+            -1
+    let res = statinfo_meta.lookup(left, statinfo_meta.call_result_key)
+    let res :~ List = if res | statinfo_meta.unpack_call_result(res) | []
+    let res_info:
+      for any ([mask, res_info]: res):
+        (mask bits.and ret_mask) != 0 && res_info
+    let e = 'rkt . $(if one | 'compose1' | 'compose')($left, $right)'
+    let e:
+      if res_info
+      | statinfo_meta.wrap(e, '(($statinfo_meta.call_result_key,
+                                 $(statinfo_meta.pack(res_info))))')
+      | e
+    let e:
+      if right_arity
+      | statinfo_meta.wrap(e, '(($statinfo_meta.function_arity_key,
+                                 $right_arity))')
+      | e
+    e
+
+expr.macro '$left compose $right':
+  ~op_stx: self
+  parse_compose(self, left, right, #true)
+
+expr.macro '$left compose_values $right':
+  ~op_stx: self
+  parse_compose(self, left, right, #false)

--- a/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
@@ -14,6 +14,7 @@
         "class_together.rhm"
         "enum.rhm"
         "pipeline.rhm"
+        "compose.rhm"
         "str.rhm"
         "closeable.rhm"
         "filesystem.rhm"

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -67,7 +67,8 @@
    buffer
    position
    locations_enabled
-   next_location))
+   next_location
+   name))
 
 (define-primitive-class Port.Input input-port
   #:lift-declaration
@@ -457,6 +458,10 @@
     [(p line col offset)
      (with-error-adjust-primitive ([set-port-next-location! Port.next_location])
        (set-port-next-location! p line col offset))]))
+
+(define/method (Port.name p)
+  (check-port who p)
+  (object-name p))
 
 (define/method (Port.FileStream.identity p)
   #:primitive (port-file-identity)

--- a/rhombus/rhombus/scribblings/reference/port.scrbl
+++ b/rhombus/rhombus/scribblings/reference/port.scrbl
@@ -174,6 +174,18 @@ output; it is possible for an object to be both an input and output port.
 }
 
 @doc(
+  method (port :: Port).name() :: Any
+){
+
+ Returns the port's name, which is typically represented by a
+ @tech{symbol} or @tech{path}, but can be any kind of value. A port's
+ name is used for printing and as a default for constructing source
+ locations.
+
+}
+
+
+@doc(
  enum Port.Mode:
    binary
    text

--- a/rhombus/rhombus/scribblings/reference/static-info.scrbl
+++ b/rhombus/rhombus/scribblings/reference/static-info.scrbl
@@ -107,6 +107,23 @@
 
 @doc(
   ~meta
+  fun statinfo_meta.check_function_arity(arity :: Syntax,
+                                         num_args :: NonnegInt,
+                                         arg_kws :: List.of(Keyword))
+    :: Boolean
+){
+
+ Takes packed arity information associated with
+ @rhombus(statinfo_meta.function_arity_key), the number of non-keyword
+ arguments in a function call, and a list of keywords for keyword
+ arguments in a function call, and reports whether the arguments are
+ consist with the packed arity information---that is, that the number and
+ keyword arguments will be accepted.
+
+}
+
+@doc(
+  ~meta
   fun statinfo_meta.pack_call_result([[arity_mask :: Int,
                                        statinfo_stx :: Syntax],
                                       ...])
@@ -257,6 +274,11 @@
  expression:
 
  @itemlist(
+
+  @item{@rhombus(statinfo_meta.function_arity_key): Packed information
+        about the number of arguments and keywords that are accepted if
+        the result value if the expression is called as a function;
+        see @rhombus(statinfo_meta.check_function_arity).}
 
   @item{@rhombus(statinfo_meta.call_result_key): Packed, per-arity static
         information for the result value if the expression is used as

--- a/rhombus/rhombus/tests/compose.rhm
+++ b/rhombus/rhombus/tests/compose.rhm
@@ -1,0 +1,19 @@
+#lang rhombus
+
+use_static
+
+check:
+  (List compose values)(1) ~is [1]
+  (List compose_values values)(1, 2, 3) ~is [1, 2, 3]
+  (List compose PairList)(1, 2, 3) ~is [PairList[1, 2, 3]]
+  (List ∘ PairList)(1, 2, 3) ~is [PairList[1, 2, 3]]
+  (List compose values)(1).length() ~is 1
+  (List compose_values values)(1, 2, 3).length() ~is 3
+  (List.cons compose_values values)(3, []) ~is [3]
+
+check:
+  ~eval
+  use_static
+  List.cons compose values
+  ~throws values("function does not accept one argument",
+                 "based on static information")

--- a/rhombus/rhombus/tests/function.rhm
+++ b/rhombus/rhombus/tests/function.rhm
@@ -440,3 +440,18 @@ block:
   check f(0, 1, 2, 3) ~is #'eff
   check f("no") ~throws "eff:"
   check f("no", 7) ~throws "eff:"
+
+block:
+  fun f1(x): x
+  fun f2(x, y = 1, ~z: z, ~w = #false): x
+  fun f3(x, y, z, & args): x
+  fun f4(x, ~y, & args, ~& kws): x
+  check f1.name() ~is #'f1
+  check f2.name() ~is #'f2
+  check print(f1.rename(#'helper)) ~prints "#<function:helper>"
+  check f1.arity() ~is values(2, [], [])
+  check f2.arity() ~is values(6, [#'~z], [#'~w, #'~z])
+  check f3.arity() ~is values(-8, [], [])
+  check f4.arity() ~is values(-2, [#'~y], #false)
+  check f2.reduce_arity(4, [#'~z], [#'~w, #'~z]) ~is_a Function
+  check f4.reduce_arity(32, [#'~y], [#'~a, #'~b, #'~c, #'~y]) ~is_a Function

--- a/rhombus/rhombus/tests/port.rhm
+++ b/rhombus/rhombus/tests/port.rhm
@@ -310,9 +310,11 @@ check:
   stderr.write_bytes(#"") ~is 0
 
 block:
-  let (in, out) = Port.Pipe.make()
+  let (in, out) = Port.Pipe.make(~input_name: #'my_in, ~output_name: #'my_out)
   check in ~is_a Port.Pipe
   check out ~is_a Port.Pipe
+  check in.name() ~is #'my_in
+  check out.name() ~is #'my_out
   check:
     Port.Output.using out:
       stdout.write_bytes(#"abcdef")


### PR DESCRIPTION
Also add `∘` as an alias for `compose`, and add `Function.arity`, `Function.reduce_arity`, `Function.name`, `Function.set_name`, and `Port.name`.