### PR TITLE
Add missing `~size` argument to triangle

### DIFF
--- a/rhombus-pict-lib/rhombus/pict/private/static.rhm
+++ b/rhombus-pict-lib/rhombus/pict/private/static.rhm
@@ -1245,8 +1245,9 @@ fun polygon([pt :: draw.PointLike.to_point, ...],
   )
 
 fun triangle(~around: around :: maybe(Pict) = #false,
-             ~width: width :: AutoReal = #'auto,
-             ~height: height :: AutoReal = #'auto,
+             ~size: size :: AutoReal = #'auto,
+             ~width: width :: AutoReal = size,
+             ~height: height :: AutoReal = size,
              ~fill: fill :: maybe(ColorMode) = #false,
              ~line: line :: maybe(ColorMode) = !fill && #'inherit,
              ~line_width: line_width :: LineWidth = #'inherit,

--- a/rhombus-pict/rhombus/pict/scribblings/shape.scrbl
+++ b/rhombus-pict/rhombus/pict/scribblings/shape.scrbl
@@ -183,6 +183,8 @@
   fun triangle(
     ~around: around :: maybe(Pict) = #false,
     ~size: size :: AutoReal = #'auto,
+    ~width: width :: AutoReal = size,
+    ~height: height :: AutoReal = size,
     ~fill: fill :: maybe(ColorMode) = #false,
     ~line: line :: maybe(ColorMode) = !fill && #'inherit,
     ~line_width: line_width :: LineWidth = #'inherit,
@@ -197,6 +199,7 @@
  Like @rhombus(rectangle), but for an isosceles triangle with a base
  along the bottom of a rectangle defined by @rhombus(width) and
  @rhombus(height) and a vertex at the center of the top of the rectangle.
+ As a short hand, the @rhombus(size) argument can be used as both the width and height.
 
 @examples(
   ~eval: pict_eval

--- a/rhombus-pict/rhombus/pict/scribblings/shape.scrbl
+++ b/rhombus-pict/rhombus/pict/scribblings/shape.scrbl
@@ -199,7 +199,8 @@
  Like @rhombus(rectangle), but for an isosceles triangle with a base
  along the bottom of a rectangle defined by @rhombus(width) and
  @rhombus(height) and a vertex at the center of the top of the rectangle.
- As a short hand, the @rhombus(size) argument can be used as both the width and height.
+ As a shorthand, the @rhombus(size) argument can be used as both the
+ @rhombus(width) and @rhombus(height).
 
 @examples(
   ~eval: pict_eval


### PR DESCRIPTION
The documentation for `triangle` mentions a `~size` argument, but it was missing from the implementation.
We could consider disallowing the use of `size` at the same time as both `width` and `height`.