### PR TITLE
make syntax_class instances more object-like

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annot-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annot-macro.rkt
@@ -16,7 +16,8 @@
                      "call-result-key.rkt"
                      "values-key.rkt"
                      (for-syntax racket/base)
-                     "srcloc.rkt")
+                     "srcloc.rkt"
+                     "syntax-wrap.rkt")
          (only-in "space.rkt" space-syntax)
          "space-provide.rkt"
          (only-in "binding.rkt" :binding-form)
@@ -83,7 +84,7 @@
   (no-srcloc #`(parsed #:rhombus/annot #,stx)))
 
 (define-for-syntax (parse-annotation-macro-result form proc #:srcloc [loc (maybe-respan form)])
-  (unless (syntax? form)
+  (unless (syntax*? form)
     (raise-bad-macro-result (proc-name proc) "annotation" form))
   (syntax-parse (unpack-group form proc #f)
     [c::annotation (relocate+reraw loc #'c.parsed)]))
@@ -128,7 +129,7 @@
                                         #:srcloc (datum->syntax #f (list stx form)))))))
 
 (define-for-syntax (check-syntax who s)
-  (unless (syntax? s)
+  (unless (syntax*? s)
     (raise-annotation-failure who s "Syntax")))
 
 (define-for-syntax (annotation-kind stx who)

--- a/rhombus-lib/rhombus/private/amalgam/assign-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/assign-macro.rkt
@@ -14,6 +14,7 @@
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
                      "values-key.rkt"
+                     "syntax-wrap.rkt"
                      (for-syntax racket/base))
          "name-root.rkt"
          "macro-macro.rkt"
@@ -45,7 +46,7 @@
   #'#f)
 
 (define-for-syntax (extract-assignment form proc)
-  (syntax-parse (if (syntax? form)
+  (syntax-parse (if (syntax*? form)
                     (unpack-group form proc #f)
                     #'#f)
     #:datum-literals (parsed group assignment left-hand-side)
@@ -98,7 +99,7 @@
          form))))
 
 (define-for-syntax (check-syntax who s)
-  (unless (syntax? s)
+  (unless (syntax*? s)
     (raise-annotation-failure who s "Syntax")))
 
 (begin-for-syntax
@@ -146,7 +147,7 @@
      #':assign-parsed
      #:arity 8
      #:kind 'group
-     #:fields #'((parsed #f parsed 0 (unpack-parsed* '#:rhombus/expr))
-                 (tail #f tail tail unpack-tail-list*))
+     #:fields #'((parsed #f parsed 0 (unpack-parsed* '#:rhombus/expr) stx)
+                 (tail #f tail tail unpack-tail-list* stx))
      #:root-swap '(parsed . group)))
   )

--- a/rhombus-lib/rhombus/private/amalgam/builtin-dot.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/builtin-dot.rkt
@@ -3,6 +3,7 @@
          "treelist.rkt"
          "mutable-treelist.rkt"
          "pipe-port.rkt"
+         "syntax-wrap.rkt"
          (submod "dot.rkt" for-builtin)
          (submod "map.rkt" for-builtin)
          (submod "set.rkt" for-builtin)
@@ -38,7 +39,8 @@
     [(treelist? v) treelist-method-table]
     [(list? v) list-method-table]
     [(vector? v) array-method-table]
-    [(syntax? v) syntax-method-table]
+    [(syntax*? v) (merge (syntax-field-table v)
+                         syntax-method-table)]
     [(pair? v) pair-method-table]
     [(string? v) string-method-table]
     [(bytes? v) bytes-method-table]

--- a/rhombus-lib/rhombus/private/amalgam/class-clause-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-clause-macro.rkt
@@ -6,7 +6,8 @@
                      "macro-result.rkt"
                      (submod "class-meta.rkt" for-static-info)
                      (only-in "static-info.rkt"
-                              get-empty-static-infos))
+                              get-empty-static-infos)
+                     "syntax-wrap.rkt")
          "space-provide.rkt"
          "class+interface.rkt"
          "class-clause.rkt"
@@ -47,6 +48,6 @@
   (lambda (stx data)
     (define defns (syntax-parse stx
                     [(head . tail) (proc (pack-tail #'tail) #'head data)]))
-    (unless (syntax? defns)
+    (unless (syntax*? defns)
       (raise-bad-macro-result (proc-name proc) "`class` clause" defns))
     (datum->syntax #f (unpack-multi defns proc #f))))

--- a/rhombus-lib/rhombus/private/amalgam/context-stx.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/context-stx.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 (require syntax/parse/pre
          "pack.rkt"
-         "annotation-failure.rkt")
+         "annotation-failure.rkt"
+         "syntax-wrap.rkt")
 
 (provide extract-ctx
          extract-group-ctx)
@@ -14,7 +15,7 @@
                      #:update-outer [update-outer (lambda (outer-stx innner-stx) outer-stx)]
                      #:annot [annot #f])
   (and (or (not false-ok?) ctx-stx)
-       (let ([t (and (syntax? ctx-stx)
+       (let ([t (and (syntax*? ctx-stx)
                      (unpack-term ctx-stx #f #f))])
          (unless t
            (raise-annotation-failure who ctx-stx (or annot (if false-ok? "maybe(Term)" "Term"))))
@@ -54,7 +55,7 @@
                            #:update-outer [update-outer (lambda (outer-stx innner-stx) outer-stx)]
                            #:annot [annot #f])
   (and (or (not false-ok?) ctx-stx)
-       (let ([t (and (syntax? ctx-stx)
+       (let ([t (and (syntax*? ctx-stx)
                      (unpack-group ctx-stx #f #f))])
          (unless t
            (raise-annotation-failure who ctx-stx (or annot (if false-ok? "maybe(Group)" "Group"))))

--- a/rhombus-lib/rhombus/private/amalgam/decl-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/decl-macro.rkt
@@ -11,6 +11,7 @@
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
+                     "syntax-wrap.rkt"
                      (for-syntax racket/base))
          (only-in "space.rkt" space-syntax)
          "space-provide.rkt"
@@ -50,7 +51,7 @@
         (unpack-declarations (proc (pack-tail #'tail) #'head) proc)]))))
 
 (define-for-syntax (unpack-declarations form proc)
-  (syntax-parse (and (syntax? form) (unpack-multi form proc #f))
+  (syntax-parse (and (syntax*? form) (unpack-multi form proc #f))
     #:datum-literals (group)
     [((group d ...) ...)
      #`((rhombus-top (group d ...))

--- a/rhombus-lib/rhombus/private/amalgam/defn-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/defn-macro.rkt
@@ -11,6 +11,7 @@
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
+                     "syntax-wrap.rkt"
                      (for-syntax racket/base))
          (only-in "space.rkt" space-syntax)
          "space-provide.rkt"
@@ -41,7 +42,7 @@
      (unpack-definitions defns proc))))
 
 (define-for-syntax (unpack-definitions form proc)
-  (syntax-parse (and (syntax? form) (unpack-multi form proc #f))
+  (syntax-parse (and (syntax*? form) (unpack-multi form proc #f))
     [(g ...)
      #`((rhombus-definition g)
         ...)]

--- a/rhombus-lib/rhombus/private/amalgam/dot.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/dot.rkt
@@ -190,7 +190,6 @@
                      tail)]
             [_ (lookup)])])]))
   (define dp-ids (extract-dot-provider-ids dp-id/s))
-  ;; make sure only one in `dp-ids` provides an answer
   (let loop ([dp-ids dp-ids])
     (cond
       [(null? dp-ids) (generic)]

--- a/rhombus-lib/rhombus/private/amalgam/entry-point-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/entry-point-macro.rkt
@@ -14,6 +14,7 @@
                      (submod "syntax-object.rkt" for-quasiquote)
                      (submod "symbol.rkt" for-static-info)
                      "call-result-key.rkt"
+                     "syntax-wrap.rkt"
                      (for-syntax racket/base))
          "space-provide.rkt"
          "entry-point.rkt"
@@ -52,7 +53,7 @@
     Shape :entry-point-shape #:rhombus/entry_point_shape))
 
 (define-for-syntax (extract-entry-point form proc adjustments)
-  (syntax-parse (if (syntax? form)
+  (syntax-parse (if (syntax*? form)
                     (unpack-group form proc #f)
                     #'#f)
     [(~var ep (:entry-point adjustments)) #'ep.parsed]

--- a/rhombus-lib/rhombus/private/amalgam/export-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/export-macro.rkt
@@ -7,6 +7,7 @@
                      "macro-result.rkt"
                      "tail-returner.rkt"
                      "name-root.rkt"
+                     "syntax-wrap.rkt"
                      (submod "syntax-class-primitive.rkt" for-syntax-class)
                      (submod "syntax-object.rkt" for-quasiquote)
                      (for-syntax racket/base))
@@ -45,7 +46,7 @@
     #:arity 2))
 
 (define-for-syntax (extract-modifier form proc req)
-  (syntax-parse (if (syntax? form)
+  (syntax-parse (if (syntax*? form)
                     (unpack-group form proc #f)
                     #'#f)
     [(~var i (:export-modifier req)) #'i.parsed]
@@ -76,7 +77,7 @@
     AfterInfixParsed :infix-op+export+tail))
 
 (define-for-syntax (extract-export form proc)
-  (syntax-parse (if (syntax? form)
+  (syntax-parse (if (syntax*? form)
                     (unpack-group form proc #f)
                     #'#f)
     [i::export #'i.parsed]

--- a/rhombus-lib/rhombus/private/amalgam/expr-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/expr-macro.rkt
@@ -15,6 +15,7 @@
                      "call-result-key.rkt"
                      "values-key.rkt"
                      "maybe-key.rkt"
+                     "syntax-wrap.rkt"
                      (for-syntax racket/base))
          (only-in "space.rkt" space-syntax)
          "space-provide.rkt"
@@ -121,7 +122,7 @@
                                    proc)))))
 
 (define-for-syntax (check-syntax who s)
-  (unless (syntax? s)
+  (unless (syntax*? s)
     (raise-annotation-failure who s "Syntax")))
 
 (begin-for-syntax

--- a/rhombus-lib/rhombus/private/amalgam/expression.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/expression.rkt
@@ -8,7 +8,8 @@
                      "introducer.rkt"
                      "expression-space.rkt"
                      (for-syntax racket/base)
-                     "macro-result.rkt")
+                     "macro-result.rkt"
+                     "syntax-wrap.rkt")
          (only-in "definition.rkt"
                   in-defn-space
                   definition-transformer-ref
@@ -81,8 +82,8 @@
     id)
 
   (define (check-expression-result form proc)
-    (unless (syntax? form) (raise-bad-macro-result (proc-name proc) "expression" form))
-    form)
+    (unless (syntax*? form) (raise-bad-macro-result (proc-name proc) "expression" form))
+    (syntax-unwrap form))
 
   (define-syntax (expr-quote stx)
     (syntax-case stx ()

--- a/rhombus-lib/rhombus/private/amalgam/immediate-callee-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/immediate-callee-macro.rkt
@@ -15,6 +15,7 @@
                      (submod "symbol.rkt" for-static-info)
                      (submod "list.rkt" for-listable)
                      "static-info-pack.rkt"
+                     "syntax-wrap.rkt"
                      (for-syntax racket/base))
          "space-provide.rkt"
          "immediate-callee.rkt"
@@ -62,12 +63,12 @@
     (make-syntax-class #':immediate-callee/split
                        #:kind 'group
                        #:arity 8 ; actually an arity mask
-                       #:fields #'((parsed #f parsed 0 (unpack-parsed* '#:rhombus/expr))
-                                   (tail #f tail tail unpack-tail-list*))
+                       #:fields #'((parsed #f parsed 0 (unpack-parsed* '#:rhombus/expr) stx)
+                                   (tail #f tail tail unpack-tail-list* stx))
                        #:root-swap '(parsed . group))))
 
 (define-for-syntax (extract-immediate-callee form tail proc static-infoss op-mode op-stx)
-  (define stx (if (syntax? form)
+  (define stx (if (syntax*? form)
                   (unpack-group form proc #f)
                   (raise-bad-macro-result (proc-name proc) "expression" form)))
   (cond

--- a/rhombus-lib/rhombus/private/amalgam/import-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/import-macro.rkt
@@ -7,6 +7,7 @@
                      "macro-result.rkt"
                      "tail-returner.rkt"
                      "name-root.rkt"
+                     "syntax-wrap.rkt"
                      (submod "syntax-class-primitive.rkt" for-syntax-class)
                      (submod "syntax-object.rkt" for-quasiquote)
                      (for-syntax racket/base))
@@ -45,7 +46,7 @@
     #:arity 2))
 
 (define-for-syntax (extract-modifier form proc req)
-  (syntax-parse (if (syntax? form)
+  (syntax-parse (if (syntax*? form)
                     (unpack-group form proc #f)
                     #'#f)
     [(~var i (:import-modifier req)) #'i.parsed]
@@ -76,7 +77,7 @@
     AfterInfixParsed :infix-op+import+tail))
 
 (define-for-syntax (extract-import form proc)
-  (syntax-parse (if (syntax? form)
+  (syntax-parse (if (syntax*? form)
                     (unpack-group form proc #f)
                     #'#f)
     [i::import #'i.parsed]

--- a/rhombus-lib/rhombus/private/amalgam/import.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/import.rkt
@@ -16,6 +16,7 @@
                      "tag.rkt"
                      "id-binding.rkt"
                      "operator-parse.rkt"
+                     "syntax-wrap.rkt"
                      (for-syntax racket/base))
          "enforest.rkt"
          "name-root.rkt"
@@ -132,7 +133,7 @@
     #:desc "import modifier"
     #:parsed-tag #:rhombus/impo
     #:in-space in-import-space
-    #:transformer-ref (make-import-modifier-ref (syntax-parse parsed-req
+    #:transformer-ref (make-import-modifier-ref (syntax-parse (syntax-unwrap parsed-req)
                                                   #:datum-literals (parsed)
                                                   [(parsed #:rhombus/impo req) #'req]
                                                   [_ (raise-arguments-error

--- a/rhombus-lib/rhombus/private/amalgam/interface-clause-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/interface-clause-macro.rkt
@@ -4,7 +4,8 @@
                      enforest/proc-name
                      "pack.rkt"
                      "macro-result.rkt"
-                     (submod "interface-meta.rkt" for-static-info))
+                     (submod "interface-meta.rkt" for-static-info)
+                     "syntax-wrap.rkt")
          "space-provide.rkt"
          "interface-clause.rkt"
          "macro-macro.rkt")
@@ -23,6 +24,6 @@
    (lambda (stx data)
      (define defns (syntax-parse stx
                      [(head . tail) (proc (pack-tail #'tail) #'head data)]))
-     (unless (syntax? defns)
+     (unless (syntax*? defns)
        (raise-bad-macro-result (proc-name proc) "`interface` clause" defns))
      (datum->syntax #f (unpack-multi defns proc #f)))))

--- a/rhombus-lib/rhombus/private/amalgam/macro-rhs.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/macro-rhs.rkt
@@ -119,8 +119,8 @@
                            #:as-tail? #t
                            #:splice? #t
                            #:splice-pattern values)))
-    (with-syntax ([((id id-ref) ...) idrs]
-                  [(((sid ...) sid-ref) ...) sidrs]
+    (with-syntax ([((id id-ref . _) ...) idrs]
+                  [(((sid ...) sid-ref . _) ...) sidrs]
                   [(left-id ...) left-ids])
       (define body
         (cond
@@ -137,7 +137,7 @@
           [else
            #`(rhombus-body-expression #,rhs)]))
       #`[#,pattern
-         (let ([id id-ref] ... [#,self-id self] [left-id left] ...)
+         (let* ([id id-ref] ... [#,self-id self] [left-id left] ...)
            (define-static-info-syntax #,self-id #:getter get-syntax-static-infos)
            (define-static-info-syntax left-id #:getter get-syntax-static-infos)
            ...
@@ -482,8 +482,8 @@
                                                                                                             #:splice-pattern values))
                                     (define-values (extra-patterns wrap-extra)
                                       (build-extra-patterns in-extra-ids extra-binds-stx extra-get-static-infoss-stx extra-shapes))
-                                    (with-syntax ([((p-id id-ref) ...) idrs]
-                                                  [(((s-id ...) sid-ref) ...) sidrs])
+                                    (with-syntax ([((p-id id-ref . _) ...) idrs]
+                                                  [(((s-id ...) sid-ref . _) ...) sidrs])
                                       #`[#,pattern
                                          #,@(if cut? #'(#:cut) '())
                                          #,@extra-patterns
@@ -495,7 +495,7 @@
                                                    (define-static-info-syntax #,all-id #:getter get-syntax-static-infos))
                                                 '())
                                          #,(wrap-extra
-                                            #`(let ([p-id id-ref] ...)
+                                            #`(let* ([p-id id-ref] ...)
                                                 (let-syntaxes ([(s-id ...) sid-ref] ...)
                                                   #,(wrap-for-tail
                                                      #`(rhombus-body-expression rhs)))))])]))
@@ -530,8 +530,8 @@
                                     (lambda (body)
                                       (define-values (pattern idrs sidrs vars can-be-empty?)
                                         (convert-pattern #`(multi . #,gs-stx)))
-                                      (with-syntax ([((p-id id-ref) ...) idrs]
-                                                    [(((s-id ...) sid-ref) ...) sidrs])
+                                      (with-syntax ([((p-id id-ref . _) ...) idrs]
+                                                    [(((s-id ...) sid-ref . _) ...) sidrs])
                                         #`(syntax-parse extra-tail
                                             #:context (insert-multi-front-head-group orig-head extra-tail)
                                             #:disable-colon-notation
@@ -544,7 +544,7 @@
                                                        (define-static-info-syntax #,all-id #:getter get-syntax-static-infos))
                                                     '())
                                              #,(wrap-extra
-                                                #`(let ([p-id id-ref] ...)
+                                                #`(let* ([p-id id-ref] ...)
                                                     (let-syntaxes ([(s-id ...) sid-ref] ...)
                                                       #,body)))])))))
 
@@ -589,14 +589,14 @@
                           #:as-tail? #t
                           #:splice? #t
                           #:splice-pattern values)]))
-    (with-syntax ([((p-id id-ref) ...) idrs]
-                  [(((s-id ...) sid-ref) ...) sidrs])
+    (with-syntax ([((p-id id-ref . _) ...) idrs]
+                  [(((s-id ...) sid-ref . _) ...) sidrs])
       (values
        (append (reverse (syntax->list
                          #`(#:with #,pattern (unpack-tail #,in-extra-id #f #f))))
                rev-withs)
        (lambda (x)
-         #`(let ([p-id id-ref] ...)
+         #`(let* ([p-id id-ref] ...)
              (let-syntaxes ([(s-id ...) sid-ref] ...)
                #,(wrap x))))))))
 

--- a/rhombus-lib/rhombus/private/amalgam/module-path.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/module-path.rkt
@@ -10,6 +10,7 @@
                      "introducer.rkt"
                      "macro-result.rkt"
                      "module-path-parse.rkt"
+                     "syntax-wrap.rkt"
                      (for-syntax racket/base))
          "name-root.rkt"
          "parens.rkt")
@@ -62,7 +63,8 @@
 
   (define current-module-path-context (make-parameter 'import))
 
-  (define (check-module-path-result form proc)
+  (define (check-module-path-result form-in proc)
+    (define form (syntax-unwrap form-in))
     (unless (and (syntax? form)
                  (module-path? (syntax->datum form)))
       (raise-bad-macro-result (proc-name proc) "module path" form))

--- a/rhombus-lib/rhombus/private/amalgam/pattern-variable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/pattern-variable.rkt
@@ -1,23 +1,41 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
-                     "srcloc.rkt")
+                     enforest/hier-name-parse
+                     enforest/syntax-local
+                     "name-path-op.rkt"
+                     "srcloc.rkt"
+                     "dotted-sequence.rkt"
+                     "pack.rkt")
          "expression.rkt"
+         (submod "annotation.rkt" for-class)
          (submod "syntax-class-primitive.rkt" for-quasiquote)
+         (submod "dot.rkt" for-dot-provider)
          "dollar.rkt"
          "repetition.rkt"
          "static-info.rkt"
-         (submod "syntax-object.rkt" for-quasiquote))
+         (submod "syntax-object.rkt" for-quasiquote)
+         "syntax-wrap.rkt"
+         "dot-provider-key.rkt"
+         "syntax-class-attributes-key.rkt"
+         "name-root-space.rkt"
+         "name-root-ref.rkt"
+         "parens.rkt")
 
 (provide (for-syntax make-pattern-variable-bind
                      deepen-pattern-variable-bind
-                     extract-pattern-variable-bind-id-and-depth))
+                     extract-pattern-variable-bind-id-and-depth
+                     normalize-pvar-statinfos
+                     get-syntax-class-static-infos
+                     build-wrap-syntax-for-attributes))
 
-(define-for-syntax (make-pattern-variable-bind name-id temp-id unpack* depth attrib-lists)
+(define-for-syntax (make-pattern-variable-bind name-id temp-id unpack* depth
+                                               #:statinfos [statinfos (get-syntax-static-infos)]
+                                               #:attribs [attrib-lists '()]
+                                               #:key [key #f])
   (define no-repetition?
     (and (eqv? 0 depth)
-         (for/and ([a (in-list attrib-lists)])
-           (eqv? 0 (pattern-variable-depth (list->pattern-variable a))))))
+         (null? attrib-lists)))
   (define ids (if no-repetition?
                   (list name-id)
                   (list name-id (in-repetition-space name-id))))
@@ -26,62 +44,77 @@
              (quote-syntax #,temp-id)
              (quote-syntax #,unpack*)
              #,depth
+             (quote-syntax #,statinfos)
              (quote-syntax #,attrib-lists)
-             #,no-repetition?)])
+             #,no-repetition?
+             (quote #,key))
+     #,@statinfos])
 
 (define-for-syntax (deepen-pattern-variable-bind sidr)
   (syntax-parse sidr
-    [(ids (make-pattern-variable-syntaxes self-id temp-id unpack* depth attrs expr?))
+    [(ids (make-pattern-variable-syntaxes self-id temp-id unpack* depth statinfos attrs expr? key) . sis)
      (define new-ids
        (syntax-parse #'ids
          [(id) #`(id #,(in-repetition-space #'id))]
          [_ #'ids]))
-     #`(#,new-ids (make-pattern-variable-syntaxes self-id temp-id unpack* #,(add1 (syntax-e #'depth)) attrs #f))]))
+     #`(#,new-ids (make-pattern-variable-syntaxes self-id temp-id unpack* #,(add1 (syntax-e #'depth)) statinfos attrs #f key) . sis)]))
 
 (define-for-syntax (extract-pattern-variable-bind-id-and-depth sids sid-ref)
   (list (car (syntax-e sids))
         (syntax-parse sid-ref
           [(make-pattern-variable-syntaxes _ _ _ depth . _) #'depth])))
 
-(define-for-syntax (make-pattern-variable-syntaxes name-id temp-id unpack* depth attributes no-repetition?)
-  (define (lookup-attribute stx var-id attr-id want-repet?)
-    (define attr (for/or ([var (in-list (syntax->list attributes))])
-                   (and (eq? (syntax-e attr-id) (syntax-e (car (syntax-e var))))
-                        (syntax-list->pattern-variable var))))
-    ;; complain if a repetition field is not being used as such, but
-    ;; don't complain if a field is not found, because maybe the dot is
-    ;; an access of a `Syntax` method
-    (when attr
-      (unless (eq? want-repet? (not (eqv? 0 (+ depth (pattern-variable-depth attr)))))
-        (raise-syntax-error #f
-                            (format
-                             (string-append (if want-repet?
-                                                "field is not a repetition\n"
-                                                "field is a repetition\n")
-                                            "  pattern: ~a\n"
-                                            "  attribute: ~a")
-                             (syntax-e var-id)
-                             (syntax-e attr-id))
-                            stx)))
-    attr)
+
+(define-for-syntax (get-syntax-class-static-infos statinfos attributes)
+  (cond
+    [(null? (syntax-e attributes))
+     statinfos]
+    [else
+     (define dp/s (extract-dot-provider-ids (static-info-lookup (normalize-pvar-statinfos statinfos)
+                                                                #'#%dot-provider)))
+     (define stx-dp-id (get-syntax-instances))
+     (if (for/or ([id (in-list dp/s)])
+           (free-identifier=? (in-dot-provider-space id)
+                              (in-dot-provider-space stx-dp-id)))
+         #`((#%dot-provider ((pattern-variable-dot-provider #,stx-dp-id) #,stx-dp-id))
+            (#%syntax-class-attributes #,attributes))
+         statinfos)]))
+
+(define-for-syntax (build-attribute-hash attributes #:vars [ids #f])
+  (define vars (map syntax-list->pattern-variable (syntax->list attributes)))
+  (define key-uses (for/fold ([counts #hasheq()]) ([var (in-list vars)])
+                     (hash-update counts (pattern-variable-sym var) add1 0)))
+  (define (multi-use? key) ((hash-ref key-uses key) . > . 1))
+  #`(hasheq
+     #,@(apply
+         append
+         (append
+          (for/list ([key (in-hash-keys key-uses)]
+                     #:when (multi-use? key))
+            (list #`(quote #,key) #'(quote ambiguous)))
+          (for/list ([var (in-list vars)]
+                     [id (in-list (or ids (map pattern-variable-val-id vars)))]
+                     #:unless (multi-use? (pattern-variable-sym var)))
+            (list #`(quote #,(pattern-variable-sym var))
+                  #`(cons #,id #,(pattern-variable-depth var))))))))
+
+(define-for-syntax (make-pattern-variable-syntaxes name-id temp-id unpack* depth statinfos attributes no-repetition? key)
   (define expr-handler
     (lambda (stx fail)
-      (syntax-parse stx
-        #:datum-literals (op |.|)
-        [(var-id (op |.|) attr-id . tail)
-         #:do [(define attr (lookup-attribute stx #'var-id #'attr-id #f))]
-         #:when attr
-         (values (wrap-static-info* (pattern-variable-val-id attr)
-                                    (get-syntax-static-infos))
-                 #'tail)]
-        [_
-         (if (eqv? depth 0)
-             (id-handler stx)
-             (fail))])))
+      (if (eqv? depth 0)
+          (id-handler stx)
+          (fail))))
   (define id-handler
     (lambda (stx)
       (syntax-parse stx
-        [(_ . tail) (values (wrap-static-info* temp-id (get-syntax-static-infos)) #'tail)])))
+        [(_ . tail) (values (if (null? (syntax-e attributes))
+                                (wrap-static-info* temp-id (get-syntax-static-infos))
+                                (wrap-static-info* #`(maybe-syntax-wrap
+                                                      (syntax-unwrap #,temp-id)
+                                                      (quote #,key)
+                                                      #,(build-attribute-hash attributes))
+                                                   statinfos))
+                            #'tail)])))
   (cond
     [no-repetition?
      (if (null? (syntax-e attributes))
@@ -92,30 +125,181 @@
             (expr-handler stx
                           (lambda ()
                             (id-handler stx))))))]
-    [else (make-expression+repetition
-           #`(([(elem) (in-list (#,unpack* #'$ #,temp-id #,depth))])
-              #,@(for/list ([i (in-range (sub1 depth))])
-                   #`([(elem) (in-list elem)])))
-           #'elem
-           get-syntax-static-infos
-           #:repet-handler (lambda (stx next)
-                             (syntax-parse stx
-                               #:datum-literals (op |.|)
-                               [(var-id (~and dot-op (op |.|)) attr-id . tail)
-                                #:do [(define attr (lookup-attribute stx #'var-id #'attr-id #t))]
-                                #:when attr
-                                (define var-depth (+ (pattern-variable-depth attr) depth))
-                                (values (make-repetition-info (respan #'(var-id dot-op attr-id))
-                                                              #`(([(elem) (in-list
-                                                                           (#,(pattern-variable-unpack* attr)
-                                                                            #'$
-                                                                            #,(pattern-variable-val-id attr)
-                                                                            #,var-depth))])
-                                                                 #,@(for/list ([i (in-range (sub1 var-depth))])
-                                                                      #`([(elem) (in-list elem)])))
-                                                              #'elem
-                                                              (get-syntax-static-infos)
-                                                              0)
-                                        #'tail)]
-                               [_ (next)]))
-           #:expr-handler expr-handler)]))
+    [else
+     (define attrs (syntax->list attributes))
+     (define attr-tmps (generate-temporaries attrs))
+     (make-expression+repetition
+      (cond
+        [(= depth 0)
+         #'()]
+        [(null? attrs)
+         #`(([(elem) (in-list (#,unpack* #'$ #,temp-id #,depth))])
+            #,@(for/list ([i (in-range (sub1 depth))])
+                 #`([(elem) (in-list elem)])))]
+        [else
+         #`(([(elem) (in-list (#,unpack* #'$ #,temp-id #,depth))]
+             #,@(for/list ([var (in-list attrs)]
+                           [tmp (in-list attr-tmps)])
+                  (define attr (syntax-list->pattern-variable var))
+                  #`[(#,tmp) (in-list #,(pattern-variable-val-id attr))]))
+            #,@(for/list ([i (in-range (sub1 depth))])
+                 #`([(elem) (in-list elem)]
+                    #,@(for/list ([tmp (in-list attr-tmps)])
+                         #`[(#,tmp) (in-list #,tmp)]))))])
+      (cond
+        [(= depth 0)
+         (let-values ([(e tail) (id-handler #'(x))])
+           e)]
+        [(null? attrs)
+         #'elem]
+        [else
+         #`(maybe-syntax-wrap
+            elem
+            (quote #,key)
+            #,(build-attribute-hash (datum->syntax #f attrs) #:vars attr-tmps))])
+      (lambda () statinfos)
+      #:repet-handler (lambda (stx next) (next))
+      #:expr-handler expr-handler)]))
+
+(define-for-syntax (build-wrap-syntax-for-attributes base-stx key attributes)
+  (cond
+    [(and key (pair? (syntax-e attributes)))
+     ;; some patterns in "quasiquote.rkt" rely on the #`(maybe-syntax-wrap #,base-stx . _) shape
+     #`(maybe-syntax-wrap #,base-stx
+                          (quote #,key)
+                          #,(build-attribute-hash attributes))]
+    [else base-stx]))
+
+(define-syntax pattern-variable-dot-provider
+  (dot-provider
+   (lambda (form1 dot field-id
+                  tail
+                  more-static?
+                  repetition?
+                  success-k fail-k)
+     (define-values (attributes depth)
+       (cond
+         [repetition?
+          (syntax-parse form1
+            [rep-info::repetition-info
+             (values (static-info-lookup #'rep-info.element-static-infos #'#%syntax-class-attributes)
+                     (length (syntax->list #'rep-info.for-clausess)))])]
+         [else
+          (values
+           (or (syntax-local-static-info form1 #'#%syntax-class-attributes)
+               #'())
+           0)]))
+     (define attrs (for/list ([var (in-list (syntax->list attributes))]
+                              #:when (eq? (syntax-e field-id) (syntax-e (car (syntax-e var)))))
+                     (syntax-list->pattern-variable var)))
+     (define attr (and (pair? attrs) (car attrs)))
+     (when (and (pair? attrs) (pair? (cdr attrs)))
+       (raise-syntax-error #f
+                           "field name is ambiguous"
+                           (datum->syntax #f (list form1 dot field-id))
+                           field-id))
+     (cond
+       [attr
+        (unless (eq? (and repetition? #t)
+                     (not (eqv? 0 (+ depth (pattern-variable-depth attr)))))
+          (raise-syntax-error #f
+                              (if repetition?
+                                  "field is not a repetition"
+                                  "field is a repetition")
+                              (datum->syntax #f (list form1 dot field-id))
+                              field-id))
+        (values
+         (cond
+           [repetition?
+            (define var-depth (pattern-variable-depth attr))
+            (syntax-parse form1
+              [form-rep-info::repetition-info
+               (define e #`(#,(pattern-variable-unpack* attr)
+                            #'$
+                            (car (hash-ref (syntax-wrap-attribs form-rep-info.body)
+                                           (quote #,(pattern-variable-sym attr))))
+                            #,var-depth))
+               (make-repetition-info (respan (datum->syntax #f (list form1 dot field-id)))
+                                     (cond
+                                       [(= var-depth 0)
+                                        #'form-rep-info.for-clausess]
+                                       [else
+                                        #`(#,@#'form-rep-info.for-clausess
+                                           ([(elem) (in-list #,e)])
+                                           #,@(for/list ([i (in-range (sub1 var-depth))])
+                                                #`([(elem) (in-list elem)])))])
+                                     (cond
+                                       [(= var-depth 0) e]
+                                       [else #'elem])
+                                     (normalize-pvar-statinfos (pattern-variable-statinfos attr))
+                                     0)])]
+           [else
+            (wrap-static-info* #`(car (hash-ref (syntax-wrap-attribs #,form1)
+                                                (quote #,(pattern-variable-sym attr))))
+                               (normalize-pvar-statinfos (pattern-variable-statinfos attr)))])
+         tail)]
+       [else
+        (fail-k)]))))
+
+(begin-for-syntax
+  (set-parse-syntax-of-annotation!
+   (lambda (stx)
+     (syntax-parse stx
+       #:datum-literals (group)
+       [(_ (_::parens (group seq::dotted-identifier-sequence)) . tail)
+        (define (bad [constraint ""])
+          (raise-syntax-error #f (string-append "not a syntax class" constraint) stx #'seq))
+        (syntax-parse #'seq
+          [(~var name (:hier-name-seq in-name-root-space in-syntax-class-space name-path-op name-root-ref))
+           (define rsc (syntax-local-value* (in-syntax-class-space #'name.name) syntax-class-ref))
+           (cond
+             [rsc
+              (unless (rhombus-syntax-class-key rsc)
+                (bad " with fields"))
+              (define (root-swap attrs)
+                (cond
+                  [(rhombus-syntax-class-root-swap rsc)
+                   => (lambda (swap)
+                        (datum->syntax
+                         #f
+                         (cons
+                          (pattern-variable->list
+                           (pattern-variable (cdr swap)
+                                             'dummy 'dummy
+                                             0
+                                             (case (rhombus-syntax-class-kind rsc)
+                                               [(group) #'unpack-group*]
+                                               [(term) (if (rhombus-syntax-class-splicing? rsc)
+                                                           #'unpack-element*
+                                                           #'unpack-term*)]
+                                               [else #'unpack-element*])
+                                             'stx))
+                          (for/list ([attr (in-list (syntax->list attrs))]
+                                     #:do [(define pv (syntax-list->pattern-variable attr))]
+                                     #:unless (eq? (car swap) (pattern-variable-sym pv)))
+                            attr))))]
+                  [else attrs]))
+              (define statinfos
+                (cond
+                  [(rhombus-syntax-class-root-swap rsc)
+                   => (lambda (swap)
+                        (or (for/or ([attr (in-list (syntax->list (rhombus-syntax-class-attributes rsc)))])
+                              (define pv (syntax-list->pattern-variable attr))
+                              (and (eq? (car swap) (pattern-variable-sym pv))
+                                   (normalize-pvar-statinfos (pattern-variable-statinfos pv))))
+                            #'()))]
+                  [else (get-syntax-static-infos)]))
+              (values
+               (annotation-predicate-form #`(lambda (v)
+                                              (and (syntax-wrap? v)
+                                                   (eq? (syntax-wrap-key v) (quote #,(rhombus-syntax-class-key rsc)))))
+                                          (get-syntax-class-static-infos statinfos
+                                                                         (root-swap (rhombus-syntax-class-attributes rsc))))
+               #'tail)]
+             [else (bad)])]
+          [else (bad)])]))))
+
+(define-for-syntax (normalize-pvar-statinfos pvar-sis)
+  (if (eq? pvar-sis 'stx)
+      (get-syntax-static-infos)
+      pvar-sis))

--- a/rhombus-lib/rhombus/private/amalgam/print.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/print.rkt
@@ -14,7 +14,8 @@
          "annotation-failure.rkt"
          "print-desc.rkt"
          "key-comp-property.rkt"
-         "enum.rkt")
+         "enum.rkt"
+         "syntax-wrap.rkt")
 
 (provide (for-spaces (#f
                       rhombus/statinfo)
@@ -414,8 +415,8 @@
                         [else "{"]))
          elems
          (pretty-text "}"))))]
-    [(syntax? v)
-     (define s (syntax->datum v))
+    [(syntax*? v)
+     (define s (syntax->datum (syntax-unwrap v)))
      (define qs
        (cond
          [(and (pair? s) (eq? 'multi (car s)))

--- a/rhombus-lib/rhombus/private/amalgam/reducer-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/reducer-macro.rkt
@@ -14,6 +14,7 @@
                      "define-arity.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
+                     "syntax-wrap.rkt"
                      (for-syntax racket/base))
          "space-provide.rkt"
          "definition.rkt"
@@ -65,7 +66,7 @@
   #`(parsed #:rhombus/reducer #,stx))
 
 (define-for-syntax (extract-reducer form proc)
-  (syntax-parse (if (syntax? form)
+  (syntax-parse (if (syntax*? form)
                     (unpack-group form proc #f)
                     #'#f)
     [b::reducer #'b.parsed]
@@ -109,7 +110,7 @@
                           proc)))))
 
 (define-for-syntax (check-syntax who s)
-  (unless (syntax? s)
+  (unless (syntax*? s)
     (raise-annotation-failure who s "Syntax")))
 
 (define-for-syntax (unpack-identifier who id-in [annot-str "Identifier"])

--- a/rhombus-lib/rhombus/private/amalgam/repet-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/repet-macro.rkt
@@ -15,8 +15,9 @@
                      (submod "syntax-object.rkt" for-quasiquote)
                      "call-result-key.rkt"
                      "maybe-key.rkt"
-                     (for-syntax racket/base)
-                     "srcloc.rkt")
+                     "syntax-wrap.rkt"
+                     "srcloc.rkt"
+                     (for-syntax racket/base))
          (only-in "space.rkt" space-syntax)
          "treelist.rkt"
          "space-provide.rkt"
@@ -72,7 +73,7 @@
     #:property prop:repetition-infix-operator (lambda (self) (prefix+infix-infix self))))
 
 (define-for-syntax (extract-repetition form proc)
-  (syntax-parse (if (syntax? form)
+  (syntax-parse (if (syntax*? form)
                     (unpack-group form proc #f)
                     #'#f)
     [b::repetition #'b.parsed]
@@ -119,7 +120,7 @@
                              proc)))))
 
 (define-for-syntax (check-syntax who s)
-  (unless (syntax? s)
+  (unless (syntax*? s)
     (raise-annotation-failure who s "Syntax")))
 
 (begin-for-syntax

--- a/rhombus-lib/rhombus/private/amalgam/repetition.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/repetition.rkt
@@ -193,7 +193,7 @@
                           want-depth
                           depth))
      (define infos (if (identifier? #'rep-info.element-static-infos)
-                       (extract-static-infos #'rep-info.element-static-infos)
+                       (datum->syntax #f (extract-static-infos #'rep-info.element-static-infos))
                        #'rep-info.element-static-infos))
      (define (add-disappeared stx)
        (add-repetition-disappeared stx #'rep-info.rep-expr))

--- a/rhombus-lib/rhombus/private/amalgam/simple-pattern.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/simple-pattern.rkt
@@ -45,11 +45,13 @@
   (syntax-parse tail-pattern
     [() null]
     [(_ name _)
-     (list
-      #`(define-syntaxes . #,(make-pattern-variable-bind #'name tail #'unpack-tail-list* 1 '())))]
+     (with-syntax ([(ids rhs . _) (make-pattern-variable-bind #'name tail #'unpack-tail-list* 1)])
+       (list
+        #`(define-syntaxes ids rhs)))]
     [(_ name _ _)
-     (list
-      #`(define-syntaxes . #,(make-pattern-variable-bind #'name tail #'unpack-tail* 0 '())))]))
+     (with-syntax ([(ids rhs . _) (make-pattern-variable-bind #'name tail #'unpack-tail* 0)])
+       (list
+        #`(define-syntaxes ids rhs)))]))
 
 ;; add tail or not for an `enforest`-based simple pattern
 (define-for-syntax (maybe-return-tail expr tail-pattern tail)

--- a/rhombus-lib/rhombus/private/amalgam/static-info-pack.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/static-info-pack.rkt
@@ -1,13 +1,14 @@
 #lang racket/base
 (require syntax/parse/pre
          "realm.rkt"
-         "parens-sc.rkt")
+         "parens-sc.rkt"
+         "syntax-wrap.rkt")
 
 (provide unpack-static-infos
          pack-static-infos)
 
 (define (unpack-static-infos who stx)
-  (syntax-parse stx
+  (syntax-parse (syntax-unwrap stx)
     [((key val) ...)
      #'(parens (group (parens (group key) (group val))) ...)]
     [_ (raise-arguments-error* who rhombus-realm
@@ -15,7 +16,7 @@
                                "syntax object" stx)]))
 
 (define (pack-static-infos who stx)
-  (syntax-parse stx
+  (syntax-parse (syntax-unwrap stx)
     #:datum-literals (group multi)
     [(_::parens (group (_::parens (group key) (group val))) ...)
      #'((key val) ...)]

--- a/rhombus-lib/rhombus/private/amalgam/syntax-class-attributes-key.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/syntax-class-attributes-key.rkt
@@ -1,0 +1,11 @@
+#lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt")
+
+(define-static-info-key-syntax/provide #%syntax-class-attributes
+  (static-info-key (lambda (a b)
+                     ;; FIXME
+                     a)
+                   (lambda (a b)
+                     ;; FIXME
+                     #'())))

--- a/rhombus-lib/rhombus/private/amalgam/syntax-wrap.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/syntax-wrap.rkt
@@ -1,0 +1,73 @@
+#lang racket/base
+
+(provide syntax-wrap
+         syntax-wrap?
+         syntax-wrap-key
+         syntax-wrap-attribs
+         syntax-unwrap
+         syntax*?
+         maybe-syntax-wrap)
+
+;; Two possible implementations of wrapped syntax to hold syntax-class
+;; fields:
+;;
+;;   * as a struct
+;;
+;;   * as a gensym-keyed property
+;;
+;; A wrapped syntax object is meant to be unwrapped auotamically
+;; before it is put into any larger syntax object or before any syntax
+;; object on the object, because we don't want extra data for fields
+;; kept indefinitely. So, a struct wrapper is ok, and it's safer
+;; overall (i.e., detects missing unwraps more often). Using a struct
+;; sets up a cross-phase problem for error reporting, however. Using a
+;; property avoids trat problem and smooths over potentialy
+;; interoperability problems at the small risk of keeping fields alive
+;; longer than intended.
+
+#;
+(begin
+  (struct syntax-wrap (stx key attribs)
+    #:guard (lambda (s k a name)
+              (unless (syntax? s)
+                (error "bad syntax wrap"))
+              (values s k a)))
+
+  (define (syntax-unwrap s)
+    (if (syntax-wrap? s)
+        (syntax-wrap-stx s)
+        s))
+
+  (define (syntax*? v)
+    (or (syntax? v)
+        (syntax-wrap? v))))
+
+(begin
+  (define wrapper-key (gensym 'syntax-wrapper))
+
+  (define (syntax-wrap stx key attribs)
+    (syntax-property stx wrapper-key (cons key  attribs)))
+
+  (define (syntax-wrap? v)
+    (and (syntax? v)
+         (syntax-property v wrapper-key)
+         #t))
+
+  (define (syntax-unwrap s)
+    (if (syntax? s)
+        (syntax-property s wrapper-key #f)
+        s))
+
+  (define (syntax-wrap-key s)
+    (car (syntax-property s wrapper-key)))
+
+  (define (syntax-wrap-attribs s)
+    (cdr (syntax-property s wrapper-key)))
+
+  (define (syntax*? v)
+    (syntax? v)))
+
+(define (maybe-syntax-wrap stx key attribs)
+  (cond
+    [(syntax*? stx) (syntax-wrap (syntax-unwrap stx) key attribs)]
+    [else stx]))

--- a/rhombus-lib/rhombus/private/amalgam/unquote-binding-identifier.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/unquote-binding-identifier.rkt
@@ -20,5 +20,5 @@
          [temp2 (cadr temps)])
     (result temp1
             (list #`[#,temp2 (#,pack* (syntax #,temp1) 0)])
-            (list (make-pattern-variable-bind id temp2 unpack* 0 null))
-            (list (pattern-variable (syntax-e id) id temp2 0 unpack*)))))
+            (list (make-pattern-variable-bind id temp2 unpack* 0))
+            (list (pattern-variable (syntax-e id) id temp2 0 unpack* 'stx)))))

--- a/rhombus-lib/rhombus/private/amalgam/veneer-clause-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/veneer-clause-macro.rkt
@@ -4,7 +4,8 @@
                      enforest/proc-name
                      "pack.rkt"
                      "macro-result.rkt"
-                     (submod "veneer-meta.rkt" for-static-info))
+                     (submod "veneer-meta.rkt" for-static-info)
+                     "syntax-wrap.rkt")
          "space-provide.rkt"
          "veneer-clause.rkt"
          "macro-macro.rkt")
@@ -23,6 +24,6 @@
    (lambda (stx data)
      (define defns (syntax-parse stx
                      [(head . tail) (proc (pack-tail #'tail) #'head data)]))
-     (unless (syntax? defns)
+     (unless (syntax*? defns)
        (raise-bad-macro-result (proc-name proc) "`veneer` clause" defns))
      (datum->syntax #f (unpack-multi defns proc #f)))))

--- a/rhombus/rhombus/scribblings/reference/stxobj.scrbl
+++ b/rhombus/rhombus/scribblings/reference/stxobj.scrbl
@@ -47,6 +47,13 @@ object that represents a pair of parentheses, brackets, braces or
 quotes, where the tail string corresponds to the closer, and the tail
 suffix corresponds to text after the closer.
 
+A syntax object that results from a match using a @tech{syntax class}
+annotation has have fields in addition to the methods of all syntax
+objects. If a field from a syntax class has the same name as a
+@rhombus(Syntax) method, the field takes precedence for dynamic access
+and for static access using @rhombus(Syntax.matched_of, ~annot) with the syntax
+class's name.
+
 @doc(
   ~also_meta
   expr.macro '«#%quotes '$term ...; ...'»'
@@ -262,6 +269,37 @@ suffix corresponds to text after the closer.
 )
 
 }
+
+
+@doc(
+  annot.macro 'Syntax.matched_of($name)'
+){
+
+ Satisfied by a @tech{syntax object} that was produced by a match to a
+ syntax pattern with a @rhombus(::, ~unquote_bind) annotation and the
+ syntax class @rhombus(name). The static information of
+ @rhombus(Syntax.matched_of(name), ~annot) provides statically resolved
+ access to fields declared by the syntax class, including fields that are
+ repetitions.
+
+@examples(
+  ~defn:
+    syntax_class ManyThenOne
+    | '$a ... $b'
+  ~defn:
+    fun describe(mto :: Syntax.matched_of(ManyThenOne)):
+      "matched " +& [mto.a, ...] +& " followed by " +& mto.b
+  ~repl:
+    def '$(mto :: ManyThenOne)' = '1 2 3 4'
+    [mto.a, ...]
+    describe(mto)
+    ~error:
+      dynamic(mto).a
+    dynamic(mto).b
+)
+
+}
+
 
 @doc(
   ~also_meta

--- a/rhombus/rhombus/tests/syntax-class.rhm
+++ b/rhombus/rhombus/tests/syntax-class.rhm
@@ -159,6 +159,96 @@ block:
     | '$(f :: Foo)': [f.x, ...]
     ~matches ['(1, 2, 3)', 'z']
 
+block:
+  syntax_class Foo
+  | '$a ... $b'
+
+  syntax_class Bar
+  | '($(f :: Foo))'
+
+  check:
+    match '(1 3)'
+    | '$(b :: Bar)': b.f
+    ~matches '1 3'
+
+  check:
+    match '(1 2 3)'
+    | '$(b :: Bar)': b.f.b
+    ~matches '3'
+
+  check:
+    match '(1 2 3)'
+    | '$(b :: Bar)': dynamic(b).f.b
+    ~matches '3'
+
+  check:
+    match '(1 2 3)'
+    | '$(b :: Bar)': dynamic(b.f).a
+    ~throws "field is a repetition"
+
+block:
+  syntax_class Foo:
+    root_swap: a group
+  | '$a $b'
+
+  syntax_class Bar
+  | '($(f :: Foo))'
+
+  check:
+    match '(1 3)'
+    | '$(b :: Bar)': b.f
+    ~matches '1'
+
+  check:
+    match '(1 3)'
+    | '$(b :: Bar)': b.f.b
+    ~matches '3'
+
+block:
+  syntax_class Foo:
+  | '$a $b; $c; ...'
+
+  syntax_class Bar
+  | '($(f :: Foo))'
+
+  check:
+    match '1 3'
+    | '$(f :: Foo)': (f).b
+    ~matches '3'
+
+  check:
+    match '1 3'
+    | '$(f :: Foo)': dynamic(f).b
+    ~matches '3'
+
+  check:
+    match '(1 3) (5 7)'
+    | '($(f :: Foo)) ...': [(f).b, ...]
+    ~matches ['3', '7']
+
+  check:
+    match '(1 3) (5 7)'
+    | '($(f :: Foo)) ...': [dynamic(f).b, ...]
+    ~matches ['3', '7']
+
+  check:
+    match '(1 3)'
+    | '$(r :: Bar)': ((r).f).b
+    ~matches '3'
+
+block:
+  syntax_class Foo:
+    kind: ~group
+  | '$a $b'
+
+  syntax_class Bar
+  | '($(f :: Foo))'
+
+  check:
+    match '(1 3)'
+    | '$(r :: Bar)': ((r).f).b
+    ~matches '3'
+
 // check that right-hand side of pattern
 // is in a more nested scope than pattern variables
 block:
@@ -438,7 +528,7 @@ check:
       field form: '~lang'
   match '(~lang, ~lang)'
   | '($(o :: Option), ...)': [o.form]
-  ~throws "field is a repetition"
+  ~throws "cannot use expression binding as a repetition"
 
 check:
   ~eval
@@ -447,7 +537,7 @@ check:
       field form: '~lang'
   match '(~lang, ~lang)'
   | '($(o :: Option), ...)': [o.form]
-  ~throws "field is a repetition"
+  ~throws "cannot use expression binding as a repetition"
 
 block:
   syntax_class NTerms
@@ -754,10 +844,6 @@ block:
     m(['8 1', '9 2 3'])
     ~matches ['1', '2']
 
-// The following two tests currently do not work due to how
-// repetitions are handled.  If these are to be fixed, the
-// corresponding `::` forms should also be fixed.
-#//
 block:
   fun m(stx):
     def [pattern match
@@ -772,7 +858,6 @@ block:
     m(['8 1', '9 2 3'])
     ~matches ['1', '2']
 
-#//
 block:
   fun m(stx):
     def [pattern match:
@@ -817,6 +902,76 @@ block:
     m(['8 1', '9 2 3'])
     ~matches ['1', '2']
 
+block:
+  use_static
+
+  syntax_class Foo
+  | '$a $b'
+
+  check:
+    match '1 4'
+    | '$(x :: Foo)': [(x).a, (x).b]
+    ~matches ['1', '4']
+
+block:
+  use_static
+
+  syntax_class Foo
+  | '$a ... $b'
+
+  check:
+    match '1 2 3 4'
+    | '$(x :: Foo)': [(x).a, ...]
+    ~matches ['1', '2', '3']
+
+  check:
+    match '(1 2 3 4) (5 6)'
+    | '($(x :: Foo)) ...': [[(x).a, ...], ...]
+    ~matches [['1', '2', '3'], ['5']]
+
+  fun help(x :: Syntax.matched_of(Foo)):
+    [[x.a, ...], x.b]
+
+  check:
+    match '1 2 3 4'
+    | '$(x :: Foo)': help(x)
+    ~matches [['1', '2', '3'], '4']
+
+check:
+  let (pattern match
+       | '9 $x $_'
+       | '8 $x'):
+    '8 1'
+  (match).x
+  ~matches '1'
+
+check:
+  match ['(8 1)', '(9 2 3)']
+  | ['($(pattern match
+         | '9 $x $_'
+         | '8 $x'))', ...]:
+      [match.x, ...]
+  ~matches ['1', '2']
+
+check:
+  match '(8 1)'
+  | '($(pattern match
+        | '9 $x $_'
+        | '8 $x'))':
+      (match).x
+  ~matches '1'
+
+block:
+  import rhombus/meta open
+  use_static
+  expr.macro 'boo $(e :: expr_meta.Parsed) $()':
+    fun help(s :: Syntax.matched_of(expr_meta.Parsed)):
+      s.group
+    '('$(help(e))')'
+  check:
+    boo 1 + 2
+    ~matches '1 + 2'
+
 // check interaction of macro introduction and pattern variables
 block:
   import rhombus/meta open
@@ -846,35 +1001,24 @@ block:
       matcher x
       ~matches '1'
 
-// field names are recognized symbolically
-// Is this the expected behavior?  I think it is.
-block:
+// field names are recognized symbolically, so  make
+// sure they're not ambigious
+check:
+  ~eval
   import rhombus/meta open
-  check:
-    expr.macro 'matcher $(ex :: Term)':
-      '«match '1 2'
-        | (pattern who | '$('$')x $('$')$ex'): who.x»'
-    matcher x
-    ~matches '2'
-  check:
-    expr.macro 'matcher $(ex :: Term)':
-      '«match '1 2'
-        | (pattern who | '$('$')x $('$')$ex'): who . $ex»'
-    matcher x
-    ~matches '2'
-  version_guard.at_least "8.10":
-    check:
-      expr.macro 'matcher $(ex :: Term)':
-        '«match '1 2'
-          | (pattern who | '$('$')$ex $('$')x'): who.x»'
-      matcher x
-      ~matches '2'
-    check:
-      expr.macro 'matcher $(ex :: Term)':
-        '«match '1 2'
-          | (pattern who | '$('$')$ex $('$')x'): who . $ex»'
-      matcher x
-      ~matches '2'
+  expr.macro 'matcher $(ex :: Term)':
+    '«match '1 2'
+      | (pattern who | '$('$')x $('$')$ex'): who.x»'
+  matcher x
+  ~throws "field name is ambiguous"
+
+check:
+  import rhombus/meta open
+  expr.macro 'matcher $(ex :: Term)':
+    '«match '1 2'
+      | (pattern who | '$('$')x $('$')$ex'): dynamic(who).x»'
+  matcher x
+  ~throws "field name is ambiguous"
 
 // check (not) `open`ing named `pattern`s
 check:
@@ -1043,6 +1187,12 @@ check:
   | '$first $second'
   ~throws "field for root already exists"
 
+check:
+  ~eval
+  syntax_class C:
+    root_swap: first other
+  | '$first ... $second'
+  ~throws "field for root cannot be a repetition"
 
 check:
   syntax_class.together:


### PR DESCRIPTION
When p is a pattern variable that is annotated with syntax class C, then preserve the fields of p on the syntax-object value of p, instead of allowing access to the fields only statically within the scope of the binding. This change also fixes the problem where binding via `pattern` did not preserve fields outside the `pattern` form.

A new `Syntax.matched_of` annotation constructor recognizes syntax objects that are the result of matches to the syntax class C and provides statically resolved access to the fields, which supports passing a syntax object from a class-annotated match to a helper function. Along similar lines, a field in a syntax class can be an instance of another syntax class retains its nested fields.

A syntax class more like a veneer than a class in one way: it provides access to fields that are repetitions, while those fields cannot be accessed dynamically (since dynamic access of a repetition doesn't work in general).

To implement a syntax object with fields, one strategy is to use wrapper struct; then, the Rhombus `Syntax` annotation is either a syntax object or a wrapped one. That strategy is best for checking that fields are pruned at the right boundaries, but it creates some cross-phase persistence issues, at least for error reporting. The strategy enabled here is to attach fields through a syntax property, instead.

Fixes #534