### PR TITLE
add operator orders for relative precedence

### DIFF
--- a/enforest/enforest/scribblings/api.scrbl
+++ b/enforest/enforest/scribblings/api.scrbl
@@ -7,6 +7,8 @@
                      racket/contract/base
                      syntax/parse))
 
+@(define order-struct @racket[order])
+
 @title{Enforestation API}
 
 @section{Name Roots}
@@ -64,20 +66,32 @@
 
 @defmodule[enforest/operator]
 
-@defstruct*[operator ([precs (or (procedure-arity-includes/c 0)
-                                 (listof (cons/c (or/c identifier? 'default)
-                                                 (or/c 'stronger 'weaker
-                                                       'same 'same-on-left 'same-on-right))))]
+@defstruct*[operator ([order (or (procedure-arity-includes/c 0)
+                                 identifier?
+                                 #f)]
+                      [precedences (or (procedure-arity-includes/c 0)
+                                       (listof (cons/c (or/c identifier? 'default)
+                                                       (or/c 'stronger 'weaker
+                                                             'same 'same-on-left 'same-on-right))))]
                       [protocol (or/c 'macro 'automatic)]
                       [proc procedure?])
             #:omit-constructor]{
 
- The @racket[precs] field is either a list or a function that produces
+ The @racket[order] field is an optional identifier or procedure to
+ return an identifier. The identifier indicates a general
+ classification of the operator that other operators (and operator
+ orders) can use to specify a precedence relationship to the operator.
+ The operator can also be bound to an instance of @|order-struct| and
+ also to provide a precedence information to augment the
+ @racket[precs] field.
+
+ The @racket[precedences] field is either a list or a function that produces
  a list on demand. The list is an association list from identifiers to
  @racket['stronger], @racket['weaker], @racket['same],
  @racket['same-on-left], or @racket['same-on-right], indicating that
  the operator's precedence is stronger than, weaker than, or the same
- as (when on the indicated side of) the associated identifier;
+ as (when on the indicated side of) the associated identifier, which
+ refers to either an operator or an operator order;
  @racket['default] can be used instead of an identifier to specify a
  default relationship.
 
@@ -138,6 +152,19 @@
 
  Returns @racket[v] if it is an instance of @racket[infix-operator],
  @racket[#f] otherwise.
+
+}
+
+@defstruct*[order ([precedences (or (procedure-arity-includes/c 0)
+                                    (listof (cons/c (or/c identifier? 'default)
+                                                    (or/c 'stronger 'weaker
+                                                          'same 'same-on-left 'same-on-right))))]
+                   [assoc (or/c 'left 'right 'none)])
+            #:omit-constructor]{
+
+ Represents an operator order for reference via the @racket[order, ~datum] field
+ of an @racket[operator]. The @racket[precedences] field is as in @racket[operator],
+ and the @racket[assoc] field is as in @racket[infix-operator].
 
 }
 

--- a/rhombus-lib/rhombus/fixnum.rhm
+++ b/rhombus-lib/rhombus/fixnum.rhm
@@ -18,37 +18,49 @@ export:
 // Rhombus's built-in rewrite table
 
 unsafeable.operator ((x :~ Fixnum) + (y :~ Fixnum)) :~ Fixnum:
+  ~order: addition
   rkt.#{fx+}(x, y)
 
-unsafeable.operator
+unsafeable.operator:
 | ((x :~ Fixnum) - (y :~ Fixnum)) :~ Fixnum:
+    ~order: addition
     rkt.#{fx-}(x, y)
 | (- (y :~ Fixnum)) :~ Fixnum:
     rkt.#{fx-}(y)
 
 unsafeable.operator ((x :~ Fixnum) * (y :~ Fixnum)) :~ Fixnum:
+  ~order: multiplication
   rkt.#{fx*}(x, y)
 
 unsafeable.operator ((x :~ Fixnum) div (y :~ Fixnum)) :~ Fixnum:
+  ~order: integer_division
   rkt.#{fxquotient}(x, y)
 
 unsafeable.operator ((x :~ Fixnum) mod (y :~ Fixnum)) :~ Fixnum:
+  ~order: integer_division
   rkt.#{fxmodulo}(x, y)
 
 unsafeable.operator ((x :~ Fixnum) rem (y :~ Fixnum)) :~ Fixnum:
+  ~order: integer_division
   rkt.#{fxremainder}(x, y)
 
 unsafeable.operator ((x :~ Fixnum) < (y :~ Fixnum)):
+  ~order: comparison
   rkt.#{fx<}(x, y)
 unsafeable.operator ((x :~ Fixnum) <= (y :~ Fixnum)):
+  ~order: comparison
   rkt.#{fx<=}(x, y)
 unsafeable.operator ((x :~ Fixnum) == (y :~ Fixnum)):
+  ~order: comparison
   rkt.#{fx=}(x, y)
 unsafeable.operator ((x :~ Fixnum) != (y :~ Fixnum)):
+  ~order: comparison
   ! rkt.#{fx=}(x, y)
 unsafeable.operator ((x :~ Fixnum) >= (y :~ Fixnum)):
+  ~order: comparison
   rkt.#{fx>=}(x, y)
 unsafeable.operator ((x :~ Fixnum) > (y :~ Fixnum)):
+  ~order: comparison
   rkt.#{fx>}(x, y)
 
 unsafeable.fun abs(x :~ Fixnum) :~ Fixnum:
@@ -80,21 +92,27 @@ namespace bits:
       rkt.#{fxrshift/logical}(x, y)
 
 unsafeable.operator ((x :~ Fixnum) << (y :~ Fixnum)):
+  ~order: bitwise_shift
   rkt.#{fxlshift}(x, y)
 
 unsafeable.operator ((x :~ Fixnum) >> (y :~ Fixnum)):
+  ~order: bitwise_shift
   rkt.#{fxrshift}(x, y)
 
 unsafeable.operator ((x :~ Fixnum) and (y :~ Fixnum)):
+  ~order: bitwise_conjunction
   rkt.#{fxand}(x, y)
 
 unsafeable.operator ((x :~ Fixnum) or (y :~ Fixnum)):
+  ~order: bitwise_disjunction
   rkt.#{fxior}(x, y)
 
 unsafeable.operator ((x :~ Fixnum) xor (y :~ Fixnum)):
+  ~order: bitwise_disjunction
   rkt.#{fxxor}(x, y)
 
 unsafeable.operator (not (x :~ Fixnum)):
+  ~order: bitwise_negation
   rkt.#{fxnot}(x)
 
 unsafeable.fun popcount(x :~ Fixnum) :~ Fixnum:
@@ -118,18 +136,22 @@ namespace wraparound:
       <<
 
   unsafeable.operator ((x :~ Fixnum) + (y :~ Fixnum)) :~ Fixnum:
+    ~order: addition
     rkt.#{fx+/wraparound}(x, y)
 
   unsafeable.operator
   | ((x :~ Fixnum) - (y :~ Fixnum)) :~ Fixnum:
+      ~order: addition
       rkt.#{fx-/wraparound}(x, y)
   | (- (y :~ Fixnum)) :~ Fixnum:
       rkt.#{fx-/wraparound}(0, y)
 
   unsafeable.operator ((x :~ Fixnum) * (y :~ Fixnum)) :~ Fixnum:
+    ~order: multiplication
     rkt.#{fx*/wraparound}(x, y)
 
   unsafeable.operator ((x :~ Fixnum) << (y :~ Fixnum)):
+    ~order: bitwise_shift
     rkt.#{fxlshift/wraparound}(x, y)
 
 unsafeable.fun from_flonum(x :~ Flonum) :~ Fixnum:

--- a/rhombus-lib/rhombus/flonum.rhm
+++ b/rhombus-lib/rhombus/flonum.rhm
@@ -32,34 +32,45 @@ export:
 // Rhombus's built-in rewrite table
 
 unsafeable.operator ((x :~ Flonum) + (y :~ Flonum)) :~ Flonum:
+  ~order: addition
   rkt.#{fl+}(x, y)
 
 unsafeable.operator
 | ((x :~ Flonum) - (y :~ Flonum)) :~ Flonum:
+    ~order: addition
     rkt.#{fl-}(x, y)
 | (- (y :~ Flonum)) :~ Flonum:
     rkt.#{fl-}(y)
 
 unsafeable.operator ((x :~ Flonum) * (y :~ Flonum)) :~ Flonum:
+  ~order: multiplication
   rkt.#{fl*}(x, y)
 
 unsafeable.operator ((x :~ Flonum) / (y :~ Flonum)) :~ Flonum:
+  ~order: multiplication
   rkt.#{fl/}(x, y)
 
 unsafeable.operator ((x :~ Flonum) ** (y :~ Flonum)) :~ Flonum:
+  ~order: exponentiation
   rkt.#{flexpt}(x, y)
 
 unsafeable.operator ((x :~ Flonum) < (y :~ Flonum)):
+  ~order: comparison
   rkt.#{fl<}(x, y)
 unsafeable.operator ((x :~ Flonum) <= (y :~ Flonum)):
+  ~order: comparison
   rkt.#{fl<=}(x, y)
 unsafeable.operator ((x :~ Flonum) == (y :~ Flonum)):
+  ~order: comparison
   rkt.#{fl=}(x, y)
 unsafeable.operator ((x :~ Flonum) != (y :~ Flonum)):
+  ~order: comparison
   ! rkt.#{fl=}(x, y)
 unsafeable.operator ((x :~ Flonum) >= (y :~ Flonum)):
+  ~order: comparison
   rkt.#{fl>=}(x, y)
 unsafeable.operator ((x :~ Flonum) > (y :~ Flonum)):
+  ~order: comparison
   rkt.#{fl>}(x, y)
 
 unsafeable.fun abs(x :~ Flonum) :~ Flonum:

--- a/rhombus-lib/rhombus/private/amalgam/annot-delayed.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annot-delayed.rkt
@@ -23,6 +23,7 @@
                                                          [completed? #:mutable]))
   (define (make-delayed-annotation proc complete!-id static-info-id)
     (delayed-annotation
+     #f
      '((default . stronger))
      'macro
      proc

--- a/rhombus-lib/rhombus/private/amalgam/annot-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annot-macro.rkt
@@ -89,8 +89,9 @@
   (syntax-parse (unpack-group form proc #f)
     [c::annotation (relocate+reraw loc #'c.parsed)]))
 
-(define-for-syntax (make-annotation-infix-operator prec protocol proc assc)
+(define-for-syntax (make-annotation-infix-operator order prec protocol proc assc)
   (annotation-infix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'macro)
@@ -109,8 +110,9 @@
                                         #:srcloc (datum->syntax #f (list form1 stx form2)))))
    assc))
 
-(define-for-syntax (make-annotation-prefix-operator prec protocol proc)
+(define-for-syntax (make-annotation-prefix-operator order prec protocol proc)
   (annotation-prefix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'macro)

--- a/rhombus-lib/rhombus/private/amalgam/annotation-converting.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation-converting.rkt
@@ -26,6 +26,7 @@
 
 (define-annotation-syntax converting
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation.rkt
@@ -229,6 +229,7 @@
 
   (define (make-identifier-annotation get [static-only? #f])
     (annotation-prefix-operator
+     #f
      '((default . stronger))
      'macro
      (lambda (stx)
@@ -248,6 +249,7 @@
 
   (define (make-identifier-binding-annotation get [static-only? #f])
     (annotation-prefix-operator
+     #f
      '((default . stronger))
      'macro
      (lambda (stx)
@@ -384,6 +386,7 @@
                                   parse-annotation-of)
     (define root
       (annotation-prefix-operator
+       #f
        '((default . stronger))
        'macro
        (lambda (stx)
@@ -399,6 +402,7 @@
      root
      ;; `of`:
      (annotation-prefix-operator
+      #f
       '((default . stronger))
       'macro
       (lambda (stx)
@@ -437,6 +441,7 @@
 
 (define-for-syntax (make-annotation-apply-expression-operator checked?)
   (expression-infix-operator
+   #f
    `((default . weaker))
    'macro
    (lambda (form tail)
@@ -494,6 +499,7 @@
 
 (define-for-syntax (make-annotation-apply-binding-operator checked?)
   (binding-infix-operator
+   #f
    `((default . weaker))
    'macro
    (lambda (form tail)
@@ -536,6 +542,7 @@
 
 (define-syntax is_a
   (expression-infix-operator
+   #f
    '((default . weaker))
    'macro
    (lambda (form tail)
@@ -891,12 +898,14 @@
 ;; annotation parsing terminates appropriately
 (define-annotation-syntax ::
   (annotation-infix-operator
+   #f
    `((default . weaker))
    'macro
    (lambda (form tail) (error "should not get here"))
    'none))
 (define-annotation-syntax is_a
   (annotation-infix-operator
+   #f
    `((default . stronger))
    'macro
    (lambda (form tail) (error "should not get here"))
@@ -907,6 +916,7 @@
 
 (define-annotation-syntax matching
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -930,6 +940,7 @@
 
 (define-annotation-syntax satisfying
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -957,6 +968,7 @@
 
 (define-annotation-syntax #%literal
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stxes)
@@ -972,6 +984,7 @@
 
 (define-for-syntax (make-unary-real-annotation id comp-stx)
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stxes)
@@ -1007,6 +1020,7 @@
 
 (define-for-syntax (make-in-annotation pred-stx annot-str)
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stxes)
@@ -1051,6 +1065,7 @@
 
 (define-annotation-syntax Any.of
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stxes)

--- a/rhombus-lib/rhombus/private/amalgam/appendable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/appendable.rkt
@@ -18,14 +18,14 @@
          "append-property.rkt"
          "call-result-key.rkt"
          "static-info.rkt"
-         (only-in "string.rkt"
-                  +&)
          (submod "set.rkt" for-append)
          "repetition.rkt"
          "compound-repetition.rkt"
          "realm.rkt"
          (only-in "class-desc.rkt" define-class-desc-syntax)
-         "is-static.rkt")
+         "is-static.rkt"
+         "order.rkt"
+         "order-primitive.rkt")
 
 (provide (for-spaces (rhombus/class
                       rhombus/annot)
@@ -114,7 +114,8 @@
 
 (define-syntax ++
   (expression-infix-operator
-   (lambda () `((,(expr-quote +&) . same)))
+   (lambda () (order-quote concatenation))
+   '()
    'automatic
    (lambda (form1-in form2 self-stx)
      (define static? (is-static-context? self-stx))
@@ -132,7 +133,8 @@
 
 (define-repetition-syntax ++
   (repetition-infix-operator
-   (lambda () `((,(repet-quote +&) . same)))
+   (lambda () (order-quote concatenation))
+   '()
    'automatic
    (lambda (form1 form2 self-stx)
      (define static? (is-static-context? self-stx))

--- a/rhombus-lib/rhombus/private/amalgam/array.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/array.rkt
@@ -112,6 +112,7 @@
 
 (define-annotation-syntax of_length
   (annotation-prefix-operator
+   #f
    `((default . stronger))
    'macro
    (lambda (stx)
@@ -317,6 +318,7 @@
 
 (define-binding-syntax Array
   (binding-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/arrow-annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/arrow-annotation.rkt
@@ -38,6 +38,7 @@
 
 (define-annotation-syntax #%parens
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stxes)
@@ -61,6 +62,7 @@
 
 (define-annotation-syntax ->
   (annotation-infix-operator
+   #f
    (lambda () `((default . stronger)))
    'macro
    (lambda (lhs stx)

--- a/rhombus-lib/rhombus/private/amalgam/assign-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/assign-macro.rkt
@@ -63,8 +63,9 @@
                    #'assign.tail)]
     [_ (raise-bad-macro-result (proc-name proc) "assignment" form)]))
 
-(define-for-syntax (make-assign-operator prec protocol proc assc)
+(define-for-syntax (make-assign-operator order prec protocol proc assc)
   (make-assign-infix-operator
+   order
    prec
    assc
    protocol

--- a/rhombus-lib/rhombus/private/amalgam/bind-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/bind-macro.rkt
@@ -518,8 +518,9 @@
     [b::binding #'b.parsed]
     [_ (raise-bad-macro-result (proc-name proc) "binding" form)]))
 
-(define-for-syntax (make-binding-infix-operator prec protocol proc assc)
+(define-for-syntax (make-binding-infix-operator order prec protocol proc assc)
   (binding-infix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'macro)
@@ -537,8 +538,9 @@
                           proc)))
    assc))
 
-(define-for-syntax (make-binding-prefix-operator prec protocol proc)
+(define-for-syntax (make-binding-prefix-operator order prec protocol proc)
   (binding-prefix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'macro)

--- a/rhombus-lib/rhombus/private/amalgam/binding.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/binding.rkt
@@ -89,7 +89,7 @@
   (property binding-infix-operator infix-operator)
 
   (define (binding-transformer proc)
-    (binding-prefix-operator '((default . stronger)) 'macro proc))
+    (binding-prefix-operator #f '((default . stronger)) 'macro proc))
 
   ;; puts pieces together into a `:binding-form`
   (define (binding-form infoer-id data)

--- a/rhombus-lib/rhombus/private/amalgam/bits.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/bits.rkt
@@ -5,7 +5,8 @@
          "define-arity.rkt"
          (submod "arithmetic.rkt" static-infos)
          "call-result-key.rkt"
-         "annotation-failure.rkt")
+         "annotation-failure.rkt"
+         "order-primitive.rkt")
 
 (provide (for-space rhombus/namespace
                     bits))
@@ -23,16 +24,16 @@
    [field bits.field]))
 
 (define-prefix #:who bits.not bitwise-not
+  #:order bitwise_negation
   #:static-infos #,(get-int-static-infos))
 (define-infix #:who bits.and bitwise-and
-  #:weaker-than (bits.not)
+  #:order bitwise_conjunction
   #:static-infos #,(get-int-static-infos))
 (define-infix #:who bits.or bitwise-ior
-  #:weaker-than (bits.and bits.not)
+  #:order bitwise_disjunction
   #:static-infos #,(get-int-static-infos))
 (define-infix #:who bits.xor bitwise-xor
-  #:weaker-than (bits.not)
-  #:same-as (bits.or)
+  #:order bitwise_disjunction
   #:static-infos #,(get-int-static-infos))
 
 (define (check-int who n)
@@ -56,11 +57,14 @@
   (arithmetic-shift a (- b)))
 
 (define-infix |bits.(<<)| arithmetic-shift-left
+  #:order bitwise_shift
   #:static-infos #,(get-int-static-infos))
 (define-infix |bits.(>>)| arithmetic-shift-right
+  #:order bitwise_shift
   #:static-infos #,(get-int-static-infos))
 
-(define-infix #:who |bits.(?)| bitwise-bit-set?)
+(define-infix #:who |bits.(?)| bitwise-bit-set?
+  #:order bitwise_test)
 
 (define/arity (bits.length n)
   #:primitive (integer-length)

--- a/rhombus-lib/rhombus/private/amalgam/boolean-annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/boolean-annotation.rkt
@@ -7,7 +7,9 @@
          "binding.rkt"
          "static-info.rkt"
          "if-blocked.rkt"
-         "rhombus-primitive.rkt")
+         "rhombus-primitive.rkt"
+         "order.rkt"
+         "order-primitive.rkt")
 
 (provide (for-space rhombus/annot
                     &&
@@ -22,7 +24,8 @@
                                             (get-combined-primitive-contract " && " form))))
 (define-annotation-syntax &&
   (annotation-infix-operator
-   (lambda () `((,(annot-quote \|\|) . stronger)))
+   (lambda () (order-quote logical_conjuction))
+   null
    'automatic
    (lambda (lhs rhs stx)
      (relocate+reraw
@@ -99,6 +102,7 @@
                                             (get-combined-primitive-contract " || " form))))
 (define-annotation-syntax \|\|
   (annotation-infix-operator
+   (lambda () (order-quote logical_disjuction))
    null
    'automatic
    (lambda (lhs rhs stx)
@@ -189,8 +193,8 @@
 (void (set-primitive-contract-combinator! 'not/c handle-not/c))
 (define-annotation-syntax !
   (annotation-prefix-operator
-   (lambda () `((,(annot-quote &&) . stronger)
-                (,(annot-quote \|\|) . stronger)))
+   (lambda () (order-quote logical_negation))
+   '()
    'automatic
    (lambda (form stx)
      (relocate+reraw

--- a/rhombus-lib/rhombus/private/amalgam/boolean-pattern.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/boolean-pattern.rkt
@@ -5,7 +5,9 @@
          "binding.rkt"
          "static-info.rkt"
          "literal.rkt"
-         "if-blocked.rkt")
+         "if-blocked.rkt"
+         "order.rkt"
+         "order-primitive.rkt")
 
 (provide (for-space rhombus/bind
                     &&
@@ -20,7 +22,8 @@
 
 (define-binding-syntax &&
   (binding-infix-operator
-   (lambda () `((,(bind-quote \|\|) . stronger)))
+   (lambda () (order-quote logical_conjuction))
+   null
    'automatic
    (lambda (lhs rhs stx)
      (binding-form
@@ -76,6 +79,7 @@
 
 (define-binding-syntax \|\|
   (binding-infix-operator
+   (lambda () (order-quote logical_disjuction))
    null
    'automatic
    (lambda (lhs rhs stx)
@@ -141,9 +145,8 @@
 
 (define-binding-syntax !
   (binding-prefix-operator
-   (lambda ()
-     `((,(bind-quote &&) . stronger)
-       (,(bind-quote \|\|) . stronger)))
+   (lambda () (order-quote logical_negation))
+   null
    'automatic
    (lambda (form stx)
      (binding-form #'not-infoer form))))

--- a/rhombus-lib/rhombus/private/amalgam/class-annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-annotation.rkt
@@ -182,6 +182,7 @@
 
 (define-for-syntax no-annotation-transformer
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/class-dot-transformer.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-dot-transformer.rkt
@@ -51,6 +51,7 @@
 
 (define-for-syntax (wrap-class-dot-via-class proc name pred dot-provider)
   (make-expression-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (packed-tail self-stx)

--- a/rhombus-lib/rhombus/private/amalgam/class-transformer-rhs.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-transformer-rhs.rkt
@@ -33,7 +33,7 @@
      #:with (~var lam (:entry-point no-adjustments)) #'g
      #`lam.parsed]))
 
-(define (wrap-prefix precedence protocol proc)
+(define (wrap-prefix order precedence protocol proc)
   (lambda (stx)
     (syntax-parse (unpack-tail stx #f #f)
       [(head . tail) (proc (pack-tail #'tail) #'head)])))

--- a/rhombus-lib/rhombus/private/amalgam/class-transformer.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-transformer.rkt
@@ -64,11 +64,12 @@
                                         #f
                                         #f
                                         #f #f
-                                        #'() #'() '()))]
+                                        #'() #'() #'() '()))]
       [_
        #`(class-transformer #,g)]))
   (with-syntax ([make-prefix-operator make-prefix-operator])
-    #`(make-prefix-operator '((default . stronger))
+    #`(make-prefix-operator #f
+                            '((default . stronger))
                             'macro
                             (let ([name #,lam])
                               (let ([name (lambda (tail head)

--- a/rhombus-lib/rhombus/private/amalgam/comparable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/comparable.rkt
@@ -10,14 +10,15 @@
          "repetition.rkt"
          (submod "annotation.rkt" for-class)
          "parse.rkt"
-         (submod "arithmetic.rkt" precedence)
          "compare-key.rkt"
          "static-info.rkt"
          "compound-repetition.rkt"
          "realm.rkt"
          (only-in "class-desc.rkt" define-class-desc-syntax)
          "is-static.rkt"
-         "number.rkt")
+         "number.rkt"
+         "order.rkt"
+         "order-primitive.rkt")
 
 (provide (for-spaces (rhombus/class
                       rhombus/annot)
@@ -260,23 +261,19 @@
                                 (list form1 self-stx form2))
                  #'())))))])])))
 
-(define-for-syntax (repet-comparison-precedences)
-  (for/list ([p (in-list (comparison-precedences))])
-    (if (identifier? (car p))
-        (cons (in-repetition-space (car p)) (cdr p))
-        p)))
-
 (define-syntax-rule (define-compare-op def-op op)
   (begin
     (define-syntax def-op
       (expression-infix-operator
-       comparison-precedences
+       (lambda () (order-quote comparison))
+       '()
        'automatic
        (make-comp-expression 'op)
        'left))
     (define-repetition-syntax def-op
       (repetition-infix-operator
-       repet-comparison-precedences
+       (lambda () (order-quote comparison))
+       '()
        'automatic
        (make-comp-repetition 'op)
        'left))))

--- a/rhombus-lib/rhombus/private/amalgam/compound-repetition.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/compound-repetition.rkt
@@ -5,7 +5,8 @@
          "expression.rkt"
          "repetition.rkt"
          "parse.rkt"
-         "static-info.rkt")
+         "static-info.rkt"
+         "order.rkt")
 
 (provide (for-syntax make-expression&repetition-prefix-operator
                      make-expression&repetition-infix-operator
@@ -19,7 +20,7 @@
   ;;  - 'prefix -- actual prefix operator
   ;;  - 'nofix  -- "nofix" operator that consumes nothing
   ;;  - 'mixfix -- both prefix and "nofix", depending on the tail
-  (define (make-expression&repetition-prefix-operator prec kind exp
+  (define (make-expression&repetition-prefix-operator order prec kind exp
                                                       #:element-statinfo? [element-statinfo? #f])
     (define (prefix-exp form self-stx)
       (exp form self-stx))
@@ -71,14 +72,14 @@
         [else
          (error "unrecognized kind")]))
     (values
-     (expression-prefix-operator prec protocol final-exp)
-     (repetition-prefix-operator (add-repet-space prec) protocol final-rep)))
+     (expression-prefix-operator order prec protocol final-exp)
+     (repetition-prefix-operator order (add-repet-space prec) protocol final-rep)))
 
   ;; `kind` can be
   ;;  - 'infix   -- actual infix operator
   ;;  - 'postfix -- postfix operator that consumes nothing
   ;;  - 'mixfix  -- both infix and postfix, depending on the tail
-  (define (make-expression&repetition-infix-operator prec kind exp assc
+  (define (make-expression&repetition-infix-operator order prec kind exp assc
                                                      #:element-statinfo? [element-statinfo? #f])
     (define (infix-exp form1 form2 self-stx)
       (exp form1 form2 self-stx))
@@ -133,13 +134,14 @@
         [else
          (error "unrecognized kind")]))
     (values
-     (expression-infix-operator prec protocol final-exp assc)
-     (repetition-infix-operator (add-repet-space prec) protocol final-rep assc)))
+     (expression-infix-operator order prec protocol final-exp assc)
+     (repetition-infix-operator order (add-repet-space prec) protocol final-rep assc)))
 
   (define (add-repet-space get-prec)
     (lambda ()
       (for/list ([p (in-list (get-prec))])
-        (if (identifier? (car p))
+        (if (and (identifier? (car p))
+                 (not (bound-identifier=? (car p) (in-order-space (car p)))))
             (cons (in-repetition-space (car p)) (cdr p))
             p))))
 

--- a/rhombus-lib/rhombus/private/amalgam/control.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/control.rkt
@@ -145,6 +145,7 @@
 
 (define-syntax throw
   (expression-prefix-operator
+   #f
    '((default . weaker))
    'automatic
    (lambda (form1 op-stx)

--- a/rhombus-lib/rhombus/private/amalgam/core-meta.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core-meta.rkt
@@ -12,6 +12,7 @@
         "annot-macro.rkt"
         "reducer-macro.rkt"
         "for-clause-macro.rkt"
+        "order-macro.rkt"
         "class-clause-macro.rkt"
         "interface-clause-macro.rkt"
         "veneer-clause-macro.rkt"
@@ -36,4 +37,3 @@
 
 (bounce-meta "space-meta-clause-primitive.rkt"
              "unquote-binding-primitive-meta.rkt")
-

--- a/rhombus-lib/rhombus/private/amalgam/core.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core.rkt
@@ -91,6 +91,7 @@
         "module-path.rkt"
         "module-path-object.rkt"
         "operator.rkt"
+        "order-primitive.rkt"
         "annotation.rkt"
         "annotation-converting.rkt"
         "list.rkt"

--- a/rhombus-lib/rhombus/private/amalgam/define-operator.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/define-operator.rkt
@@ -8,7 +8,8 @@
          "rhombus-primitive.rkt"
          "flonum-key.rkt"
          "fixnum-key.rkt"
-         "parse.rkt")
+         "parse.rkt"
+         "order.rkt")
 
 (provide define-prefix
          define-infix
@@ -23,6 +24,7 @@
   (define-syntax (prefix stx)
     (syntax-parse stx
       [(_ prim:identifier
+          (~optional (~seq #:order order-id:identifier))
           (~optional (~seq #:precedences precedences-expr))
           (~optional (~seq #:weaker-than (weaker-op ...))
                      #:defaults ([(weaker-op 1) '()]))
@@ -43,6 +45,8 @@
                      #:defaults ([fxprim #'#f]
                                  [fixnum-statinfos #'()])))
        #`(make-expression&repetition-prefix-operator
+          (~? (lambda () (order-quote order-id))
+              #f)
           (~? precedences-expr
               (lambda ()
                 (list (cons (quote-syntax weaker-op)
@@ -94,6 +98,7 @@
   (define-syntax (infix stx)
     (syntax-parse stx
       [(_ prim:identifier
+          (~optional (~seq #:order order-id:identifier))
           (~optional (~seq #:precedences precedences-expr))
           (~optional (~seq #:weaker-than (weaker-op ...))
                      #:defaults ([(weaker-op 1) '()]))
@@ -114,6 +119,8 @@
                      #:defaults ([fxprim #'#f]
                                  [fixnum-statinfos #'()])))
        #`(make-expression&repetition-infix-operator
+          (~? (lambda () (order-quote order-id))
+              #f)
           (~? precedences-expr
               (lambda ()
                 (list (cons (quote-syntax weaker-op)

--- a/rhombus-lib/rhombus/private/amalgam/dot.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/dot.rkt
@@ -18,7 +18,9 @@
          "realm.rkt"
          "parse.rkt"
          "is-static.rkt"
-         (submod "assign.rkt" for-assign))
+         (submod "assign.rkt" for-assign)
+         "order.rkt"
+         "order-primitive.rkt")
 
 (provide (for-spaces (#f
                       rhombus/repet
@@ -56,7 +58,8 @@
 
 (define-syntax |.|
   (expression-infix-operator
-   '((default . stronger))
+   (lambda () (order-quote member_access))
+   '()
    'macro
    (lambda (form1 tail)
      (define more-static? (is-static-context/tail? tail))
@@ -83,7 +86,8 @@
 
 (define-repetition-syntax |.|
   (repetition-infix-operator
-   '((default . stronger))
+   (lambda () (order-quote member_access))
+   '()
    'macro
    (lambda (form1 tail)
      (define more-static? (is-static-context/tail? tail))
@@ -129,7 +133,8 @@
 ;; for something like `"a" :: String.length()`
 (define-annotation-syntax |.|
   (annotation-infix-operator
-   '((default . stronger))
+   (lambda () (order-quote member_access))
+   '()
    'macro
    (lambda (form1 tail)
      (syntax-parse tail

--- a/rhombus-lib/rhombus/private/amalgam/equal.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/equal.rkt
@@ -13,6 +13,7 @@
 
 (define-syntax rhombus=
   (expression-infix-operator
+   #f
    '((default . weaker))
    'macro
    (lambda (form tail)

--- a/rhombus-lib/rhombus/private/amalgam/export-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/export-macro.rkt
@@ -85,8 +85,9 @@
 
 (define-for-syntax (parsed-argument form) #`(parsed #:rhombus/expo #,form))
 
-(define-for-syntax (make-export-infix-operator prec protocol proc assc)
+(define-for-syntax (make-export-infix-operator order prec protocol proc assc)
   (export-infix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'automatic)
@@ -104,8 +105,9 @@
                                    proc)))
    assc))
 
-(define-for-syntax (make-export-prefix-operator prec protocol proc)
+(define-for-syntax (make-export-prefix-operator order prec protocol proc)
   (export-prefix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'automatic)

--- a/rhombus-lib/rhombus/private/amalgam/export.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/export.rkt
@@ -196,6 +196,7 @@
 
 (define-export-syntax as
   (export-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -207,6 +208,7 @@
 
 (define-export-syntax rename
   (export-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -282,6 +284,7 @@
 
 (define-export-syntax names
   (export-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -294,6 +297,7 @@
 
 (define-export-syntax all_from
   (export-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -365,6 +369,7 @@
 
 (define-export-syntax all_defined
   (export-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -378,6 +383,7 @@
 
 (define-export-syntax #%juxtapose
   (export-infix-operator
+   #f
    '((default . weaker))
    'macro
    (lambda (form1 stx)
@@ -395,6 +401,7 @@
 
 (define-export-syntax |.|
   (export-infix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (form stx)

--- a/rhombus-lib/rhombus/private/amalgam/expr-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/expr-macro.rkt
@@ -90,8 +90,9 @@
      [_ (syntax-parse (unpack-group form 'expression #f)
           [e::expression #'e.parsed])])))
 
-(define-for-syntax (make-expression-infix-operator prec protocol proc assc)
+(define-for-syntax (make-expression-infix-operator order prec protocol proc assc)
   (expression-infix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'automatic)
@@ -111,8 +112,9 @@
                                    proc)))
    assc))
 
-(define-for-syntax (make-expression-prefix-operator prec protocol proc)
+(define-for-syntax (make-expression-prefix-operator order prec protocol proc)
   (expression-prefix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'automatic)

--- a/rhombus-lib/rhombus/private/amalgam/expression.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/expression.rkt
@@ -47,14 +47,14 @@
   (property expression-infix-operator infix-operator)
 
   (define (expression-transformer proc)
-    (expression-prefix-operator '((default . stronger)) 'macro proc))
+    (expression-prefix-operator #f '((default . stronger)) 'macro proc))
 
   ;; shortcut for an expression binding that can be used by itself like
   ;; an identifier in a repetition; this is a little bit of a cheat, so use
   ;; it only for things that are rename-transformer-like
   (struct expression-repeatable-prefix-operator expression-prefix-operator ())
   (define (expression-repeatable-transformer proc)
-    (expression-repeatable-prefix-operator '((default . stronger)) 'macro proc))
+    (expression-repeatable-prefix-operator #f '((default . stronger)) 'macro proc))
 
   (define early-unbound? #f)
   (define (check-unbound-identifier-early!)

--- a/rhombus-lib/rhombus/private/amalgam/for.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/for.rkt
@@ -360,6 +360,7 @@
 ;; reducer parsing terminates appropriately
 (define-reducer-syntax #%call
   (reducer-infix-operator
+   #f
    `((default . stronger))
    'macro
    (lambda (form tail) (error "should not get here"))

--- a/rhombus-lib/rhombus/private/amalgam/function.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/function.rkt
@@ -202,6 +202,7 @@
 (void (set-primitive-contract-combinator! 'procedure-arity-includes/c handle-procedure-arity-includes/c))
 (define-annotation-syntax of_arity
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -255,6 +256,7 @@
 
 (define-annotation-syntax all_of
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/implicit.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/implicit.rkt
@@ -262,6 +262,7 @@
 
 (define-syntax #%call
   (expression-infix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (rator stxes)
@@ -275,6 +276,7 @@
 
 (define-repetition-syntax #%call
   (repetition-infix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (rator stxes)
@@ -310,6 +312,7 @@
 
 (define-syntax #%index
   (expression-infix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (array stxes)
@@ -319,6 +322,7 @@
 
 (define-repetition-syntax #%index
   (repetition-infix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (array stxes)

--- a/rhombus-lib/rhombus/private/amalgam/import-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/import-macro.rkt
@@ -85,8 +85,9 @@
 
 (define-for-syntax (parsed-argument form) #`(parsed #:rhombus/impo #,form))
 
-(define-for-syntax (make-import-infix-operator prec protocol proc assc)
+(define-for-syntax (make-import-infix-operator order prec protocol proc assc)
   (import-infix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'automatic)
@@ -104,8 +105,9 @@
                                    proc)))
    assc))
 
-(define-for-syntax (make-import-prefix-operator prec protocol proc)
+(define-for-syntax (make-import-prefix-operator order prec protocol proc)
   (import-prefix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'automatic)

--- a/rhombus-lib/rhombus/private/amalgam/import.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/import.rkt
@@ -796,6 +796,7 @@
 
 (define-import-syntax #%juxtapose
   (import-infix-operator
+   #f
    '((default . weaker))
    'macro
    (lambda (form1 stx)
@@ -838,6 +839,7 @@
 
 (define-for-syntax infix-path-dot
   (import-infix-operator
+   #f
    '((default . weaker))
    'macro
    ;; infix
@@ -857,6 +859,7 @@
 (define-import-syntax rhombus.
   (import-prefix+infix-operator
    (import-prefix-operator
+    #f
     '((default . weaker))
     'macro
     (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/macro-expr-parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/macro-expr-parse.rkt
@@ -33,7 +33,7 @@
                                    #f
                                    #f
                                    #f #f
-                                   #'() #'() '())
+                                   #'() #'() #'() '())
        '#f
        #'wrap-prefix
        #f
@@ -65,7 +65,7 @@
                        ()
                        ())))
 
-(define (wrap-prefix precedence protocol proc)
+(define (wrap-prefix order precedence protocol proc)
   (lambda (stx)
     (syntax-parse (unpack-tail stx #f #f)
       [(head . tail) (proc (pack-tail #'tail) #'head)])))

--- a/rhombus-lib/rhombus/private/amalgam/macro-rhs.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/macro-rhs.rkt
@@ -37,7 +37,7 @@
                      parse-transformer-definition-sequence-rhs))
 
 (begin-for-syntax
-  (struct parsed (fixity name opts-stx prec-stx assc-stx parsed-right? extra-kw-args
+  (struct parsed (fixity name opts-stx order-name-stx prec-stx assc-stx parsed-right? extra-kw-args
                          ;; implementation is function stx if `parsed-right?`,
                          ;; or a clause over #'self and maybe #'left otherwise
                          impl))
@@ -70,7 +70,7 @@
 (define-for-syntax (parse-one-macro-definition pre-parsed adjustments case-shape)
   (define-values (who kind parsed-right?)
     (syntax-parse pre-parsed
-      [(_ name _ _ kind _ _ _ _ parsed-right-id . _)
+      [(_ name _ _ kind _ _ _ _ _ parsed-right-id . _)
        (values #'name (syntax-e #'kind) (and (syntax-e #'parsed-right-id) #t))]))
   (define (macro-clause self-id all-id left-ids tail-pattern-in rhs)
     (define-values (tail-pattern implicit-tail?)
@@ -172,6 +172,7 @@
                  _
                  opt
                  (extra-kw-id ...)
+                 order-name
                  prec
                  assc
                  parsed-right-id
@@ -183,6 +184,7 @@
      (parsed 'infix
              #'name
              #'opt
+             #'order-name
              #'prec
              #'assc
              (and (syntax-e #'parsed-right-id) #t)
@@ -217,6 +219,7 @@
                  _
                  opt
                  (extra-kw-id ...)
+                 order-name
                  prec
                  assc ; only non-#f if main (i.e., specified before `match` in the definition)
                  parsed-right-id
@@ -227,6 +230,7 @@
      (parsed 'prefix
              #'name
              #'opt
+             #'order-name
              #'prec
              #'assc
              (and (syntax-e #'parsed-right-id) #t)
@@ -291,6 +295,7 @@
                  _
                  _
                  _
+                 _
                  [tail-pattern
                   . _])
      (if (is-simple-pattern? #'tail-pattern)
@@ -334,6 +339,7 @@
                         orig-stx))
   (define p (car ps))
   #`(#,make-id
+     #,(parsed-order-name-stx p)
      #,(parsed-prec-stx p)
      #,(if (parsed-parsed-right? p)
            #''automatic

--- a/rhombus-lib/rhombus/private/amalgam/macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/macro.rkt
@@ -55,7 +55,7 @@
                                       '#f
                                       #'rules-rhs
                                       #f #f
-                                      #'() #'() '()))]
+                                      #'() #'() #'() '()))]
         [(form-id main-op::operator-or-identifier
                   (~optional (_::block
                               (~var main-options (:all-operator-options #f))))
@@ -73,6 +73,7 @@
                                       #'rules-rhs
                                       (if (attribute main-op) #'main-op.name #'#f)
                                       #'#f
+                                      (if (attribute main-options) #'main-options.order-name #'())
                                       (if (attribute main-options) #'main-options.prec #'())
                                       (if (attribute main-options) #'main-options.assc #'())
                                       '()))]

--- a/rhombus-lib/rhombus/private/amalgam/map.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/map.rkt
@@ -491,6 +491,7 @@
 
 (define-annotation-syntax Map.by
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -657,6 +658,7 @@
 
 (define-annotation-syntax MutableMap.by
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -689,6 +691,7 @@
 
 (define-annotation-syntax WeakMutableMap.by
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/match.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/match.rkt
@@ -179,6 +179,7 @@
 
 (define-syntax matches
   (expression-infix-operator
+   #f
    `((default . weaker))
    'macro
    (lambda (form tail)
@@ -199,6 +200,7 @@
 ;; for precedence
 (define-binding-syntax matches
   (binding-infix-operator
+   #f
    `((default . stronger))
    'macro
    (lambda (form tail) (error "should not get here"))

--- a/rhombus-lib/rhombus/private/amalgam/maybe.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/maybe.rhm
@@ -2,6 +2,7 @@
 import:
   "core-meta.rkt" open
   "pipeline.rhm".(|>)
+  "pipeline.rhm".pipeline
   "pipeline.rhm"!for_maybe.parse_pipeline_expr
 
 use_static
@@ -47,8 +48,7 @@ expr.macro '$e !!':
                         demaybe_statinfos(statinfos))
 
 expr.macro '$e !!. $tail ... ~nonempty':
-  ~same_as: .
-  ~stronger_than: ~other
+  ~order: member_access
   ~op_stx: self
   let dot = syntax_meta.dynamic_name('.', ~as_static: syntax_meta.is_static(self))
   values('($e !!)', '$dot $tail ...')
@@ -66,15 +66,13 @@ repet.macro '$e !!':
                          $(demaybe_statinfos(statinfos)))')
 
 repet.macro '$e !!. $tail ... ~nonempty':
-  ~same_as: .
-  ~stronger_than: ~other
+  ~order: member_access
   ~op_stx: self
   let dot = syntax_meta.dynamic_name('.', ~as_static: syntax_meta.is_static(self))
   values('($e !!)', '$dot $tail ...')
 
 expr.macro '$e ?. $(id :: Identifier) $(args && '($_, ...)') ... ~once $tail ...':
-  ~stronger_than: ~other
-  ~same_as: .
+  ~order: member_access
   ~op_stx: self
   maybe_op(e, self,  '.', '$id $args ...',
            fun (left, '$op $(id_and_args :: Sequence)', ~as_static: as_static):
@@ -83,8 +81,7 @@ expr.macro '$e ?. $(id :: Identifier) $(args && '($_, ...)') ... ~once $tail ...
              values(v, '$tail ...'))
 
 expr.macro '$e ?> $tail ... ~nonempty':
-  ~weaker_than: ~other
-  ~stronger_than: |>
+  ~order: pipeline
   ~op_stx: self
   maybe_op(e, self, '|>', '$tail ...', parse_pipeline_expr)
 
@@ -109,8 +106,7 @@ meta:
     )
 
 repet.macro '$e ?. $(id :: Identifier) $(args && '($_, ...)') ... ~once $tail ...':
-  ~stronger_than: ~other
-  ~same_as: .
+  ~order: member_access
   ~op_stx: self
   let '($src, $binds, $body, $used_depth, $staticinfos)' = repet_meta.unpack_generator(e)
   let left = repet_meta.pack_generator('($src, $binds, $body, $used_depth, $(demaybe_statinfos(staticinfos)))')

--- a/rhombus-lib/rhombus/private/amalgam/module-path.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/module-path.rkt
@@ -103,6 +103,7 @@
 
 (define-for-syntax (make-module-path-literal-operator prefix-operator)
   (prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -123,6 +124,7 @@
 
 (define-for-syntax (make-module-path-/-operator infix-operator)
   (infix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (form1 stx)
@@ -154,6 +156,7 @@
 
 (define-for-syntax (make-module-path-string-arg-operator prefix-operator mp-form-id check)
   (prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -198,6 +201,7 @@
 
 (define-for-syntax (make-module-path-submod-operator infix-operator)
   (infix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (mp stx)
@@ -236,6 +240,7 @@
 
 (define-for-syntax (make-module-path-submod-same-operator prefix-operator)
   (prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -256,6 +261,7 @@
 
 (define-for-syntax (make-module-path-submod-up-operator prefix-operator)
   (prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -299,6 +305,7 @@
 
 (define-module-path-syntax rhombus.
   (module-path-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/order-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/order-macro.rkt
@@ -1,0 +1,91 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     enforest/operator
+                     enforest/syntax-local
+                     enforest/hier-name-parse
+                     "introducer.rkt"
+                     "name-root.rkt"
+                     "name-path-op.rkt")
+         (only-in "space.rkt" space-syntax)
+         "space-provide.rkt"
+         "order.rkt"
+         "definition.rkt"
+         "dotted-sequence-parse.rkt"
+         "macro-macro.rkt"
+         "static-info.rkt"
+         "parens.rkt"
+         "name-root-ref.rkt"
+         "name-root-space.rkt")
+
+(provide (for-space rhombus/namespace
+                    operator_order)
+         (for-syntax (for-space rhombus/namespace
+                                operator_order_meta)))
+
+(define+provide-space operator_order #f
+  #:fields
+  (def
+   def_set))
+
+(begin-for-syntax
+  (define-name-root operator_order_meta
+    #:fields
+    (space)))
+
+(define-for-syntax space
+  (space-syntax 'rhombus/operator-order))
+
+(define-defn-syntax def
+  (definition-transformer
+    (lambda (stx name-prefix)
+      (syntax-parse stx
+        [(_ name-seq::dotted-identifier-sequence)
+         #:with name::dotted-identifier #'name-seq
+         (list
+          (build-syntax-definition/maybe-extension
+           'rhombus/operator_order #'name.name #'name.extends
+           #`(make-order
+              null
+              'left)))]
+        [(_ name-seq::dotted-identifier-sequence
+            (_::block
+             (~var options (:order-options 'rhombus/operator_order))))
+         #:with name::dotted-identifier #'name-seq
+         (list
+          (build-syntax-definition/maybe-extension
+           'rhombus/operator_order #'name.name #'name.extends
+           #`(make-order
+              #,(convert-prec #'options.prec)
+              #,(convert-assc #'options.assc #'()))))]))))
+
+(define-defn-syntax def_set
+  (definition-transformer
+    (lambda (stx name-prefix)
+      (syntax-parse stx
+        [(_ name-seq::dotted-identifier-sequence
+            (_::block
+             (group order-name-seq::dotted-identifier-sequence ...)
+             ...))
+         #:with name::dotted-identifier #'name-seq
+         (define order-names (for/list ([order-name-seq (in-list (syntax->list #'(order-name-seq ... ...)))])
+                               (syntax-parse order-name-seq
+                                 [(~var name (:hier-name-seq in-name-root-space in-order-space name-path-op name-root-ref))
+                                  (in-order-space #'name.name)])))
+         (define flat-order-names
+           (apply
+            append
+            (for/list ([order-name (in-list order-names)])
+              (define v (syntax-local-value* order-name order-set-ref))
+              (unless v
+                (raise-syntax-error #f
+                                    "not defined as an operator order"
+                                    order-name))
+              (order-set->order-names v order-name))))
+         (with-syntax ([(order-name ...) flat-order-names])
+           (list
+            (build-syntax-definition/maybe-extension
+             'rhombus/operator_order #'name.name #'name.extends
+             #`(order-set
+                (lambda ()
+                  (list (quote-syntax order-name) ...))))))]))))

--- a/rhombus-lib/rhombus/private/amalgam/order-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/order-primitive.rkt
@@ -1,0 +1,186 @@
+#lang racket/base
+(require (for-syntax racket/base)
+         "order.rkt")
+
+(provide (for-space rhombus/operator_order
+                    addition
+                    multiplication
+                    exponentiation
+                    integer_division
+                    arithmetic
+                    comparison
+                    assignment
+                    enumeration
+                    concatenation
+                    member_access
+                    logical_negation
+                    logical_conjunction
+                    logical_disjunction
+                    bitwise_negation
+                    bitwise_shift
+                    bitwise_conjunction
+                    bitwise_disjunction
+                    bitwise_test))
+
+(define-order-syntax addition
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote exponentiation) 'weaker)
+      (cons (order-quote multiplication) 'weaker)
+      (cons (order-quote integer_division) 'weaker)))
+   'left))
+
+(define-order-syntax multiplication
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote exponentiation) 'weaker)))
+   'left))
+
+(define-order-syntax exponentiation
+  (make-order
+   (list)
+   'right))
+
+(define-order-syntax integer_division
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote multiplication) 'weaker)
+      (cons (order-quote exponentiation) 'weaker)))
+   'left))
+
+;; can't use this shorthand internally
+(define-order-syntax arithmetic
+  (order-set
+   (lambda ()
+     (list
+      (order-quote addition)
+      (order-quote multiplication)
+      (order-quote exponentiation)
+      (order-quote integer_division)))))
+
+(define-order-syntax enumeration
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote addition) 'weaker)
+      (cons (order-quote multiplication) 'weaker)
+      (cons (order-quote exponentiation) 'weaker)
+      (cons (order-quote integer_division) 'weaker)))
+   'none))
+
+(define-order-syntax comparison
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote addition) 'weaker)
+      (cons (order-quote multiplication) 'weaker)
+      (cons (order-quote exponentiation) 'weaker)
+      (cons (order-quote integer_division) 'weaker)))
+   'none))
+
+(define-order-syntax assignment
+  (make-order
+   (lambda ()
+     (list
+      (cons 'default 'weaker)))
+   'none))
+
+(define-order-syntax member_access
+  (make-order
+   (lambda ()
+     (list
+      (cons 'default 'stronger)))
+   'none))
+
+(define-order-syntax concatenation
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote comparison) 'weaker)
+      (cons (order-quote addition) 'weaker)
+      (cons (order-quote multiplication) 'weaker)
+      (cons (order-quote exponentiation) 'weaker)
+      (cons (order-quote integer_division) 'weaker)
+      (cons (order-quote logical_disjunction) 'weaker)
+      (cons (order-quote logical_conjunction) 'weaker)))
+   'none))
+
+(define-order-syntax logical_negation
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote logical_conjunction) 'stronger)
+      (cons (order-quote logical_disjunction) 'stronger)
+      (cons (order-quote comparison) 'stronger)))
+   'none))
+
+(define-order-syntax logical_conjunction
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote logical_disjunction) 'stronger)
+      (cons (order-quote comparison) 'weaker)
+      (cons (order-quote addition) 'weaker)
+      (cons (order-quote multiplication) 'weaker)
+      (cons (order-quote exponentiation) 'weaker)
+      (cons (order-quote integer_division) 'weaker)))
+   'left))
+
+(define-order-syntax logical_disjunction
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote comparison) 'weaker)
+      (cons (order-quote addition) 'weaker)
+      (cons (order-quote multiplication) 'weaker)
+      (cons (order-quote exponentiation) 'weaker)
+      (cons (order-quote integer_division) 'weaker)))
+   'left))
+
+(define-order-syntax bitwise_negation
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote bitwise_conjunction) 'stronger)
+      (cons (order-quote bitwise_disjunction) 'stronger)
+      (cons (order-quote bitwise_shift) 'stronger)
+      (cons (order-quote bitwise_test) 'stronger)
+      (cons (order-quote comparison) 'stronger)))
+   'none))
+
+(define-order-syntax bitwise_shift
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote bitwise_conjunction) 'stronger)
+      (cons (order-quote bitwise_disjunction) 'stronger)
+      (cons (order-quote bitwise_test) 'stronger)
+      (cons (order-quote comparison) 'stronger)))
+   'left))
+
+(define-order-syntax bitwise_conjunction
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote bitwise_disjunction) 'stronger)
+      (cons (order-quote bitwise_test) 'stronger)
+      (cons (order-quote comparison) 'stronger)))
+   'left))
+
+(define-order-syntax bitwise_disjunction
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote bitwise_test) 'stronger)
+      (cons (order-quote comparison) 'stronger)))
+   'left))
+
+(define-order-syntax bitwise_test
+  (make-order
+   (lambda ()
+     (list
+      (cons (order-quote comparison) 'stronger)))
+   'left))

--- a/rhombus-lib/rhombus/private/amalgam/order.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/order.rkt
@@ -1,0 +1,38 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     enforest/operator
+                     enforest/syntax-local
+                     "introducer.rkt"
+                     "name-root.rkt"
+                     (for-syntax racket/base)))
+
+(provide define-order-syntax
+         (for-syntax in-order-space
+                     order-quote
+                     (rename-out [order make-order])
+                     order-set
+                     order-set-ref
+                     order-set->order-names))
+
+(begin-for-syntax
+  (define in-order-space (make-interned-syntax-introducer/add 'rhombus/operator_order))
+
+  (struct order-set (get-order-names))
+
+  (define (order-set-ref v) (if (order-set? v) v (order-ref v)))
+
+  (define (order-set->order-names v name)
+    (cond
+      [(order-set? v) ((order-set-get-order-names v))]
+      [else (list name)]))
+
+  (define-syntax (order-quote stx)
+    (syntax-case stx ()
+      [(_ id) #`(quote-syntax #,((make-interned-syntax-introducer 'rhombus/operator_order) #'id))])))
+
+(define-syntax (define-order-syntax stx)
+  (syntax-parse stx
+    [(_ id:identifier rhs)
+     #`(define-syntax #,(in-order-space #'id)
+         rhs)]))

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -234,6 +234,7 @@
 
 (define-annotation-syntax Path.like
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/pipeline.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/pipeline.rhm
@@ -6,6 +6,7 @@ use_static
 
 export:
   |>
+  pipeline
 
 module for_maybe:
   export:
@@ -38,8 +39,11 @@ meta:
     values(statinfo_meta.wrap(expr, unpacked_res),
            tail)
 
+operator_order.def pipeline:
+  ~weaker_than: ~other
+
 expr.macro '$arg |> $tail ...':
   ~op_stx: self
-  ~weaker_than: ~other
+  ~order: pipeline
   parse_pipeline_expr(arg, '$self $tail ...',
                       ~as_static: syntax_meta.is_static(self))

--- a/rhombus-lib/rhombus/private/amalgam/quasiquote.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/quasiquote.rkt
@@ -615,6 +615,7 @@
 
 (define-unquote-binding-syntax #%quotes
   (unquote-binding-prefix-operator
+   #f
    null
    'macro
    (lambda (stx)
@@ -1052,6 +1053,7 @@
 
 (define-syntax #%quotes
   (expression-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -1064,6 +1066,7 @@
 
 (define-binding-syntax #%quotes
   (binding-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -1087,6 +1090,7 @@
 
 (define-repetition-syntax #%quotes
   (repetition-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/range.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/range.rkt
@@ -31,7 +31,9 @@
          (submod "dot.rkt" for-dot-provider)
          "define-arity.rkt"
          "call-result-key.rkt"
-         "sequence-constructor-key.rkt")
+         "sequence-constructor-key.rkt"
+         "order.rkt"
+         "order-primitive.rkt")
 
 (provide (for-spaces (rhombus/namespace
                       rhombus/annot)
@@ -119,19 +121,10 @@
   #:methods
   ([to_list Range.to_list]))
 
-(define-for-syntax (range-precedences)
-  `((,(expr-quote rhombus-a:+) . weaker)
-    (,(expr-quote rhombus-a:-) . weaker)
-    (,(expr-quote rhombus-a:*) . weaker)
-    (,(expr-quote rhombus-a:/) . weaker)
-    (,(expr-quote rhombus-a:**) . weaker)
-    (,(expr-quote rhombus-a:div) . weaker)
-    (,(expr-quote rhombus-a:mod) . weaker)
-    (,(expr-quote rhombus-a:rem) . weaker)))
-
 (define-values-for-syntax (..-expr-prefix ..-repet-prefix)
   (make-expression&repetition-prefix-operator
-   range-precedences
+   (lambda () (order-quote enumeration))
+   '()
    'mixfix
    (case-lambda
      [(self-stx)
@@ -150,7 +143,8 @@
 
 (define-values-for-syntax (..-expr-infix ..-repet-infix)
   (make-expression&repetition-infix-operator
-   range-precedences
+   (lambda () (order-quote enumeration))
+   '()
    'mixfix
    (case-lambda
      [(left self-stx)
@@ -182,7 +176,8 @@
 
 (define-values-for-syntax (..=-expr-prefix ..=-repet-prefix)
   (make-expression&repetition-prefix-operator
-   range-precedences
+   (lambda () (order-quote enumeration))
+   '()
    'prefix
    (lambda (right self-stx)
      (wrap-static-info*
@@ -194,7 +189,8 @@
 
 (define-values-for-syntax (..=-expr-infix ..=-repet-infix)
   (make-expression&repetition-infix-operator
-   range-precedences
+   (lambda () (order-quote enumeration))
+   '()
    'infix
    (lambda (left right self-stx)
      (wrap-static-info*
@@ -218,7 +214,8 @@
 
 (define-values-for-syntax (<..-expr-infix <..-repet-infix)
   (make-expression&repetition-infix-operator
-   range-precedences
+   (lambda () (order-quote enumeration))
+   '()
    'mixfix
    (case-lambda
      [(left self-stx)
@@ -246,7 +243,8 @@
 
 (define-values-for-syntax (<..=-expr-infix <..=-repet-infix)
   (make-expression&repetition-infix-operator
-   range-precedences
+   (lambda () (order-quote enumeration))
+   '()
    'infix
    (lambda (left right self-stx)
      (wrap-static-info*
@@ -267,6 +265,7 @@
 (define-binding-syntax ..
   (binding-prefix+infix-operator
    (binding-prefix-operator
+    (lambda () (order-quote enumeration))
     `()
     'macro
     (lambda (tail)
@@ -279,6 +278,7 @@
          (values (parse-range-binding #'Range.to #'rhs.parsed)
                  #'rhs.tail)])))
    (binding-infix-operator
+    (lambda () (order-quote enumeration))
     `()
     'macro
     (lambda (form1 tail)
@@ -295,11 +295,13 @@
 (define-binding-syntax ..=
   (binding-prefix+infix-operator
    (binding-prefix-operator
+    (lambda () (order-quote enumeration))
     `()
     'automatic
     (lambda (form stx)
       (parse-range-binding #'Range.to_inclusive form)))
    (binding-infix-operator
+    (lambda () (order-quote enumeration))
     `()
     'automatic
     (lambda (form1 form2 stx)
@@ -308,6 +310,7 @@
 
 (define-binding-syntax <..
   (binding-infix-operator
+   (lambda () (order-quote enumeration))
    `()
    'macro
    (lambda (form1 tail)
@@ -323,6 +326,7 @@
 
 (define-binding-syntax <..=
   (binding-infix-operator
+   (lambda () (order-quote enumeration))
    `()
    'automatic
    (lambda (form1 form2 stx)

--- a/rhombus-lib/rhombus/private/amalgam/reducer-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/reducer-macro.rkt
@@ -72,8 +72,9 @@
     [b::reducer #'b.parsed]
     [_ (raise-bad-macro-result (proc-name proc) "reducer" form)]))
 
-(define-for-syntax (make-reducer-infix-operator prec protocol proc assc)
+(define-for-syntax (make-reducer-infix-operator order prec protocol proc assc)
   (reducer-infix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'macro)
@@ -91,8 +92,9 @@
                           proc)))
    assc))
 
-(define-for-syntax (make-reducer-prefix-operator prec protocol proc)
+(define-for-syntax (make-reducer-prefix-operator order prec protocol proc)
   (reducer-prefix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'macro)

--- a/rhombus-lib/rhombus/private/amalgam/reducer.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/reducer.rkt
@@ -29,7 +29,7 @@
   (property reducer-infix-operator infix-operator)
 
   (define (reducer-transformer proc)
-    (reducer-prefix-operator '((default . stronger)) 'macro proc))
+    (reducer-prefix-operator #f '((default . stronger)) 'macro proc))
 
   (define-syntax-class :reducer-form
     #:description "reducer"

--- a/rhombus-lib/rhombus/private/amalgam/repet-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/repet-macro.rkt
@@ -82,8 +82,9 @@
 (define-for-syntax (wrap-parsed stx)
   #`(parsed #:rhombus/repet #,stx))
 
-(define-for-syntax (make-repetition-infix-operator prec protocol proc assc)
+(define-for-syntax (make-repetition-infix-operator order prec protocol proc assc)
   (repetition-infix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'macro)
@@ -101,8 +102,9 @@
                           proc)))
    assc))
 
-(define-for-syntax (make-repetition-prefix-operator prec protocol proc)
+(define-for-syntax (make-repetition-prefix-operator order prec protocol proc)
   (repetition-prefix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'macro)

--- a/rhombus-lib/rhombus/private/amalgam/repetition.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/repetition.rkt
@@ -146,7 +146,7 @@
                                         #'tail)])))))))
 
   (define (repetition-transformer proc)
-    (repetition-prefix-operator '((default . stronger)) 'macro proc))
+    (repetition-prefix-operator #f '((default . stronger)) 'macro proc))
 
   (define (repetition-static-info-lookup element-static-infos key)
     (if (identifier? element-static-infos)

--- a/rhombus-lib/rhombus/private/amalgam/rest-bind.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/rest-bind.rkt
@@ -14,12 +14,14 @@
 
 (define-syntax rest-bind
   (expression-prefix-operator
+   #f
    `()
    'macro
    (lambda (tail) (error "should not get here"))))
 
 (define-binding-syntax rest-bind
   (binding-prefix-operator
+   #f
    `()
    'macro
    (lambda (tail)

--- a/rhombus-lib/rhombus/private/amalgam/set.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/set.rkt
@@ -693,6 +693,7 @@
 
 (define-annotation-syntax Set.by
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -853,6 +854,7 @@
 
 (define-annotation-syntax MutableSet.by
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -868,6 +870,7 @@
 
 (define-annotation-syntax WeakMutableSet.by
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/space-meta-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/space-meta-macro.rkt
@@ -277,8 +277,9 @@
          (datum->syntax #f (list 'parsed parsed-tag form))])
       form))
 
-(define ((make-make-prefix-operator new-prefix-operator parsed-tag) prec protocol proc)
+(define ((make-make-prefix-operator new-prefix-operator parsed-tag) order prec protocol proc)
   (new-prefix-operator
+   order
    prec
    protocol
    (cond
@@ -296,8 +297,9 @@
                  proc))
        (object-name proc))])))
 
-(define ((make-make-infix-operator new-infix-operator parsed-tag) prec protocol proc assc)
+(define ((make-make-infix-operator new-infix-operator parsed-tag) order prec protocol proc assc)
   (new-infix-operator
+   order
    prec
    protocol
    (cond

--- a/rhombus-lib/rhombus/private/amalgam/string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/string.rkt
@@ -9,9 +9,6 @@
          "../version-case.rkt"
          "provide.rkt"
          "define-operator.rkt"
-         (only-in "arithmetic.rkt"
-                  ==
-                  ===)
          (only-in (submod "print.rkt" for-string)
                   [display rhombus:display]
                   [print rhombus:print])
@@ -33,7 +30,8 @@
          "number.rkt"
          "treelist.rkt"
          "static-info.rkt"
-         "rx-object.rkt")
+         "rx-object.rkt"
+         "order-primitive.rkt")
 
 (provide (for-spaces (#f
                       rhombus/repet)
@@ -245,7 +243,7 @@
   (identifier-annotation string? #,(get-readable-string-locale-ci-static-infos) #:static-only))
 
 (define-infix +& append-as-strings
-  #:stronger-than (== ===)
+  #:order concatenation
   #:static-infos #,(get-string-static-infos))
 
 (define (append-as-strings a b)

--- a/rhombus-lib/rhombus/private/amalgam/syntax-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/syntax-object.rkt
@@ -187,6 +187,7 @@
 
 (define-annotation-syntax Syntax.matched_of
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/try-rest-bind.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/try-rest-bind.rkt
@@ -36,12 +36,14 @@
 
 (define-syntax try-rest-bind
   (expression-prefix-operator
+   #f
    `()
    'macro
    (lambda (tail) (error "should not get here"))))
 
 (define-binding-syntax try-rest-bind
   (binding-prefix-operator
+   #f
    `()
    'macro
    (lambda (tail)

--- a/rhombus-lib/rhombus/private/amalgam/unquote-binding-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/unquote-binding-macro.rkt
@@ -21,8 +21,9 @@
   #'make-unquote-binding-infix-operator
   #'unquote-binding-prefix+infix-operator)
 
-(define-for-syntax (make-unquote-binding-prefix-operator prec protocol proc)
+(define-for-syntax (make-unquote-binding-prefix-operator order prec protocol proc)
   (unquote-binding-prefix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'automatic)
@@ -37,8 +38,9 @@
                      [(head . tail) (proc (pack-tail #'tail) #'head)]))
                  proc)))))
 
-(define-for-syntax (make-unquote-binding-infix-operator prec protocol proc assc)
+(define-for-syntax (make-unquote-binding-infix-operator order prec protocol proc assc)
   (unquote-binding-prefix-operator
+   order
    prec
    protocol
    (if (eq? protocol 'automatic)

--- a/rhombus-lib/rhombus/private/amalgam/unquote-binding-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/unquote-binding-primitive.rkt
@@ -21,6 +21,8 @@
          "name-root-space.rkt"
          "name-root-ref.rkt"
          "op-literal.rkt"
+         "order.rkt"
+         "order-primitive.rkt"
          "parens.rkt"
          (submod "function-parse.rkt" for-call)
          (only-in "import.rkt" as open)
@@ -118,6 +120,7 @@
 
 (define-unquote-binding-syntax ::
   (unquote-binding-infix-operator
+   #f
    null
    'macro
    (lambda (form1 stx)
@@ -506,6 +509,7 @@
 
 (define-unquote-binding-syntax &&
   (unquote-binding-infix-operator
+   (lambda () (order-quote logical_conjuction))
    null
    'automatic
    (lambda (form1 form2 stx)
@@ -526,6 +530,7 @@
 
 (define-unquote-binding-syntax \|\|
   (unquote-binding-infix-operator
+   (lambda () (order-quote logical_disjuction))
    null
    'automatic
    (lambda (form1 form2 stx)
@@ -546,6 +551,7 @@
 
 (define-unquote-binding-syntax !
   (unquote-binding-prefix-operator
+   (lambda () (order-quote logical_negation))
    `()
    'automatic
    (lambda (form stx)

--- a/rhombus-lib/rhombus/private/amalgam/unquote-binding.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/unquote-binding.rkt
@@ -32,7 +32,7 @@
   (property unquote-binding-infix-operator infix-operator)
 
   (define (unquote-binding-transformer proc)
-    (unquote-binding-prefix-operator '((default . stronger)) 'macro proc))
+    (unquote-binding-prefix-operator #f '((default . stronger)) 'macro proc))
 
   (define (make-identifier-unquote-binding id)
     id)

--- a/rhombus-lib/rhombus/private/amalgam/values.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/values.rkt
@@ -27,6 +27,7 @@
 
 (define-binding-syntax values
   (binding-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -39,6 +40,7 @@
 
 (define-annotation-syntax values
   (annotation-prefix-operator
+   #f
    '((default . stronger))
    'macro
    (lambda (stx)

--- a/rhombus-lib/rhombus/private/amalgam/with.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/with.rkt
@@ -11,7 +11,8 @@
          "parens.rkt"
          "realm.rkt"
          (submod "equal.rkt" for-parse)
-         (only-in "assign.rkt" :=)
+         "order.rkt"
+         "order-primitive.rkt"
          "is-static.rkt")
 
 (provide with)
@@ -33,8 +34,9 @@
 
 (define-syntax with
   (expression-infix-operator
+   #f
    (lambda ()
-     `((,(expr-quote :=) . stronger)
+     `((,(order-quote assignment) . stronger)
        (default . weaker)))
    'macro
    (lambda (orig-form1 tail)

--- a/rhombus-lib/rhombus/private/unsafeable.rhm
+++ b/rhombus-lib/rhombus/private/unsafeable.rhm
@@ -5,22 +5,29 @@ export:
     u_operator as operator
     u_fun as fun
 
+meta:
+  syntax_class KWs
+  | '$(kw :: Keyword) $rest ...; ...'
+
 defn.macro
-| 'u_operator $(head :: Sequence): $body':
+| 'u_operator $(head :: Sequence): $(kws :: KWs); $body':
     'operator $head:
+       $kws
        ~unsafe: $body
        $body'
 | 'u_operator
-   | $(head :: Sequence): $body
+   | $(head :: Sequence): $(kws :: KWs); $body
    | ...':
     'operator
      | $head:
+         $kws
          ~unsafe: $body
          $body
      | ...'
 
 defn.macro
-| 'u_fun $(head :: Sequence): $body':
+| 'u_fun $(head :: Sequence): $(kws :: KWs); $body':
     'fun $head:
+       $kws
        ~unsafe: $body
        $body'

--- a/rhombus-scribble-lib/rhombus/scribble/private/rhombus-spacer.rhm
+++ b/rhombus-scribble-lib/rhombus/scribble/private/rhombus-spacer.rhm
@@ -22,6 +22,9 @@ export:
     fun
     doc
     operator
+    names:
+      // export namespace extensions
+      operator_order
     class
     interface
     veneer
@@ -320,6 +323,17 @@ meta:
   | '$(_ :: Operator)'
 
 meta:
+  fun adjust_operator_option(opt, esc):
+    match opt
+    | '$(kw && '~order') $(rest :: Sequence)':
+        '$kw $(spacer.adjust_sequence(rest, #'#{rhombus/operator_order}, esc))'.relocate_group(opt)
+    | '$(kw && ('~stronger_than' || '~weaker_than'
+                  || '~same_as' || '~same_as_on_left' || '~same_as_on_right'))
+           $(rest :: Sequence)':
+        '$kw $(spacer.adjust_sequence(rest, [#'#{rhombus/operator_order}, #false], esc))'.relocate_group(opt)
+    | ~else:
+        spacer.adjust_group(opt, #'~expr, esc)
+
   fun adjust_op(op, esc):
     syntax_class Header:
       kind ~sequence
@@ -329,7 +343,7 @@ meta:
     fun adjust_body(body):
       match body
       | ': $(opt && '$(_ :: Keyword) $_'); ...; $g; ...':
-          let [new_opt, ...] = [spacer.adjust_group(opt, #'~expr, esc), ...]
+          let [new_opt, ...] = [adjust_operator_option(opt, esc), ...]
           let [new_g, ...] = [spacer.adjust_group(g, body_spaces, esc), ...]
           ': $new_opt; ...; $new_g; ...'.relocate(body)
     fun adjust_op_case(case) :~ Syntax:
@@ -391,6 +405,28 @@ meta:
 spacer.bridge operator(self, tail, context, esc):
   ~in: ~defn
   '$self $(adjust_op(tail, esc))'
+
+spacer.bridge operator_order.def(self, tail, context, esc):
+  ~in: ~defn
+  match tail
+  | '$(name :: Sequence): $(block :: Block)':
+      match block
+      | ': $opt; ...':
+          let new_name = spacer.adjust_sequence(name, #'#{rhombus/operator_order}, esc)
+          let new_block = ': $(adjust_operator_option(opt, esc)); ...'.relocate(block)
+          '$self $new_name $new_block'
+  | '$(name :: Sequence) $(rest :: Sequence)':
+      let new_name = spacer.adjust_sequence(name, #'#{rhombus/operator_order}, esc)
+      '$self $new_name $rest'
+  | ~else: '$self $(spacer.adjust_sequence(tail, context, esc))'
+spacer.bridge operator_order.def_set(self, tail, context, esc):
+  ~in: ~defn
+  match tail
+  | '$(name :: Sequence): $(block :: Block)':
+      let new_name = spacer.adjust_sequence(name, #'#{rhombus/operator_order}, esc)
+      let new_block = spacer.adjust_term(block, #'#{rhombus/operator_order}, esc)
+      '$self $new_name $new_block'
+  | ~else: '$self $(spacer.adjust_sequence(tail, context, esc))'
 
 meta:
   syntax_class Ann:

--- a/rhombus-scribble/rhombus/scribble/scribblings/doc.scrbl
+++ b/rhombus-scribble/rhombus/scribble/scribblings/doc.scrbl
@@ -413,6 +413,29 @@
 
 }
 
+@doc(
+  ~nonterminal:
+    id_name: namespace ~defn
+  doc 'operator_order.def $id_name'
+  doc 'operator_order.def $id_name: $option; ...'
+  doc 'operator_order.def_set $id_name: $option; ...'
+  doc 'operator_order: $option; ...'
+){
+
+ The @rhombus(operator_order.def, ~doc) and
+ @rhombus(operator_order.def_set, ~doc) forms are @tech{doc entry} forms
+ to document an operator order like @rhombus(addition, ~operator_order)
+ or operator order set like @rhombus(arithmetic, ~operator_order).
+
+ The @rhombus(operator_order, ~doc) form does not document a binding
+ itself, but is meant to be used alongside @rhombus(expr.macro, ~doc) and
+ similar when documenting a prefix or infix operator. Each
+ @rhombus(option) is typically @rhombus(~order: #,(@rhombus(name, ~var)))
+ to document the operator's order or a @rhombus(~stronger_than) or
+ @rhombus(~weaker_than) form to document its precedence directly.
+
+}
+
 
 @doc(
   ~nonterminal:

--- a/rhombus-scribble/rhombus/scribble/scribblings/rhombus.scrbl
+++ b/rhombus-scribble/rhombus/scribble/scribblings/rhombus.scrbl
@@ -40,6 +40,7 @@
     ~space_meta_clause
     ~key_comp
     ~immediate_callee
+    ~operator_order
     ~doc
 ){
 

--- a/rhombus-scribble/rhombus/scribble/tests/doc_expect.shrub
+++ b/rhombus-scribble/rhombus/scribble/tests/doc_expect.shrub
@@ -497,6 +497,7 @@ html:
                           span {class: "hspace"}: nbsp
                           span {class: "RktVar"}: "c"
                           span {class: "stt"}: ":"
+                          span {class: "hspace"}: nbsp
                           span {class: "stt"}: span {class: "RktSym"}: "fun"
                           span {class: "hspace"}: nbsp
                           span {class: "RktPn"}: "("

--- a/rhombus/rhombus/scribblings/reference/annotation.scrbl
+++ b/rhombus/rhombus/scribblings/reference/annotation.scrbl
@@ -279,6 +279,8 @@
 @doc(
   expr.macro '$expr !!.'
   repet.macro '$repet !!.'
+  operator_order:
+    ~order: member_access
 ){
 
  The @rhombus(!!.) operator is equivalent to @rhombus(!!) followed by
@@ -303,6 +305,8 @@
   expr.macro '$expr ?. $id'
   repet.macro '$repet ?. $id ($arg, ...)'
   repet.macro '$repet ?. $id'
+  operator_order:
+    ~order: member_access
 ){
 
  If @rhombus(expr) produces @rhombus(#false), then the result of a

--- a/rhombus/rhombus/scribblings/reference/appendable.scrbl
+++ b/rhombus/rhombus/scribblings/reference/appendable.scrbl
@@ -21,7 +21,7 @@ An @deftech{appendable} value is one that supports @rhombus(++). Maps,
     set_expr: block expr
     elem_expr: block expr
 
-  operator ((v1 :: Map) ++ (v2 :: Map)) :: Map
+  operator ((v1 :: Map) ++ (v2 :: Map)) :: Map  operator_order
   operator ((v1 :: Set) ++ (v2 :: Set)) :: Set
   operator ((v1 :: List) ++ (v2 :: List)) :: List
   operator ((v1 :: PairList) ++ (v2 :: PairList)) :: PairList
@@ -29,7 +29,8 @@ An @deftech{appendable} value is one that supports @rhombus(++). Maps,
   operator ((v1 :: ReadableString) ++ (v2 :: ReadableString))
     :: String
   operator ((v1 :: Bytes) ++ (v2 :: Bytes)) :: MutableBytes
-  operator ((v1 :: Appendable) ++ (v2 :: Appendable)) :: Any
+  operator ((v1 :: Appendable) ++ (v2 :: Appendable)) :: Any:
+    ~order: concatenation
 ){
 
  Appends @rhombus(v1) and @rhombus(v2) to create a new map, set, list,

--- a/rhombus/rhombus/scribblings/reference/boolean.scrbl
+++ b/rhombus/rhombus/scribblings/reference/boolean.scrbl
@@ -37,6 +37,8 @@
     right_repet: block repet
   expr.macro '$left_expr || $right_expr'
   repet.macro '$left_repet || $right_repet'
+  operator_order:
+    ~order: logical_disjunction
 ){
 
  Produces the value of @rhombus(left_expr) if it is
@@ -53,6 +55,8 @@
     left_bind: def bind ~defn
     right_bind: def bind ~defn
   bind.macro '$left_bind || $right_bind'
+  operator_order:
+    ~order: logical_disjunction
 ){
 
  Matches if either @rhombus(left_bind) or @rhombus(right_bind) matches.
@@ -77,6 +81,8 @@
     left_annot: :: annot
     right_annot: :: annot
   annot.macro '$left_annot || $right_annot'
+  operator_order:
+    ~order: logical_disjunction
 ){
 
  Creates an annotation that accepts a value satisfying either
@@ -140,6 +146,8 @@
     right_repet: block repet
   expr.macro '$left_expr && $right_expr'
   repet.macro '$left_repet && $right_repet'
+  operator_order:
+    ~order: logical_conjunction
 ){
 
  Produces @rhombus(#false) if the value of @rhombus(left_expr) is
@@ -156,6 +164,8 @@
     left_bind: def bind ~defn
     right_bind: def bind ~defn
   bind.macro '$left_bind && $right_bind'
+  operator_order:
+    ~order: logical_conjunction
 ){
 
  Matches when both @rhombus(left_bind) and @rhombus(right_bind) match.
@@ -185,6 +195,8 @@
     left_annot: :: annot
     right_annot: :: annot
   annot.macro '$left_annot && $right_annot'
+  operator_order:
+    ~order: logical_conjunction
 ){
 
  Creates an annotation that accepts a value satisfying both
@@ -250,6 +262,8 @@
 
 @doc(
   operator (! (v :: Any)) :: Boolean
+  operator_order:
+    ~order: logical_negation
 ){
 
  Returns @rhombus(#true) if @rhombus(v) is @rhombus(#false),
@@ -265,6 +279,8 @@
 
 @doc(
   bind.macro '! $bind'
+  operator_order:
+    ~order: logical_negation
 ){
 
  Matches if @rhombus(bind) does not match. Because @rhombus(bind) does
@@ -283,6 +299,8 @@
 
 @doc(
   annot.macro '! $annot'
+  operator_order:
+    ~order: logical_negation
 ){
 
  Creates an annotation that accepts a value not satisfying

--- a/rhombus/rhombus/scribblings/reference/class.scrbl
+++ b/rhombus/rhombus/scribblings/reference/class.scrbl
@@ -955,6 +955,10 @@
 
 @doc(
   expr.macro '$obj with ($id = $expr, ...)'
+
+  operator_order:
+    ~stronger_than: assignment
+    ~weaker_than: ~other
 ){
 
  Performs a functional update of the object produced by @rhombus(obj) by

--- a/rhombus/rhombus/scribblings/reference/comparable.scrbl
+++ b/rhombus/rhombus/scribblings/reference/comparable.scrbl
@@ -16,14 +16,20 @@ and @tech{paths} are all comparable, as are instances of classes that
 implement @rhombus(Comparable, ~class).
 
 @doc(
-  operator ((v1 :: Comparable) < (v2 :: Comparable)) :: Boolean
-  operator ((v1 :: Comparable) > (v2 :: Comparable)) :: Boolean
-  operator ((v1 :: Comparable) <= (v2 :: Comparable)) :: Boolean
-  operator ((v1 :: Comparable) >= (v2 :: Comparable)) :: Boolean
+  operator ((v1 :: Comparable) < (v2 :: Comparable)) :: Boolean:
+    ~order: comparison
+  operator ((v1 :: Comparable) > (v2 :: Comparable)) :: Boolean:
+    ~order: comparison
+  operator ((v1 :: Comparable) <= (v2 :: Comparable)) :: Boolean:
+    ~order: comparison
+  operator ((v1 :: Comparable) >= (v2 :: Comparable)) :: Boolean:
+    ~order: comparison
   operator ((v1 :: Comparable) compares_equal (v2 :: Comparable))
-    :: Boolean
+    :: Boolean:
+      ~order: comparison
   operator ((v1 :: Comparable) compares_unequal (v2 :: Comparable))
-    :: Boolean
+    :: Boolean:
+      ~order: comparison
 ){
 
  Compares @rhombus(v1) and @rhombus(v2), which uses a primitive

--- a/rhombus/rhombus/scribblings/reference/dot.scrbl
+++ b/rhombus/rhombus/scribblings/reference/dot.scrbl
@@ -12,6 +12,8 @@
   expr.macro '$target_expr . $id'
   expr.macro '$target_expr . $id $assign_op $expr'
   repet.macro '$target_repet . $id'
+  operator_order:
+    ~order: member_access
   grammar assign_op:
     :=
     $other_assign_op

--- a/rhombus/rhombus/scribblings/reference/entry_form.scrbl
+++ b/rhombus/rhombus/scribblings/reference/entry_form.scrbl
@@ -78,6 +78,13 @@ sequences, not values. So, @rhombus(0), @rhombus(0 + 1), and
 @rhombus(0 + 1 + 1) fit the grammar for @rhombus(peano_num, ~var), but
 @rhombus(2) does not.
 
+When a syntactic form is an operator, then precedence or an
+@tech{operator order} for the operator is shown by keywords such as
+@rhombus(~order), @rhombus(~weaker_than), or @rhombus(~stronger_than),
+as in a @rhombus(macro, ~defn) form. Unless otherwise documented, a
+prefix operator's precedence corresponds to
+@rhombus(~stronger_than: ~other).
+
 @section(~tag: "doc_method"){Documenting Methods}
 
 When a binding is documented with @rhombus(method, ~class_clause), it

--- a/rhombus/rhombus/scribblings/reference/equal.scrbl
+++ b/rhombus/rhombus/scribblings/reference/equal.scrbl
@@ -5,7 +5,8 @@
 @title{Equality}
 
 @doc(
-  operator ((v1 :: Any) == (v2 :: Any)) :: Boolean
+  operator ((v1 :: Any) == (v2 :: Any)) :: Boolean:
+    ~order: comparison
   key_comp.def '=='
 ){
 
@@ -32,7 +33,8 @@
 }
 
 @doc(
-  operator ((v1 :: Any) === (v2 :: Any)) :: Boolean
+  operator ((v1 :: Any) === (v2 :: Any)) :: Boolean:
+    ~order: comparison
   key_comp.def '==='
 ){
 
@@ -55,8 +57,10 @@
 }
 
 @doc(
-  operator ((x :: Number) .= (y :: Number)) :: Boolean
-  operator ((x :: Number) .!= (y :: Number)) :: Boolean
+  operator ((x :: Number) .= (y :: Number)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Number) .!= (y :: Number)) :: Boolean:
+    ~order: comparison
 ){
 
  Reports whether @rhombus(x) and @rhombus(y) are numerically equal or
@@ -78,7 +82,8 @@
 }
 
 @doc(
-  operator ((v1 :: Any) != (v2 :: Any)) :: Boolean
+  operator ((v1 :: Any) != (v2 :: Any)) :: Boolean:
+    ~order: comparison
 ){
 
  Equivalent to @rhombus(!(v1 == v2)).
@@ -91,7 +96,8 @@
 
 
 @doc(
-  operator ((v1 :: Any) is_now (v2 :: Any)) :: Boolean
+  operator ((v1 :: Any) is_now (v2 :: Any)) :: Boolean:
+    ~order: comparison
   key_comp.def 'is_now'
 ){
 
@@ -125,7 +131,8 @@
 
 @doc(
   operator ((v1 :: Any) is_same_number_or_object (v2 :: Any))
-    :: Boolean
+    :: Boolean:
+      ~order: comparison
   key_comp.def 'is_same_number_or_object'
 ){
 

--- a/rhombus/rhombus/scribblings/reference/fixnum.scrbl
+++ b/rhombus/rhombus/scribblings/reference/fixnum.scrbl
@@ -31,13 +31,20 @@ unspecialized and fixnum-specific operations.
 @(~version_at_least "8.14.0.4")
 
 @doc(
-  operator ((x :: Fixnum) fixnum.(+) (y :: Fixnum)) :: Fixnum
-  operator ((x :: Fixnum) fixnum.(-) (y :: Fixnum)) :: Fixnum
-  operator (fixnum.(-) (x :: Fixnum)) :: Fixnum
-  operator ((x :: Fixnum) fixnum.(*) (y :: Fixnum)) :: Fixnum
-  operator ((x :: Fixnum) fixnum.div (y :: Fixnum)) :: Fixnum
-  operator ((x :: Fixnum) fixnum.rem (y :: Fixnum)) :: Fixnum
-  operator ((x :: Fixnum) fixnum.mod (y :: Fixnum)) :: Fixnum
+  operator ((x :: Fixnum) fixnum.(+) (y :: Fixnum)) :: Fixnum:
+    ~order: addition
+  operator ((x :: Fixnum) fixnum.(-) (y :: Fixnum)) :: Fixnum:
+    ~order: addition
+  operator (fixnum.(-) (x :: Fixnum)) :: Fixnum:
+    ~order: addition
+  operator ((x :: Fixnum) fixnum.(*) (y :: Fixnum)) :: Fixnum:
+    ~order: multiplication
+  operator ((x :: Fixnum) fixnum.div (y :: Fixnum)) :: Fixnum:
+    ~order: integer_division
+  operator ((x :: Fixnum) fixnum.rem (y :: Fixnum)) :: Fixnum:
+    ~order: integer_division
+  operator ((x :: Fixnum) fixnum.mod (y :: Fixnum)) :: Fixnum:
+    ~order: integer_division
 ){
 
  The same as operators like @rhombus(+), but restricted to @tech{fixnum}
@@ -48,12 +55,18 @@ unspecialized and fixnum-specific operations.
 }
 
 @doc(
-  operator ((x :: Fixnum) fixnum.(<) (y :: Fixnum)) :: Boolean
-  operator ((x :: Fixnum) fixnum.(<=) (y :: Fixnum)) :: Boolean
-  operator ((x :: Fixnum) fixnum.(==) (y :: Fixnum)) :: Boolean
-  operator ((x :: Fixnum) fixnum.(!=) (y :: Fixnum)) :: Boolean
-  operator ((x :: Fixnum) fixnum.(>=) (y :: Fixnum)) :: Boolean
-  operator ((x :: Fixnum) fixnum.(>) (y :: Fixnum)) :: Boolean
+  operator ((x :: Fixnum) fixnum.(<) (y :: Fixnum)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Fixnum) fixnum.(<=) (y :: Fixnum)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Fixnum) fixnum.(==) (y :: Fixnum)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Fixnum) fixnum.(!=) (y :: Fixnum)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Fixnum) fixnum.(>=) (y :: Fixnum)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Fixnum) fixnum.(>) (y :: Fixnum)) :: Boolean:
+    ~order: comparison
 ){
 
  The same as operators like @rhombus(<), but restricted to @tech{fixnum}
@@ -74,15 +87,21 @@ unspecialized and fixnum-specific operations.
 }
 
 @doc(
-  operator ((x :: Fixnum) fixnum.bits.(<<) (y :: Fixnum)) :: Fixnum
-  operator ((x :: Fixnum) fixnum.bits.(>>) (y :: Fixnum)) :: Fixnum
+  operator ((x :: Fixnum) fixnum.bits.(<<) (y :: Fixnum)) :: Fixnum:
+    ~order: bitwise_shift
+  operator ((x :: Fixnum) fixnum.bits.(>>) (y :: Fixnum)) :: Fixnum:
+    ~order: bitwise_shift
   operator ((x :: Fixnum) fixnum.bits.logical.(>>) (y :: Fixnum))
-    :: Fixnum
-  operator ((x :: Fixnum) fixnum.bits.and (y :: Fixnum)) :: Fixnum
-  operator ((x :: Fixnum) fixnum.bits.or (y :: Fixnum)) :: Fixnum
-  operator ((x :: Fixnum) fixnum.bits.xor (y :: Fixnum)) :: Fixnum
-  operator ((x :: Fixnum) fixnum.bits.not (y :: Fixnum)) :: Fixnum
-  operator ((x :: Fixnum) fixnum.bits.xor (y :: Fixnum)) :: Fixnum
+    :: Fixnum:
+      ~order: bitwise_shift
+  operator ((x :: Fixnum) fixnum.bits.and (y :: Fixnum)) :: Fixnum:
+    ~order: bitwise_conjunction
+  operator ((x :: Fixnum) fixnum.bits.or (y :: Fixnum)) :: Fixnum:
+    ~order: bitwise_disjunction
+  operator ((x :: Fixnum) fixnum.bits.xor (y :: Fixnum)) :: Fixnum:
+    ~order: bitwise_disjunction
+  operator ((x :: Fixnum) fixnum.bits.not (y :: Fixnum)) :: Fixnum:
+    ~order: bitwise_negation
 ){
 
  The same as operators like @rhombus(bits.(<<)), but restricted to
@@ -113,15 +132,20 @@ unspecialized and fixnum-specific operations.
 
 @doc(
   operator ((x :: Fixnum) fixnum.wraparound.(+) (y :: Fixnum))
-    :: Fixnum
+    :: Fixnum:
+      ~order: addition
   operator ((x :: Fixnum) fixnum.wraparound.(-) (y :: Fixnum))
-    :: Fixnum
+    :: Fixnum:
+      ~order: addition
   operator (fixnum.wraparound.(-) (x :: Fixnum))
-    :: Fixnum
+    :: Fixnum:
+      ~order: addition
   operator ((x :: Fixnum) fixnum.wraparound.(*) (y :: Fixnum))
-    :: Fixnum
+    :: Fixnum:
+      ~order: multiplication
   operator ((x :: Fixnum) fixnum.wraparound.bits.(<<) (y :: Fixnum))
-    :: Fixnum
+    :: Fixnum:
+      ~order: bitwise_shift
 ){
 
  Like @rhombus(fixnum.(+)), @rhombus(fixnum.(-)), @rhombus(fixnum.(*)),

--- a/rhombus/rhombus/scribblings/reference/flonum.scrbl
+++ b/rhombus/rhombus/scribblings/reference/flonum.scrbl
@@ -31,12 +31,18 @@ unspecialized and flonum-specific operations.
 @(~version_at_least "8.14.0.4")
 
 @doc(
-  operator ((x :: Flonum) flonum.(+) (y :: Flonum)) :: Flonum
-  operator ((x :: Flonum) flonum.(-) (y :: Flonum)) :: Flonum
-  operator (flonum.(-) (x :: Flonum)) :: Flonum
-  operator ((x :: Flonum) flonum.(*) (y :: Flonum)) :: Flonum
-  operator ((x :: Flonum) flonum.(/) (y :: Flonum)) :: Flonum
-  operator ((x :: Flonum) flonum.(**) (y :: Flonum)) :: Flonum
+  operator ((x :: Flonum) flonum.(+) (y :: Flonum)) :: Flonum:
+    ~order: addition
+  operator ((x :: Flonum) flonum.(-) (y :: Flonum)) :: Flonum:
+    ~order: addition
+  operator (flonum.(-) (x :: Flonum)) :: Flonum:
+    ~order: addition
+  operator ((x :: Flonum) flonum.(*) (y :: Flonum)) :: Flonum:
+    ~order: multiplication
+  operator ((x :: Flonum) flonum.(/) (y :: Flonum)) :: Flonum:
+    ~order: multiplication
+  operator ((x :: Flonum) flonum.(**) (y :: Flonum)) :: Flonum:
+    ~order: exponentiation
 ){
 
  The same as operators like @rhombus(+), but restricted to @tech{flonum}
@@ -47,12 +53,18 @@ unspecialized and flonum-specific operations.
 }
 
 @doc(
-  operator ((x :: Flonum) flonum.(<) (y :: Flonum)) :: Boolean
-  operator ((x :: Flonum) flonum.(<=) (y :: Flonum)) :: Boolean
-  operator ((x :: Flonum) flonum.(==) (y :: Flonum)) :: Boolean
-  operator ((x :: Flonum) flonum.(!=) (y :: Flonum)) :: Boolean
-  operator ((x :: Flonum) flonum.(>=) (y :: Flonum)) :: Boolean
-  operator ((x :: Flonum) flonum.(>) (y :: Flonum)) :: Boolean
+  operator ((x :: Flonum) flonum.(<) (y :: Flonum)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Flonum) flonum.(<=) (y :: Flonum)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Flonum) flonum.(==) (y :: Flonum)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Flonum) flonum.(!=) (y :: Flonum)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Flonum) flonum.(>=) (y :: Flonum)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Flonum) flonum.(>) (y :: Flonum)) :: Boolean:
+    ~order: comparison
 ){
 
  The same as operators like @rhombus(<), but restricted to @tech{flonum}

--- a/rhombus/rhombus/scribblings/reference/function-call.scrbl
+++ b/rhombus/rhombus/scribblings/reference/function-call.scrbl
@@ -87,6 +87,8 @@ normally bound to implement @tech{function} calls.
     fun_expr: block expr
   expr.macro '$arg_expr |> $immediate_callee'
   expr.macro '$arg_expr |> $fun_expr'
+  operator_order:
+    ~order: pipeline
 ){
 
  The @rhombus(|>) operator applies its second argument as a function to
@@ -125,6 +127,8 @@ normally bound to implement @tech{function} calls.
     fun_expr: block expr
   expr.macro '$arg_expr ?> $immediate_callee'
   expr.macro '$arg_expr ?> $fun_expr'
+  operator_order:
+    ~order: pipeline
 ){
 
  Like @rhombus(|>), but if the result of @rhombus(arg_expr) is

--- a/rhombus/rhombus/scribblings/reference/list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/list.scrbl
@@ -39,10 +39,10 @@ it supplies its elements in order.
   ~nonterminal:
     listable_expr: block expr
   fun List(v :: Any, ...) :: List
-  expr.macro '#%brackets [$expr_or_splice, ...]'
-  repet.macro '#%brackets [$repet_or_splice, ...]'
   expr.macro 'List[$expr_or_splice, ...]'
   repet.macro 'List[$repet_or_splice, ...]'
+  expr.macro '#%brackets [$expr_or_splice, ...]'
+  repet.macro '#%brackets [$repet_or_splice, ...]'
 
   grammar expr_or_splice:
     $expr
@@ -83,8 +83,8 @@ it supplies its elements in order.
     list_repet_bind: def bind ~defn
     repet_bind: def bind ~defn
   bind.macro 'List($bind_or_splice, ...)'
-  bind.macro '#%brackets [$bind_or_splice, ...]'
   bind.macro 'List[$bind_or_splice, ...]'
+  bind.macro '#%brackets [$bind_or_splice, ...]'
   grammar bind_or_splice:
     $bind
     $splice

--- a/rhombus/rhombus/scribblings/reference/macro.scrbl
+++ b/rhombus/rhombus/scribblings/reference/macro.scrbl
@@ -52,6 +52,8 @@
     $id
     ($parsed_id)
   grammar option:
+    ~order $name
+    ~order: $name
     ~stronger_than $other ...
     ~stronger_than: $other ...; ...
     ~weaker_than $other ...
@@ -69,8 +71,7 @@
     ~all_stx $id
     ~all_stx: $id
   grammar other:
-    $id
-    $op
+    $name
     ~other
   grammar assoc:
     ~left
@@ -151,10 +152,13 @@
  @rhombus(option) keywords can appear. The options
  @rhombus(~weaker_than), @rhombus(~stronger_than), @rhombus(~same_as),
  @rhombus(~same_on_left_as), and @rhombus(~same_on_right_as) declare
- an name's precedence relative to other names, where @rhombus(~other)
+ an name's precedence relative to other names or @tech{operator orders}, where @rhombus(~other)
  stands for any operator not otherwise mentioned. The
  @rhombus(~associativity) option is allowed only with an infix
- @rhombus(macro_pattern). The @rhombus(~op_stx) option binds an
+ @rhombus(macro_pattern). The @rhombus(~order) option selects a @tech{operator order}
+ for the operator, which defines precedence relationships to other operator orders and a default
+ associativity, but precedence and associativity options within @rhombus(macro, ~defn) override
+ the ones defined with the operator order. The @rhombus(~op_stx) option binds an
  identifier to an identifier or operator syntax object as it appears
  in a use of the macro (which cannot be
  matched directly in the @rhombus(macro_pattern), since that position

--- a/rhombus/rhombus/scribblings/reference/meta-lib.scrbl
+++ b/rhombus/rhombus/scribblings/reference/meta-lib.scrbl
@@ -43,6 +43,7 @@ alternative to starting with @rhombuslangname(rhombus) and importing
 @include_section("static-info.scrbl")
 @include_section("dot-provider.scrbl")
 @include_section("repet-macro.scrbl")
+@include_section("operator-order.scrbl")
 @include_section("macro-more.scrbl")
 @include_section("stxobj-meta.scrbl")
 @include_section("syntax-parameter.scrbl")

--- a/rhombus/rhombus/scribblings/reference/number.scrbl
+++ b/rhombus/rhombus/scribblings/reference/number.scrbl
@@ -242,12 +242,18 @@ operations like @rhombus(.<) and @rhombus(.>) work only on real numbers.
 
 
 @doc(
-  operator ((x :: Number) + (y :: Number)) :: Number
-  operator ((x :: Number) - (y :: Number)) :: Number
-  operator (- (x :: Number)) :: Number
-  operator ((x :: Number) * (y :: Number)) :: Number
-  operator ((x :: Number) / (y :: Number)) :: Number
-  operator ((x :: Number) ** (y :: Number)) :: Number
+  operator ((x :: Number) + (y :: Number)) :: Number:
+    ~order: addition
+  operator ((x :: Number) - (y :: Number)) :: Number:
+    ~order: addition
+  operator (- (x :: Number)) :: Number:
+    ~order: addition
+  operator ((x :: Number) * (y :: Number)) :: Number:
+    ~order: multiplication
+  operator ((x :: Number) / (y :: Number)) :: Number:
+    ~order: multiplication
+  operator ((x :: Number) ** (y :: Number)) :: Number:
+    ~order: exponentiation
 ){
 
  The usual arithmetic operators with the usual precedence.
@@ -281,9 +287,12 @@ operations like @rhombus(.<) and @rhombus(.>) work only on real numbers.
 
 
 @doc(
-  operator ((x :: Integral) div (y :: Integral)) :: Integral
-  operator ((x :: Integral) rem (y :: Integral)) :: Integral
-  operator ((x :: Integral) mod (y :: Integral)) :: Integral
+  operator ((x :: Integral) div (y :: Integral)) :: Integral:
+    ~order: integer_division
+  operator ((x :: Integral) rem (y :: Integral)) :: Integral:
+    ~order: integer_division
+  operator ((x :: Integral) mod (y :: Integral)) :: Integral:
+    ~order: integer_division
 ){
 
  Integer division (truncating), remainder, and modulo operations. These
@@ -301,10 +310,14 @@ operations like @rhombus(.<) and @rhombus(.>) work only on real numbers.
 
 
 @doc(
-  operator ((x :: Real) .> (y :: Real)) :: Boolean
-  operator ((x :: Real) .>= (y :: Real)) :: Boolean
-  operator ((x :: Real) .< (y :: Real)) :: Boolean
-  operator ((x :: Real) .<= (y :: Real)) :: Boolean
+  operator ((x :: Real) .> (y :: Real)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Real) .>= (y :: Real)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Real) .< (y :: Real)) :: Boolean:
+    ~order: comparison
+  operator ((x :: Real) .<= (y :: Real)) :: Boolean:
+    ~order: comparison
 ){
 
  The usual comparison operators on real numbers prefixed with @litchar{.} to
@@ -548,13 +561,20 @@ operations like @rhombus(.<) and @rhombus(.>) work only on real numbers.
 }
 
 @doc(
-  operator ((n :: Int) bits.and (m :: Int)) :: Int
-  operator ((n :: Int) bits.or (m :: Int)) :: Int
-  operator ((n :: Int) bits.xor (m :: Int)) :: Int
-  operator (bits.not (n :: Int)) :: Int
-  operator ((n :: Int) bits.(<<) (m :: NonnegInt)) :: Int
-  operator ((n :: Int) bits.(>>) (m :: NonnegInt)) :: Int
-  operator ((n :: Int) bits.(?) (m :: NonnegInt)) :: Boolean
+  operator ((n :: Int) bits.and (m :: Int)) :: Int:
+    ~order: bitwise_conjunction
+  operator ((n :: Int) bits.or (m :: Int)) :: Int:
+    ~order: bitwise_disjunction
+  operator ((n :: Int) bits.xor (m :: Int)) :: Int:
+    ~order: bitwise_disjunction
+  operator (bits.not (n :: Int)) :: Int:
+    ~order: bitwise_negation
+  operator ((n :: Int) bits.(<<) (m :: NonnegInt)) :: Int:
+    ~order: bitwise_shift
+  operator ((n :: Int) bits.(>>) (m :: NonnegInt)) :: Int:
+    ~order: bitwise_shift
+  operator ((n :: Int) bits.(?) (m :: NonnegInt)) :: Boolean:
+    ~order: bitwise_test
   fun bits.length(n :: Int) :: Int
   fun bits.field(n :: Int,
                  start :: NonnegInt,

--- a/rhombus/rhombus/scribblings/reference/operator-order.scrbl
+++ b/rhombus/rhombus/scribblings/reference/operator-order.scrbl
@@ -1,0 +1,213 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@title{Operator Orders}
+
+An @deftech{operator order} declares precedence relationships to other
+operator orders or a default order. An operator defined with a form such
+as @rhombus(operator, ~defn) or @rhombus(macro, ~defn) can select an
+operator order using @rhombus(~order), and then precedence
+specifications else using the operator order's name apply to the newly
+declared operator. The operator also inherits precedence declarations
+and an associativity declared in its operator order, but an operator
+declaration can override those.
+
+An operator order is not specific to a @tech{space}, and operators bound
+in multple spaces (such as via @rhombus(bind.macro, ~defn) or
+@rhombus(annot.macro, ~defn)) can use the same set of operator orders.
+
+@doc(
+  defn.macro 'operator_order.def $id_name:
+                $option
+                ...'
+  grammar option:
+    ~stronger_than $other ...
+    ~stronger_than: $other ...; ...
+    ~weaker_than $other ...
+    ~weaker_than: $other ...; ...
+    ~same_as $other ...
+    ~same_as: $other ...; ...
+    ~same_on_left_as $other ...
+    ~same_on_left_as: $other ...; ...
+    ~same_on_right_as $other ...
+    ~same_on_right_as: $other ...; ...
+    ~associativity $assoc
+    ~associativity: $assoc
+){
+
+ Defines @rhombus(id_name) as an @tech{operator order} with precedence
+ relationships to other operation orders declared by @rhombus(option)s.
+ Each @rhombus(other) in an @rhombus(option) must by either
+ @rhombus(~other) or refer to a previously defined operator order; an
+ @rhombus(other) cannot be an operator name.
+
+}
+
+@doc(
+  ~nonterminal:
+    order_id_name: namespace id_name ~defn
+  defn.macro 'operator_order.def_set $id_name:
+                $order_id_name ...
+                ...'
+){
+
+ Defines @rhombus(id_name) as a shorthand for a specification that lists
+ all of the individual @rhombus(order_id_name)s. The defined
+ @rhombus(id_name) can be used in @rhombus(~stronger), @rhombus(~weaker),
+ etc., options to declare precedence relationships, but it cannot be used
+ in @rhombus(~order) (i.e., an operator has at more one operator order).
+
+}
+
+@doc(
+  operator_order.def comparison
+){
+
+ The precedence for a comparison operator such as @rhombus(<) or
+ @rhombus(==).
+
+}
+
+@doc(
+  operator_order.def addition:
+    ~weaker_than:
+      integer_division
+      multiplication
+      exponentiation
+    ~stronger_than:
+      comparison
+  operator_order.def integer_division:
+    ~weaker_than:
+      multiplication
+      exponentiation
+    ~stronger_than:
+      comparison
+  operator_order.def multiplication:
+    ~weaker_than:
+      exponentiation
+    ~stronger_than:
+      comparison
+  operator_order.def exponentiation:
+    ~associativity: ~right
+    ~stronger_than:
+      comparison
+  operator_order.def_set arithmetic:
+    addition
+    integer_division
+    multiplication
+    exponentiation
+){
+
+ Precedence orders for arithmetic operators such as @rhombus(+),
+ @rhombus(mod),  @rhombus(*), and @rhombus(**).
+
+}
+
+@doc(
+  operator_order.def logical_disjunction:
+    ~weaker_than:
+      comparison
+      arithmetic
+      logical_conjunction
+      logical_negation
+  operator_order.def logical_conjunction:
+    ~weaker_than:
+      comparison
+      arithmetic
+      logical_negation
+  operator_order.def logical_negation:
+    ~weaker_than:
+      comparison
+){
+
+ Precedence orders for operators such as @rhombus(||),
+ @rhombus(&&), and @rhombus(!).
+
+}
+
+@doc(
+  operator_order.def assignment:
+    ~weaker_than: ~other
+){
+
+ Precedence orders for operators such as @rhombus(:=).
+
+}
+
+@doc(
+  operator_order.def enumeration:
+    ~weaker_than: arithmetic
+){
+
+ Precedence orders for operators such as @rhombus(..).
+
+}
+
+@doc(
+  operator_order.def concatenation:
+    ~weaker_than:
+      comparison
+      arithmetic
+      logical_disjunction
+      logical_conjunction
+){
+
+ Precedence orders for operators such as @rhombus(++) and @rhombus(+&).
+
+}
+
+@doc(
+  operator_order.def member_access:
+    ~stronger_than: ~other
+){
+
+ The precedence for an operator such as @rhombus(.) or
+ @rhombus(?.).
+
+}
+
+@doc(
+  operator_order.def pipeline:
+    ~weaker_than: ~other
+){
+
+ The precedence for an operator such as @rhombus(|>) or
+ @rhombus(?>).
+
+}
+
+@doc(
+  operator_order.def bitwise_test:
+    ~weaker_than:
+      comparison
+      bitwise_shift
+      bitwise_disjunction
+      bitwise_conjunction
+      bitwise_negation
+  operator_order.def bitwise_shift:
+    ~weaker_than:
+      comparison
+      bitwise_disjunction
+      bitwise_conjunction
+      bitwise_negation
+  operator_order.def bitwise_disjunction:
+    ~weaker_than:
+      comparison
+      bitwise_conjunction
+      bitwise_negation
+  operator_order.def bitwise_conjunction:
+    ~weaker_than:
+      comparison
+      bitwise_negation
+  operator_order.def bitwise_negation:
+    ~weaker_than:
+      comparison
+){
+
+ Precedence orders for operators such as @rhombus(bits.(?)),
+ @rhombus(bits.(<<)), @rhombus(bits.or), @rhombus(bits.and), and
+ @rhombus(bits.not).
+
+}

--- a/rhombus/rhombus/scribblings/reference/operator.scrbl
+++ b/rhombus/rhombus/scribblings/reference/operator.scrbl
@@ -40,6 +40,8 @@
     ~unsafe: $unsafe_body; ...
 
   grammar option:
+    ~order $name
+    ~order: $name
     ~stronger_than $other ...
     ~stronger_than: $other ...; ...
     ~weaker_than $other ...
@@ -100,8 +102,13 @@
 
  At the start of an operator body, @rhombus(option)s can declare
  precedence, associativity (in the case of an infix operator), and/or
- naming options. Each @rhombus(option) keyword can appear at most once. In
- a precedence specification, @rhombus(~other) stands for any operator not
+ naming options. Each @rhombus(option) keyword can appear at most once. The
+ @rhombus(~order) option selects a @tech{operator order} for the operator, which
+ defines precedence relationships to other operator orders and a default
+ associativity, but precedence and associativity options with @rhombus(operator)
+ override the ones defined with the operator order. In
+ a precedence specification, a @rhombus(name) refers to another operator binding
+ or to a @tech{operator order}, while @rhombus(~other) stands for any operator not
  otherwise mentioned. The @rhombus(~name), @rhombus(~who), and @rhombus(~unsafe) options are
  as in @rhombus(fun, ~defn). When multiple cases are provided using an immediate @vbar, then
  only the first prefix case and the first infix/postfix case can supply
@@ -149,7 +156,7 @@
     ^^^ "b"
   ~defn:
     operator ^^^:
-      ~weaker_than: +
+      ~weaker_than: arithmetic
     | x ^^^ y:
         x +& y +& x
     | ^^^ y:

--- a/rhombus/rhombus/scribblings/reference/range.scrbl
+++ b/rhombus/rhombus/scribblings/reference/range.scrbl
@@ -56,6 +56,8 @@ equal to'' the upper bound by comparison on bounds.
   expr.macro '..'
   repet.macro '..'
   bind.macro '..'
+  operator_order:
+    ~order: enumeration
 ){
 
  The same as @rhombus(Range.from_to, ~expr),
@@ -83,6 +85,8 @@ equal to'' the upper bound by comparison on bounds.
   expr.macro '..= $end_expr'
   repet.macro '..= $end_repet'
   bind.macro '..= $end_bind'
+  operator_order:
+    ~order: enumeration
 ){
 
  The same as @rhombus(Range.from_to_inclusive, ~expr) and
@@ -108,6 +112,8 @@ equal to'' the upper bound by comparison on bounds.
   expr.macro '$start_expr <..'
   repet.macro '$start_repet <..'
   bind.macro '$start_bind <..'
+  operator_order:
+    ~order: enumeration
 ){
 
  The same as @rhombus(Range.from_exclusive_to, ~expr) and
@@ -126,6 +132,8 @@ equal to'' the upper bound by comparison on bounds.
   expr.macro '$start_expr <..= $end_expr'
   repet.macro '$start_repet <..= $end_repet'
   bind.macro '$start_bind <..= $end_bind'
+  operator_order:
+    ~order: enumeration
 ){
 
  The same as @rhombus(Range.from_exclusive_to_inclusive, ~expr).

--- a/rhombus/rhombus/scribblings/reference/string.scrbl
+++ b/rhombus/rhombus/scribblings/reference/string.scrbl
@@ -76,7 +76,8 @@ Strings are @tech{comparable}, which means that generic operations like
 
 
 @doc(
-  operator ((v1 :: Any) +& (v2 :: Any)) :: String
+  operator ((v1 :: Any) +& (v2 :: Any)) :: String:
+    ~order: concatenation
 ){
 
  Coerces @rhombus(v1) and @rhombus(v2) to a string, then appends the strings.

--- a/rhombus/rhombus/tests/operator_order.rhm
+++ b/rhombus/rhombus/tests/operator_order.rhm
@@ -1,0 +1,81 @@
+#lang rhombus/and_meta
+
+block:
+  operator (a $$ b):
+    ~weaker_than: multiplication
+    [a, b]
+  check 1 * 2 $$ 3 ~is [2, 3]
+
+check:
+  ~eval
+  operator (a $$ b):
+    ~weaker_than: multiplication
+    [a, b]
+  1 + 2 $$ 3
+  ~throws "explicit parenthesization needed"
+
+block:
+  operator (a $$ b):
+    ~weaker_than: arithmetic
+    [a, b]
+  check 1 * 20 $$ 3 ~is [20, 3]
+  check 1 + 20 $$ 3 ~is [21, 3]
+
+block:
+  operator_order.def tighter
+  operator_order.def looser:
+    ~weaker_than tighter
+  operator (a $$ b):
+    ~order tighter
+    [a, b]
+  operator (a ?? b):
+    ~order looser
+    [a, b]
+  operator (a !! b):
+    ~weaker_than tighter
+    [a, b]
+  operator (a !++! b):
+    ~weaker_than tighter
+    ~stronger_than $$ // can override spec by order
+    [a, b]
+  operator (a !**! b):
+    ~order looser
+    ~stronger_than $$ // can override spec inherited from order
+    [a, b]
+  check 1 ?? 2 $$ 3 ~is [1, [2, 3]]
+  check 1 $$ 2 ?? 3 ~is [[1, 2], 3]
+  check 1 !! 2 $$ 3 ~is [1, [2, 3]]
+  check 1 $$ 2 !! 3 ~is [[1, 2], 3]
+  check 1 $$ 2 !++! 3 ~is [1, [2, 3]]
+  check 1 $$ 2 !**! 3 ~is [1, [2, 3]]
+
+block:
+  operator_order.def_set addmult:
+    addition
+    multiplication
+  operator_order.def_set addmultdiv:
+    addmult
+    integer_division
+  operator (a $$ b):
+    ~weaker_than: addmult
+    [a, b]
+  operator (a $$$ b):
+    ~weaker_than: addmultdiv
+    [a, b]
+  check 1 * 20 $$ 3 ~is [20, 3]
+  check 1 + 20 $$ 3 ~is [21, 3]
+  check 1 * 20 $$$ 3 ~is [20, 3]
+  check 1 + 20 $$$ 3 ~is [21, 3]
+  check 1 + 20 $$$ 3 mod 2 ~is [21, 1]
+
+check:
+  ~eval
+  import rhombus/meta open
+  operator_order.def_set addmult:
+    addition
+    multiplication
+  operator (a $$ b):
+    ~weaker_than: addmult
+    [a, b]
+  1 < 20 $$ 3
+  ~throws "explicit parenthesization needed"

--- a/shrubbery-render-lib/shrubbery/render/define.rhm
+++ b/shrubbery-render-lib/shrubbery/render/define.rhm
@@ -162,6 +162,7 @@ meta:
          || #'~space_meta_clause
          || #'~key_comp
          || #'~immediate_callee
+         || #'~operator_order
          || #'~doc):
         #'spaced
     | ~else:
@@ -226,22 +227,28 @@ meta:
           match opt
           | '~escape: $(op :: Operator)': op
           | '$_: $body': escape_op
+      let space:
+        for values(space = #false) (opt: [opt, ...]):
+          match opt
+          | '~space: $space ...': [space.unwrap(), ...]
+          | '$_: $body': space
       let [opt, ...]:
         for List (opt: [opt, ...]):
           skip_when:
             match opt
             | '~escape $_ ...': #true
+            | '~space $_ ...': #true
             | _: #false
           opt
       '$typeset_rhombusblock_stx(
          $opt, ...,
-         $(escape_top_term(self, spacer.adjust_term(fin_tail, #false, escape_op), escape_op, escape_id))
+         $(escape_top_term(self, spacer.adjust_term(fin_tail, space, escape_op), escape_op, escape_id))
        )'
     fun check_options(options :~ List):
       for values(kws :~ Set = Set{}) (opt :~ Syntax: options):
         match opt
         | '$(kw_stx && ('~inset' || '~indent' || '~prompt' || '~indent_from_block'
-                          || '~spacer_info_box' || '~escape')) $_ ...':
+                          || '~spacer_info_box' || '~escape' || '~space')) $_ ...':
             let kw = kw_stx.unwrap()
             if kws[kw]
             | syntax_meta.error("duplicate option", stx, kw_stx)

--- a/shrubbery-render-lib/shrubbery/render/private/space_name.rhm
+++ b/shrubbery-render-lib/shrubbery/render/private/space_name.rhm
@@ -40,6 +40,7 @@ def space_names:
     #'~space_meta_clause,
     #'~key_comp,
     #'~immediate_callee,
+    #'~operator_order,
     #'~doc }
 
 fun is_builtin_space_keyword(v):


### PR DESCRIPTION
Previously, the only way to specify precedence between two operators is for one of the operators to know specifically about the other one. For example, `+` needed to mention `*` specifically, or vice versa.

This commit adds support for *operator orders* as a alternative. An operator order is a category like `addition` or `comparison` that has a precedence relation to other operator orders. For example, the `+`, `-`, `flonum.(+)`, `flonum.(-)`, `fixnum.(+)`, `fixnum.(-)`, `fixnum.wraparound.(+)`, and `fixnum.wraparound(-)` operators all declare the `addition` order, and the `*`, `flonum.(*)`, etc., operators have the `multiplication` order; all those operators then relate to each other as expected, because the `addition` declares itself weaker than `multiplcation`.

An operator declares itself to have up to one operator order. Any precedence relation defined relative to that order then applies releative to the operator, too. The operator inherits precedence declarations (with respect to other orders) from the order's definition, but it can optionally override those. An operator order is also defined with an associativity that serves as a default for operations that have the order. Precedence relationships declared in an operator can metion either operator orders or specific operators.

An operator order is not associated with an operator binding space, such as the expression space or annotation, so multiple spaces can all used the same operator orders. This flexibility is ensured in part by having operator orders refer only to other operator orders, never to specific operators. (That is, operators can refer to operator orders, but not the other way around.)

Predefined orders in this commit:

```
   addition
   multiplication
   exponentiation
   integer_division
   arithmetic ; shorthand for the above four
   comparison
   assignment
   enumeration
   concatenation
   logical_negation
   logical_conjunction
   logical_disjunction
   bitwise_negation
   bitwise_shift
   bitwise_conjunction
   bitwise_disjunction
   bitwise_test
```

The `arithmetic` operator order is more precisely an operator order set. It can only be used for writing precedence relationships, while an operator can only declare itself to have one of the specific operator orders.

When an operator's precedence is `~weaker` or `~stronger` with `~other`, then there's usually no need for an operator order, because there's nothing left to say about precedence. That's why there's no predefined operator order for `.`, for example, at least not so far. An operator set with `~weaker` or `~stronger` as `~other` can be useful if some precedence declaration needs to make an exception, however, such as `with` with respect to `assignment`.