### PR TITLE
add `rhombus/cmdline`

### DIFF
--- a/rhombus-lib/rhombus/cmdline.rhm
+++ b/rhombus-lib/rhombus/cmdline.rhm
@@ -1,0 +1,402 @@
+#lang rhombus/static/and_meta
+import:
+  "private/cmdline.rhm" open
+  meta:
+    "private/cmdline_flag.rhm" open
+
+export:
+  parse
+  parser
+
+  args
+  flag
+  multi
+  once_each
+  once_any
+  help
+
+  state
+
+  String
+
+  current_command_line
+  current_program
+  current_flag_string
+  current_containing_flag_string
+
+module class ~lang rhombus:
+  import:
+    "private/cmdline.rhm" open
+  export:
+    Parser
+    Handler
+    Flag
+    FinalFlag
+    Multi
+    OnceEach
+    OnceAny
+    Text
+    EndText
+    Content
+    make_builtin_flags
+
+annot.macro '(String.to_lib_module_path)':
+  'converting(fun (s :: String where p :: ModulePath = convert_lib_module_path(s)) :: ModulePath: p)'
+
+annot.macro 'providing($statinfos)':
+  annot_meta.pack_predicate('fun (x): #true', statinfos)
+
+fun convert_lib_module_path(x):
+  match String.split(x, "!")
+  | [base, submod, ...]:
+      cond
+      | all(submod.length() != 0, ...):
+          ModulePath.try('lib($base) $(List.append(['!', Symbol.from_string(submod)], ...))')
+      | ~else: #false
+  | ~else: #false
+
+meta:
+  syntax_class Arg:
+    fields: name_str
+            id
+            kind
+  | '$(id :: Identifier)':
+      field name_str: to_string(id)
+      field kind: 'String'
+  | '($(name :: Identifier) $(bound_as impo_meta.space: 'as') $(id :: Identifier))':
+      field name_str: to_string(name)
+      field kind: 'String'
+  | '($(id :: Identifier) $(bound_as bind_meta.space: '::') $(kind :: Name))':
+      field name_str: to_string(id)
+  | '($(name :: Identifier) $(bound_as impo_meta.space: 'as') $(id :: Identifier) $(bound_as bind_meta.space: '::') $(kind :: Name))':
+      field name_str: to_string(name)
+
+  syntax_class MaybeDots
+  | '$(bound_as bind_meta.space: '...')':
+      field [seq, ...] = ['...']
+  | '':
+      field [seq, ...] = []
+
+  syntax_class Key
+  | '~key: $key_body'
+  | '~key $(key_body :: Sequence)'
+
+  syntax_class Init
+  | '~init: $init_body'
+  | '~init $(init_body :: Sequence)'
+
+syntax_parameter.bridge state_var:
+  #false
+
+meta:
+  fun lookup_state_var(self):
+    let var = syntax_parameter_meta.lookup('state_var')
+    when !var
+    | syntax_meta.error("allowed only within a flag or args handler",
+                        self)
+    var
+
+expr.macro
+| 'state $(bound_as expr_meta.space: ':=') $(expr :: expr_meta.Parsed) $()':
+    ~op_stx: self
+    '$(lookup_state_var(self)) := $expr'
+| 'state[$key_expr] $(bound_as expr_meta.space: ':=') $(expr :: expr_meta.Parsed) $()':
+    ~op_stx: self
+    let var = lookup_state_var(self)
+    '$var := $var ++ {$key_expr: $expr}'
+| 'state':
+    ~op_stx: self
+    lookup_state_var(self)    
+    
+syntax_parameter.bridge multi_mode:
+  #false
+    
+meta:
+  fun parse_handler(stx,
+                    ctr,
+                    [arg :~ Syntax.matched_of(Arg), ...], dots :~ Syntax.matched_of(MaybeDots),
+                    key_body, get_default_key, ~always_arg_list = #false,
+                    ~multi_mode = #false,
+                    init_body,
+                    [body, ...],
+                    [extra, ...]):
+    when [arg, ...] == [] && [dots.seq, ...] != []
+    | syntax_meta.error("no arguments before ellipses", stx, dots)
+    let [[bind_string, from_string, statinfos], ...]:
+      for List (kind: [arg.kind, ...]):
+        match kind
+        | '$(k :: annot_meta.Parsed)':
+            let (bind, expr, statinfos) = annot_meta.unpack_converter(k)
+            [bind, expr, statinfos]
+    let has_body = [body, ...].length() > 0
+    let key:
+      cond
+      | has_body: #false
+      | key_body: 'key'
+      | ~else: get_default_key()
+    let e:
+      '$ctr(
+         block: $(init_body || (if multi_mode && !has_body
+                                | '{ $key: [] }'
+                                | '{}')),
+         [$(arg.name_str), ...],
+         $([dots.seq, ...] != []),
+         fun (accum :~ Map,
+              $arg.id :: converting(fun (s :~ String) :~ providing($statinfos):
+                                      match s
+                                      | $bind_string: $from_string
+                                      | ~else:
+                                          arg_fail($arg.name_str, s)),
+              ...,
+              $dots.seq, ...):
+           $(cond
+             | has_body:
+                 '«def mutable accum_state :: Map = accum
+                   syntax_parameter.relet state_var: 'accum_state'
+                   $body
+                   ...
+                   accum_state»'
+             | ~else:
+                 fun build_set_key(val):
+                   if multi_mode
+                   | 'accum ++ { $key: (Map.get(accum, $key, []) :~ List) ++ [$val] }'
+                   | 'accum ++ { $key: $val }'
+                 match [arg.id, ..., dots.seq, ...]
+                 | [] when !always_arg_list:
+                     'accum ++ { $key: #true }'
+                 | [arg] when !always_arg_list:
+                     build_set_key(arg)
+                 | ~else:
+                     build_set_key('[$arg.id, ..., $dots.seq, ...]')),
+         $extra,
+         ...
+       )'
+    cond
+    | !has_body && key_body:
+        'block:
+           def key: $key_body
+           $e'
+    | ~else:
+        e
+
+expr.macro
+| 'args $(arg :: Arg) ... $(dots :: MaybeDots) $()':
+    ~all_stx: stx
+    parse_handler(
+      stx,
+      'Handler',
+      [arg, ...], dots,
+      #false, fun (): '#'args', ~always_arg_list: #true,
+      '{}',
+      [],
+      []
+    )
+| 'args $(arg :: Arg) ... $(dots :: MaybeDots):
+     $(group_option_sequence
+       | '$(_ :: Key: open)'
+       | '$(_ :: Init: open)':
+           default init_body = '{}')
+     $body
+     ...':
+    ~all_stx: stx
+    parse_handler(
+      stx,
+      'Handler',
+      [arg, ...], dots,
+      key_body, fun (): '#'args',
+      init_body,
+      [body, ...],
+      []
+    )
+
+meta:
+  fun flag_to_key(str :~ Syntax):
+    let str :: String = str.unwrap()
+    let sym:
+      if str[0] == str[1]
+      | Symbol.from_string(str.substring(2, str.length()))
+      | Symbol.from_string(str.substring(1, str.length()))
+    '#'$sym'
+
+  fun check_flag_string(stx, str_stx :: Syntax):
+    let str :: String = str_stx.unwrap()
+    unless ok_flag_string(str)
+    | syntax_meta.error("invalid flag string",
+                        stx,
+                        str_stx)
+
+expr.macro
+| 'flag $(str :: String) $(arg :: Arg) ... $(dots :: MaybeDots) $()':
+    ~all_stx: stx
+    check_flag_string(stx, str)
+    parse_handler(
+      stx,
+      'Flag',
+      [arg, ...], dots,
+      #false, fun (): flag_to_key(str),
+      ~multi_mode: syntax_parameter_meta.lookup('multi_mode'),
+      #false,
+      [],      
+      ['[$str]',
+       '#false']
+    )
+| 'flag $(str :: String) $(arg :: Arg) ... $(dots :: MaybeDots):
+     $(group_option_sequence
+       | '$(pattern
+            | '~alias: $(alias_str :: String) ...; ...'
+            | '~alias $(alias_one_str :: String) ...':
+                field [[alias_str, ...], ...] = [[alias_one_str, ...]])'
+       | '$(pattern
+            | '~help: $help_text'
+            | '~help $(help_text :: Sequence)')'
+       | '$(_ :: Key: open)'
+       | '$(_ :: Init: open)'
+       | '~multi':
+           field multi = #true
+       | '~final':
+           field final = #true)
+     $body
+     ...':
+    ~all_stx: stx
+    check_flag_string(stx, str)
+    Function.pass(check_flag_string(stx, alias_str), ..., ...)
+    let multi_mode = multi || syntax_parameter_meta.lookup('multi_mode')
+    let e:
+      parse_handler(
+        stx,
+        if final | 'FinalFlag' | 'Flag',
+        [arg, ...], dots,
+        key_body, fun (): flag_to_key(str),
+        ~multi_mode: multi_mode,
+        init_body,
+        [body, ...],
+        ['[$str, $alias_str, ..., ...]',
+         'block:
+            $help_text']
+      )
+    if multi_mode
+    | 'Multi([$e])'
+    | e
+
+expr.macro 'multi: $flag_or_list; ...':
+  ~op_stx: who
+  'block:
+     syntax_parameter.relet multi_mode: #true
+     build_multi(#'$who, [$flag_or_list, ...], [$(flag_or_list.srcloc()), ...])'
+
+fun build_multi(who, flag_or_lists, srclocs):  
+  Multi(flatten(who, flag_or_lists, srclocs,
+                fun (v): v is_a Flag || v is_a Multi,
+                "flag, multi flag set, or list of valid elements"))
+
+expr.macro 'once_each: $flag_or_list; ...':
+  ~op_stx: who
+  'build_once_each(#'$who, [$flag_or_list, ...], [$(flag_or_list.srcloc()), ...])'
+
+fun build_once_each(who, flag_or_lists, srclocs):  
+  OnceEach(flatten(who, flag_or_lists, srclocs,
+                   fun (v): v is_a Flag || v is_a OnceEach,
+                   "flag, once-each flag set, or list of valid elements"))
+
+expr.macro 'once_any: $flag; ...':
+  ~op_stx: who
+  'build_once_any(#'$who, [$flag, ...], [$(flag.srcloc()), ...])'
+
+fun build_once_any(who, flag_or_lists, srclocs):  
+  OnceAny(flatten(who, flag_or_lists, srclocs,
+                  fun (v): v is_a Flag || v is_a OnceAny,
+                  "flag, once-any flag set, or list of valid elements"))
+
+fun flatten(who, args :~ List, srclocs :~ List, pred, desc, keep_srcloc = #false):
+  List.append(
+    & for List (arg: args,
+                srcloc: srclocs):
+      cond
+      | arg is_a List:
+          let srclocs: for List (a: arg :~ List): srcloc
+          flatten(who, arg, srclocs, pred, desc, keep_srcloc)
+      | pred(arg): (if keep_srcloc | [[arg, srcloc]] | [arg])
+      | ~else:
+          error(~who: who,
+                "not a valid element",
+                ~exn: Exn.Fail.Annot,
+                ~srcloc: srcloc,
+                error.val(~label: "element", arg),
+                error.text(~label: "allowed", desc))
+  )
+
+expr.macro 'help:
+              $(group_option_sequence
+                | '~end':
+                    field end = #true)
+              $body
+              ...':
+  '$(if end | 'EndText' | 'Text')(block: $body; ...)'
+
+fun arg_fail(arg_name, str):
+  error(~who: to_string(current_program()),
+        ~exn: Exn.Fail.User,
+        "invalid argument",
+        & (if current_flag_string()
+           | [error.text(~label: "after flag", current_flag_string())]
+           | []),
+        error.text(~label: "for", "<" ++ arg_name ++ ">"),
+        error.text(~label: "given", str),
+        & (if current_flag_string() == current_containing_flag_string()
+           | []
+           | [error.text(~label: "within combined flag", current_containing_flag_string())]))
+
+meta:
+  fun parse_parser(who, stx):
+    match stx
+    | '$(_ :: Term):
+         $(group_option_sequence
+           | '$(_ :: Init: open)':
+               default init_body = '{}'
+           | '~no_builtin':
+               field no_builtin = #true)
+         $element
+         ...':
+        '(block:
+            let element_and_srclocs = flatten_for_parse(#'$who, [$element, ...], [$(element.srcloc()), ...])
+            Parser(~who: #'$who,
+                   ~args: extract_args(#'$who, element_and_srclocs),
+                   ~flags: extract_flags(#'$who, element_and_srclocs),
+                   ~init: $init_body,
+                   ~add_builtin: $(!no_builtin))) :~ Parser'
+
+expr.macro
+| 'parser $tail ...':
+    ~all_stx: stx
+    ~op_stx: who
+    parse_parser(who, stx)
+
+expr.macro
+| 'parse $tail ...':
+    ~all_stx: stx
+    ~op_stx: who
+    '($(parse_parser(who, stx))).parse()'
+
+fun flatten_for_parse(who, elements, srclocs):  
+  flatten(who, elements, srclocs,
+          fun (v): (v is_a Handler) || (v is_a Content),
+          "args handler, flag, flag set (either multi, once-any, or once-each), help text, or list of valid elements",
+          #true)
+
+fun extract_args(who, element_and_srclocs :~ List):
+  def args:
+    for values(args = #false) ([element, srcloc]: element_and_srclocs):
+      if element is_a Handler && !(element is_a Flag)
+      | when args
+        | error(~who: who,
+                ~exn: Exn.Fail.Annot,
+                ~srcloc: srcloc,
+                "multiple args handlers provided")
+        element
+      | args
+  args || Handler({}, [], #false, fun (accum): accum)
+
+fun extract_flags(who, element_and_srclocs :~ List):
+  for List ([element, srcloc]: element_and_srclocs):
+    skip_when element is_a Handler && !(element is_a Flag)
+    element

--- a/rhombus-lib/rhombus/private/cmdline.rhm
+++ b/rhombus-lib/rhombus/private/cmdline.rhm
@@ -1,0 +1,466 @@
+#lang rhombus/static
+import:
+  lib("racket/base.rkt"):
+    expose:
+      #{find-system-path}
+      #{current-command-line-arguments}
+  "cmdline_flag.rhm" open
+  rhombus/meta.annot
+
+export:
+  current_command_line
+  current_program
+  current_flag_string
+  current_containing_flag_string
+
+  Parser
+
+  Handler
+
+  Flag
+  FinalFlag
+  Multi
+  OnceEach
+  OnceAny
+  Text
+  EndText
+
+  only_space annot:
+    Content
+
+  make_builtin_flags
+
+Parameter.def current_command_line :: List.of(String) = Array.to_list(#{current-command-line-arguments}())
+Parameter.def current_program :: String || Path = #{find-system-path}(#'#{run-file})
+Parameter.def current_flag_string :: maybe(String) = #false
+Parameter.def current_containing_flag_string :: maybe(String) = #false
+
+class Handler(init :~ Map,
+              args :~ List.of(String),
+              repeat_last :~ Boolean,
+              handler :: (~any) -> Map):
+  nonfinal
+  constructor (init :: Map,
+               args :: List.of(String),
+               repeat_last :: Any.to_boolean,
+               handler :: Function described_as ((~any) -> Map)):
+    ~who: who
+    let (a, req_kws, _) = handler.arity()
+    let args_mask: (if repeat_last | -1 | 1) bits.(<<) (args.length() + 1)
+    unless req_kws == [] && ((a bits.and args_mask) == args_mask)
+    | error(~who: who,
+            "handler function's arity is not consistent with receiving a map followed by arguments",
+            error.val(~label: "handler", handler),
+            error.val(~label: "arguments", args))
+    super(init, args, repeat_last, handler)
+
+interface Content
+
+class Flag(flag_strs :~ List.of(String),
+           help :~ maybe(String)):
+  extends Handler
+  implements Content
+  nonfinal
+  constructor (defaults :: Map,
+               args :: List.of(String),
+               repeat_last :: Any.to_boolean,
+               handler :: Function described_as ((~any) -> Map),
+               flag_strs :: List.of(String),
+               help :: maybe(String)):
+    ~who: who
+    let self:
+      super(defaults, args, repeat_last, handler)(flag_strs, help)
+    for (flag: flag_strs):
+      unless (ok_flag_string(flag))
+      | error(~who: who,
+              "invalid flag string",
+              error.val(~label: "flag string", flag))
+    self
+
+class FinalFlag():
+  extends Flag
+  internal _FinalFlag
+
+class Multi(choices :: List.of(Flag || Multi)):
+  implements Content
+
+class OnceEach(choices :: List.of(Flag || OnceEach)):
+  implements Content
+
+class OnceAny(choices :: List.of(Flag || OnceAny)):
+  implements Content
+
+class Text(text :: String):
+  nonfinal
+  implements Content
+
+class EndText():
+  extends Text
+
+class Parser(private _parse,
+             private _flags,
+             private _args,
+             private _init):
+  opaque
+  internal _Parser
+  constructor (
+    ~who: alt_who :: maybe(error.Who) = #false,
+    ~flags: flags :: List.of(Content),
+    ~add_builtin: add_builtin = #true,
+    ~args: args :: Handler,
+    ~init: init_state :: Map = {}
+  ):
+    ~who: who
+    command_line_parser(~who: alt_who || who,
+                        ~flags: flags,
+                        ~add_builtin: add_builtin,
+                        ~args: args,
+                        ~init: init_state)
+
+  property flags :~ List.of(Content): _flags
+  property args :~ Handler: _args
+  property init :~ Map: _init
+
+  method print_help(~program: exe_who :: String || Path = current_program()):
+    show_help(~program: exe_who,
+              ~flags: _flags,
+              ~args: _args)
+  method parse(~program: exe_who :: String || Path = current_program(),
+               ~line: line :: List.of(String) = current_command_line()) :~ Map:
+    _parse(~program: exe_who,
+           ~line: line)
+
+fun make_builtin_flags(help :: Map -> Map) :~ List.of(Content):
+  [
+    OnceEach([Flag({}, [], #false, help, ["--help", "-h"], "Show this information and exit, ignoring remaining arguments."),
+              FinalFlag({}, [], #false, fun (state): state, ["--"], "No argument after this flag is a flag.")])
+  ]
+
+fun command_line_parser(
+  ~who: who,
+  ~flags: flags :: List.of(Content),
+  ~add_builtin: add_builtin,
+  ~args: args :: Handler,
+  ~init: init_state
+) :~ Parser:
+  let flags:
+    if add_builtin
+    | let (flags, end_text) = split_end_text(flags)
+      flags ++ make_builtin_flags(fun (state): print_help_and_exit(result_parser)) ++ end_text
+    | flags
+  let (init_state, long_flags :~ Map, short_flags :~ Map, once_keys):
+    gather_flags(flags,
+                 args,
+                 init_state,
+                 ~who: who)
+  def result_parser:
+    _Parser(
+      fun (~program: exe_who :: String || Path = current_program(),
+           ~line: line :: List.of(String) = current_command_line()):
+        parameterize { current_program: exe_who,
+                       current_command_line: line }:
+          recur parse(state = init_state,
+                      once = {},
+                      line :~ List = line):
+            fun finish(state, line :~ List):
+              cond
+              | args.repeat_last:
+                  when line.length() < args.args.length() - 1
+                  | throw_wrong_args(~who: to_string(exe_who), args, line, #false, #false)
+              | ~else:
+                  when line.length() != args.args.length()
+                  | throw_wrong_args(~who: to_string(exe_who), args, line, #false, #false)
+              args.handler(state, & line)
+            match line
+            | []:
+                finish(state, line)
+            | [first :~ String, rest, ...]:
+                cond
+                | first.length() > 1 && (first[0] == Char"-" || first[0] == Char"+"):
+                    if first.length() > 2 && first[0] == first[1]
+                    | // long flag
+                      let (state, once, line, is_final):
+                        apply_flag(first, first, long_flags.get(first, #false), state, [rest, ...],
+                                   once_keys, once, #false,
+                                   ~who: to_string(exe_who))
+                      if is_final
+                      | finish(state, line)
+                      | parse(state, once, line)
+                    | // short flag(s)
+                      let (state, once, line, is_final):
+                        for values(state = state, once = once, line = [rest, ...], is_final = #false):
+                          each i: 1 .. first.length()
+                          let flag = first[0] +& first[i]
+                          apply_flag(flag, first, short_flags.get(flag, #false), state, line,
+                                     once_keys, once, is_final,
+                                     ~who: to_string(exe_who))
+                      if is_final
+                      | finish(state, line)
+                      | parse(state, once, line)
+                | ~else:
+                    finish(state, line),
+      flags,
+      args,
+      init_state
+    )
+  result_parser
+
+fun gather_flags(flags :~ List, args, init_state,
+                 ~who: who):
+  recur setup(c = flags.add(args),
+              state = init_state,
+              long_flags = {},
+              short_flags = {},
+              once_keys :~ Map = {},
+              once_key = #'self):
+    match c
+    | [c, ...]:
+        for values(state = state, long_flags = long_flags, short_flags = short_flags, once_keys = once_keys):
+          each c: [c, ...]
+          setup(c, state, long_flags, short_flags, once_keys, once_key)
+    | h :: Handler:
+        let once_keys:
+          cond
+          | once_key == #'self: once_keys ++ { h: h }
+          | once_key: once_keys ++ { h: once_key }
+          | ~else: once_keys
+        let state:
+          for values(state :~ Map = state):
+            each (key, val): h.init
+            if state.has_key(key)
+            | error(~who: who,
+                    "duplicate default key",
+                    error.val(~label: "key", key))
+            | state ++ { key : val }
+        match c
+        | f :: Flag:
+            let (long_flags, short_flags):
+              for values(long_flags :~ Map = long_flags,
+                         short_flags :~ Map = short_flags):
+                each flag_str: f.flag_strs
+                let is_short = flag_str.length() == 2
+                when (if is_short
+                      | short_flags.get(flag_str, #false)
+                      | long_flags.get(flag_str, #false))
+                | error(~who: who,
+                        "duplicate flag",
+                        error.val(~label: "flag", flag_str))
+                if is_short
+                | values(long_flags, short_flags ++ { flag_str: f })
+                | values(long_flags ++ { flag_str: f }, short_flags)
+            values(state, long_flags, short_flags, once_keys)
+        | ~else:
+            values(state, long_flags, short_flags, once_keys)
+    | fs :: Multi:
+        setup(fs.choices, state, long_flags, short_flags, once_keys, #false)
+    | fs :: OnceEach:
+        for values(state = state, long_flags = long_flags, short_flags = short_flags, once_keys = once_keys):
+          each c: fs.choices
+          setup(c, state, long_flags, short_flags, once_keys, #'self)
+    | fs :: OnceAny:
+        setup(fs.choices, state, long_flags, short_flags, once_keys, Symbol.gen())
+    | ~else:
+        values(state, long_flags, short_flags, once_keys)
+
+fun apply_flag(flag_str, first, flag, state, line :~ List,
+               once_keys :~ Map, once :~ Map, is_final,
+               ~who: exe_who):
+  match flag
+  | #false:
+      error(~exn: Exn.Fail.User,
+            ~who: exe_who,
+            "unrecognized flag " ++ flag_str,
+            & make_within(flag_str, first))
+  | f :: Flag:
+      let already = once.get(once_keys.get(f, #false), #false)
+      when already
+      | error(~exn: Exn.Fail.User,
+              ~who: exe_who,
+              if already == flag_str
+              | "the " ++ flag_str ++ " flag can only be used once"
+              | "the " ++ flag_str ++ " flag cannot be used after " ++ already,
+              & make_within(flag_str, first))
+      when line.length() < f.args.length() - (if f.repeat_last | 1 | 0)
+      | throw_wrong_args(~who: exe_who, f, line, flag_str, first)
+      let (state, line :~ List):
+        if f.repeat_last
+        | values(f.handler(state, & line), [])
+        | let n = f.args.length()
+          let state:
+            parameterize { current_flag_string: flag_str,
+                           current_containing_flag_string: first }:
+              f.handler(state, & line.take(n))
+          values(state, line.drop(n))
+      let once:
+        let key = once_keys.get(f, #false)
+        if key
+        | once ++ { key: flag_str }
+        | once
+      values(state, once, line, is_final || f is_a FinalFlag)
+
+fun format_args(args :~ Handler, prefix :~ String = "") :~ String:
+  if args.args == []
+  | ""
+  | prefix ++ "<" ++ String.join(args.args, "> <") ++ ">" ++ (if args.repeat_last | " ..." | "")
+
+fun throw_wrong_args(~who: exe_who, h :~ Handler, line :~ List, flag_str, first):
+  let (flag_desc, after_desc):
+    match flag_str
+    | s :: String: values(s ++ " ", " after " ++ s)
+    | ~else: values("", "")
+  let args_desc:
+    if h.args == []
+    | "no arguments"
+    | format_args(h)
+  error(~exn: Exn.Fail.User,
+        ~who: exe_who,
+        "expected " ++ flag_desc ++ args_desc ++ " on the command line,"
+          ++ " given " +& line.length() +& " argument" ++ (if line.length() == 1 | "" | "s")
+          ++ after_desc,
+        & (if line == []
+           | []
+           | [error.vals(~label: "given arguments", & line)]),
+        & make_within(flag_str, first))
+
+fun make_within(flag_str, first):
+  if flag_str == first
+  | []
+  | [error.text(~label: "within combined flag",
+                first)]
+
+fun split_end_text(flags :: List) :~ values(List, List):
+  match flags
+  | []: values([], [])
+  | [rest, ..., t :: EndText]:
+      let (flags, end_text) = split_end_text([rest, ...])
+      values(flags, end_text.add(t))
+  | ~else:
+      values(flags, [])
+
+fun print_help_and_exit(parser :: _Parser):
+  show_help(~flags: parser.flags,
+            ~args: parser.args)
+  system.exit(0)
+
+fun show_help(~program: exe_who :: String || Path = current_program(),
+              ~flags: flags :: List,
+              ~args: args :: Handler):
+  let (min_flags, max_flags, num_flags):
+    recur seek(flags :~ List = flags, just_once = #true):
+      for values(min_flags = 0, max_flags = 0, num_flags = 0) (flag: flags):
+        let (min_flag, max_flag, a_flag):
+          match flag
+          | f :: Flag: values(1, if just_once | 1 | #inf, f.flag_strs.length())
+          | fs :: Multi:
+              seek(fs.choices, #false)
+          | fs :: OnceEach:
+              let [flag, ...] = fs.choices
+              seek([OnceAny([flag]), ...], #true)
+          | fs :: OnceAny: seek(fs.choices, #true)
+          | _: values(0, 0, 0)
+        values(min_flags + min_flag,
+               max_flags + max_flag,
+               num_flags + a_flag)
+  let options_str:
+    match max_flags
+    | 0: ""
+    | 1: " [<option>]"
+    | ~else: " [<option> ...]"
+  let args_str:
+    format_args(args, " ")
+  println(@str{usage: @exe_who@options_str@args_str})
+  when min_flags > 0
+  | println("")
+    if max_flags == 1
+    | print("The <option>, if present, starts with ")
+    | print("Each <option> starts with ")
+    if num_flags == 1
+    | println("the flag listed below.")
+    | println("one of the flags listed below.")
+    println("")
+    let mode_and_flags :~ List:
+      recur flatten(flags = flags, mode = #'once_each):
+        match flags
+        | []: []
+        | [flag, rest, ...]:
+            let first :~ List:
+              match flag
+              | f :: Flag: [[mode, f]]
+              | fs :: Multi: flatten(fs.choices, #'multi)
+              | fs :: OnceEach: flatten(fs.choices, #'once_each)
+              | fs :: OnceAny:
+                  let prs = flatten(fs.choices, #'once_each)
+                  let (prs, _):
+                    recur adapt_mode(prs = prs, started = #false):
+                      match prs
+                      | []: values([], #false)
+                      | [[mode, f :: Flag], rest, ...]:
+                          let (prs, ended) = adapt_mode([rest, ...], #true)
+                          let mode:
+                            cond
+                            | started && ended: #'once_continue
+                            | started && !ended: #'once_end
+                            | !started && ended: #'once_start
+                            | ~else: #'once_each
+                          values([[mode, f]] ++ prs, #true)
+                      | [pr, rest, ...]:
+                          let (prs, ended) = adapt_mode([rest, ...], started)
+                          values([pr] ++ prs, ended)
+                  prs
+              | _: [[#'inherit, flag]]
+            first ++ flatten([rest, ...], mode)
+    for ([mode, flag]: mode_and_flags):
+      match flag
+      | f :: Flag:
+          match mode
+          | #'multi: print("* ")
+          | #'once_each: print("  ")
+          | #'once_start: print("/ ")
+          | #'once_continue: print("| ")
+          | #'once_end: (if f.help | print("| ") | print("\\ "))
+          for (flag_str: f.flag_strs,
+               i: 0..):
+            when i > 0
+            | print(", ")
+            print(flag_str)
+            print(format_args(f, " "))
+          println("")
+          when f.help:
+          | let help = f.help!!.split("\n")
+            for (h: help.drop_last(1)):
+              match mode
+              | #'multi || #'once_each: print("    ")
+              | ~else: print("|   ")
+              println(h)
+            match mode
+            | #'multi || #'once_each: print("    ")
+            | #'once_start || #'once_continue: print("|   ")
+            | #'once_end: print("\\   ")
+            println(help.last)
+      | t :: Text:
+          println(t.text)
+    let any_multi = (for any ([mode, flag]: mode_and_flags): mode == #'multi)
+    let any_once = (for any ([mode, flag]: mode_and_flags): mode == #'once_start)
+    when any_multi || any_once
+    | println("")
+    when any_multi
+    | println(" * " ++ (if any_once | "  " | "") ++ "Asterisks indicate options allowed multiple times.")
+    when any_once
+    | println("/|\\ Brackets indicate mutually exclusive options.")
+    fun find_single_flag(f :~ Flag):
+      for any (flag_str: f.flag_strs):
+        flag_str.length() == 2 && flag_str
+    let singles = mode_and_flags.filter(~keep: fun([mode, flag]):
+                                                 match flag
+                                                 | f :: Flag:
+                                                     find_single_flag(f)
+                                                 | ~else: #false)
+    when singles.length() > 1
+    | println("")
+      let [_, f1] = singles[singles.length() - 2]
+      let [_, f2] = singles[singles.length() - 1]
+      let flag_str1 :~ String = find_single_flag(f1)
+      let flag_str2 :~ String = find_single_flag(f2)
+      println(" Multiple single-letter flags can be combined after one `-`.")
+      println(@str{ For example, `@(flag_str1)@(flag_str2[1])@(format_args(f1, " "))@(format_args(f2, " "))`}
+                ++ @str{ is the same as `@(flag_str1)@(format_args(f1, " ")) @(flag_str2)@(format_args(f2, " "))`.})

--- a/rhombus-lib/rhombus/private/cmdline_flag.rhm
+++ b/rhombus-lib/rhombus/private/cmdline_flag.rhm
@@ -1,0 +1,9 @@
+#lang rhombus/static
+
+export:
+  ok_flag_string
+
+fun ok_flag_string(flag :~ String):
+  !((flag.length() < 2)
+      || (flag[0] != Char"-"  && flag[0] != Char"+")
+      || (flag.length() > 2 && (flag[0] != flag[1])))

--- a/rhombus-scribble/rhombus/scribble/tests/doc.scrbl
+++ b/rhombus-scribble/rhombus/scribble/tests/doc.scrbl
@@ -11,7 +11,8 @@
           println
           String
           ReadableString
-      rhombus/draw)
+      rhombus/draw
+      rhombus/cmdline)
 
 @title{Example}
 
@@ -102,5 +103,17 @@ Starting example:
 ){
 
  Draw description.
+
+}
+
+@section{Command Line}
+
+@docmodule(rhombus/cmdline)
+
+@doc(
+  annot.macro 'cmdline.String.to_lib_module_path'
+){
+
+  Annotation via namespace extension.
 
 }

--- a/rhombus-scribble/rhombus/scribble/tests/doc_expect.shrub
+++ b/rhombus-scribble/rhombus/scribble/tests/doc_expect.shrub
@@ -924,4 +924,43 @@ html:
                             span {class: "RktSym"}:
                               a {class: "RktValDef RktValLink"}: "winding"
           div {class: "SIntrapara"}: "Draw description."
+        h3:«»
+        p:
+          table:
+            tr:
+              td:
+                span {class: "hspace"}: nbsp
+                span {class: "stt"}: span {class: "RktSym"}: "import"
+                span {class: "stt"}: ": "
+                a {class: "RktModLink"}:
+                  span {class: "stt"}: "rhombus"
+                  span {class: "stt"}: "/"
+                  span {class: "stt"}: "cmdline"
+              td:
+                span {class: "RpackageSpec"}:
+                  span {class: "Smaller"}:
+                    nbsp
+                    "package:"
+                  " "
+                  a: span {class: "stt"}: "rhombus-lib"
+        p:
+          div {class: "SIntrapara"}:
+            table:
+              tr:
+                td:
+                  div {class: "RBackgroundLabel SIEHidden"}:
+                    div {class: "RBackgroundLabelInner"}: p: "annotation"
+              tr:
+                td:
+                  table:
+                    tr:
+                      td:
+                        p:
+                          a:«»
+                          span:
+                            span {class: "RktSym"}: "cmdline."
+                            span {class: "RktSym"}:
+                              a {class: "RktValDef RktValLink"}:
+                                "String.to_lib_module_path"
+          div {class: "SIntrapara"}: "Annotation via namespace extension."
     div: nbsp

--- a/rhombus/info.rkt
+++ b/rhombus/info.rkt
@@ -3,7 +3,8 @@
 (define collection 'multi)
 
 (define deps
-  '("rhombus-lib"
+  '("base"
+    "rhombus-lib"
     ;; The following dependencies serve a similar role to the
     ;; "rhombus-main-distribution" package, which is to ensure a
     ;; certain basic set of libraries when someone installs just

--- a/rhombus/rhombus/info.rkt
+++ b/rhombus/rhombus/info.rkt
@@ -1,0 +1,4 @@
+#lang info
+
+(define racket-launcher-libraries '("run.rhm"))
+(define racket-launcher-names '("rhombus"))

--- a/rhombus/rhombus/run.rhm
+++ b/rhombus/rhombus/run.rhm
@@ -1,0 +1,88 @@
+#lang rhombus/static
+import:
+  lib("racket/base.rkt") as rkt
+  rhombus/cmdline:
+    expose:
+      flag
+      multi
+      state
+
+fun file_to_mod_path(str :: String):
+  match str.split("!")
+  | [base, submod, ...]:
+      all(submod.length() != 0, ...)
+        && ModulePath.try('file($base) $(List.append(['!', Symbol.from_string(submod)], ...))')
+  | ~else: #false
+
+def args :~ Map:
+  cmdline.parse:
+    multi:
+      flag "-l" (mod_path :: cmdline.String.to_lib_module_path):
+        ~alias "--lib"
+        ~help (@str{Loads the collection-based module <mod_path>
+                    Use `!` at end to refer to a submodule.})
+        state[#'lib] := (state.get(#'lib, []) :~ List) ++ [mod_path]
+        state[#'eval] := #true
+      flag "-f" path:
+        ~alias "--file"
+        ~help (@str{Loads the module <path>.
+                    Use `!` at end to refer to a submodule.})
+        let mod_path = file_to_mod_path(path)
+        unless mod_path
+        | error(~who: to_string(cmdline.current_program()),
+                "expected a module path",
+                error.text(~label: "given", path),
+                error.text(~label: "for flag", cmdline.current_flag_string()))
+        state[#'lib] := (state.get(#'lib, []) :~ List) ++ [mod_path]
+        state[#'eval] := #true
+      flag "-t" (path :: PathString):
+        ~alias "--require"
+        ~help (@str{Loads the module <path> exactly, without treating
+                    `!` as a submodule separator.})
+        state[#'lib] := (state.get(#'lib, []) :~ List) ++ [ModulePath('file($path)')]
+        state[#'eval] := #true
+    flag "-i":
+      ~alias "--repl"
+      ~key: #'repl
+      ~help: "Run a read-eval-print-loop."
+    flag "-u":
+      ~alias "--no-make"
+      ~key: #'no_make
+      ~help: "Disable automatic compilation of modules."
+    flag "-v":
+      ~alias "--version"
+      ~help: "Show version."
+      state[#'version] := #true
+      state[#'eval] := #true
+    cmdline.args arg ...:
+      let args = [arg, ...]
+      if !state.get(#'eval, #false) && (args.length() != 0)
+      | let mp = file_to_mod_path(args.first)
+        unless mp
+        | error(~who: to_string(cmdline.current_program()),
+                "expected a module path as first argument",
+                error.text(~label: "given", args.first))
+        state[#'lib] := [mp]
+        state[#'args] := args.rest
+        state[#'eval] := #true
+      | state[#'args] := [arg, ...]
+
+cmdline.current_command_line(args[#'args])
+
+when args.get(#'version, #false) || !args.get(#'eval, #false)
+| println(@str{Welcome to Rhombus v@(system.version())})
+
+when args.get(#'eval, #false) && !args.get(#'no_make, #false)
+| let make:
+    rkt.#{dynamic-require}(ModulePath('lib("compiler/private/cm-minimal.rkt")').s_exp(),
+                           #'#{make-compilation-manager-load/use-compiled-handler})
+  rkt.#{current-load/use-compiled}(make())
+
+for (mp :~ ModulePath: args.get(#'lib, []) :~ List):
+  Evaluator.import(mp)
+
+when args.get(#'repl, #false) || !args.get(#'eval, #false)
+| when !args.get(#'eval, #false)
+  | Evaluator.import(ModulePath 'rhombus')
+  Evaluator.import(ModulePath 'lib("racket/interactive.rkt")')
+  rkt.#{read-eval-print-loop}()

--- a/rhombus/rhombus/scribblings/guide/running.scrbl
+++ b/rhombus/rhombus/scribblings/guide/running.scrbl
@@ -1,0 +1,91 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    meta_label:
+      rhombus/cmdline
+      rhombus/cmdline open
+      rhombus/cmdline!class open)
+
+@title(~style: #'toc, ~tag: "running"){Building and Running Rhombus Programs}
+
+@section(~tag: "cmdline"){Command Line Parsing}
+
+The @rhombusmodname(rhombus/cmdline) library provides a
+@rhombus(cmdline.parse) form to contain @rhombus(cmdline.flag) and
+@rhombus(cmdline.args) forms that together describe parsing for
+command-line arguments. A parse result is represented as a map
+that (by default) uses the flag names as symbol keys and
+@rhombus(#'args) as a key to hold arguments that appear after all flags.
+
+Here's an example for a program that supports @exec{--channel},
+@exec{--volume}, @exec{++louder}, and @exec{--quieter} flags:
+
+@rhombusblock(
+  import:
+    rhombus/cmdline open
+
+  def config:
+    parse:
+      flag "--channel" name
+      flag "--volume" (n :: String.to_int):
+        ~init: { #'volume: -20 }
+        ~alias: "-v"
+      multi:
+        flag "++louder":
+          state[#'volume] := state[#'volume] + 1
+        flag "--quieter":
+          state[#'volume] := state[#'volume] - 1
+
+  println(@str{Listen to @(config.get(#'channel, "unknown"))
+               at volume @(config[#'volume]).})
+)
+
+In the example, the @exec{--channel} flag gets a default implementation
+that adds an argument string to the result map. The @exec{--volume} flag
+also gets default handling, but adds an initial value for
+@rhombus(#'volume) in the map to give it a default value, and supports
+the shorthand @exec{-v} in place of @exec{--volume}; also, its argument
+is annotated with @rhombus(String.to_int, ~annot) to allow only integer
+arguments to be passed on the command line (i.e., strings that can be
+converted to integers). Each of @exec{--channel} and @exec{--volume} is
+allowed at most once, but @exec{++louder} and @exec{--quieter} are each
+allowed any number of times, and they have custom handling to adjust
+@rhombus(#'volume) instead of adding @rhombus(#'louder) and
+@rhombus(#'quieter) keys to the map. In this example,
+@rhombus(cmdline.args) is not used alongside @rhombus(cmdline.flag) and
+@rhombus(cmdline.multi), which means that the program does not accept
+additional arguments after flags.
+
+Since the example above uses @rhombus(cmdline.parse), then running the
+program will always parse command-line arguments. The
+@rhombus(cmdline.parser) (with an ``r'' at the end) form has the same
+syntax, but produces a @rhombus(Parser) object whose
+@rhombus(Parser.parse) method can be called to trigger parsing and get a
+result map.
+
+@examples(
+  ~hidden:
+    import:
+      rhombus/cmdline open
+  ~defn:
+    def config_getter:
+      parser:
+        flag "--channel" name
+        flag "--volume" (n :: String.to_int):
+          ~init: { #'volume: -20 }
+          ~alias: "-v"
+        multi:
+          flag "++louder":
+            state[#'volume] := state[#'volume] + 1
+          flag "--quieter":
+            state[#'volume] := state[#'volume] - 1
+  ~repl:
+    config_getter.parse(~line: ["--volume", "-17",
+                                "++louder",
+                                "++louder",
+                                "--channel", "The 90s"])
+    ~error:
+      config_getter.parse(~line: ["--volume", "oops"],
+                          ~program: "demo")
+    config_getter.print_help(~program: "demo")
+)

--- a/rhombus/rhombus/scribblings/reference/cmdline-class.scrbl
+++ b/rhombus/rhombus/scribblings/reference/cmdline-class.scrbl
@@ -1,0 +1,100 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open:
+      except: def
+    "nonterminal.rhm" open
+    meta_label:
+      rhombus/cmdline
+      rhombus/cmdline!class open)
+
+@title(~tag: "cmdline-class"){Command Line Parsing Classes}
+
+@docmodule(rhombus/cmdline!class)
+
+@doc(
+  class Parser():
+    constructor (
+      ~flags: flags :: List.of(Content),
+      ~add_builtin: add_builtin :: Any.to_boolean = #true,
+      ~args: args :: Handler,
+      ~init: init :: Map = {},
+      ~who: who :: maybe(error.Who) = #false
+    )
+  method (p :: Parser).parse(
+    ~program: program :: String || Path = cmdline.current_program(),
+    ~line: line :: List.of(String) = cmdline.current_command_line()
+  ) :: Map
+  method (p :: Parser).print_help(
+    ~program: program :: String || Path = cmdline.current_program()
+  ) :: Void
+  property (p :: Parser).flags :: List.of(Content)
+  property (p :: Parser).args :: Handler
+  property (p :: Parser).init :: Map
+){
+
+ Represents a parser as normally created by @rhombus(cmdline.parser).
+
+}
+
+@doc(
+  class Handler(init :: Map,
+                args :: List.of(String),
+                repeat_last :: Any.to_boolean,
+                handler :: (~any) -> Map):
+    nonfinal
+){
+
+ Represents a handler, either for a flag or for arguments after all
+ flags. A handler that represents a flag is more specifically an instance
+ of @rhombus(Flag).
+
+ The constructor for @rhombus(Handler) accepts the same arguments as the
+ default constructor, but checks that @rhombus(args) contains valid
+ flags and that @rhombus(handler) accepts the number of arguments implied
+ by @rhombus(args).
+
+}
+
+@doc(
+  class Flag(flag_strs :: List.of(String),
+             help :: maybe(String)):
+    nonfinal
+    extends Handler
+  class FinalFlag():
+    extends Flag
+  class Multi(choices :: List.of(Flag || Multi))
+  class OnceEach(choices :: List.of(Flag || OnceEach))
+  class OnceAny(choices :: List.of(Flag || OnceAny))
+  class Text():
+    nonfinal
+  class EndText():
+    extends Text
+  enum Content:
+    ~is_a Flag
+    ~is_a Multi
+    ~is_a OnceEach
+    ~is_a OnceAny
+    ~is_a Text
+){
+
+ Flags, flag sets, and help text that can be part of a command-line
+ parser constructed with @rhombus(cmdline.parser) or @rhombus(Parser).
+
+ The constructor for @rhombus(Flag) accepts the same arguments as the
+ default constructor, but checks that @rhombus(flag_strs) constaints
+ valid flags.
+
+}
+
+
+@doc(
+  fun make_builtin_flags(help :: Map -> Map) :~ List.of(Content)
+){
+
+ Returns a list of @rhombus(Content) corresponding to flags that are
+ normally added to a command-line parser by default, unless
+ @rhombus(~no_builtin) is used with @rhombus(cmdline.parser) or
+ @rhombus(~add_builtin) is supplied as @rhombus(#false) to
+ @rhombus(Parser).
+
+}

--- a/rhombus/rhombus/scribblings/reference/cmdline-help.scrbl
+++ b/rhombus/rhombus/scribblings/reference/cmdline-help.scrbl
@@ -1,0 +1,65 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open:
+      except: def
+    "nonterminal.rhm" open
+    meta_label:
+      rhombus/cmdline
+      rhombus/cmdline!class open)
+
+@title(~tag: "cmdline-help"){Command Line Parser Parameters and Annotations}
+
+@(~version_at_least "8.14.0.4")
+
+@doc(
+  Parameter.def cmdline.current_program
+    :: String || Path
+  Parameter.def cmdline.current_command_line
+    :: List.of(String)
+  Parameter.def cmdline.current_flag_string
+    :: maybe(String)
+  Parameter.def cmdline.current_containing_flag_string
+    :: maybe(String)
+){
+
+ Parameters used for command-line parsing.
+
+ The @rhombus(cmdline.current_program) and
+ @rhombus(cmdline.current_command_line) parameters provide defaults to
+ start parsing, but they are also set by @rhombus(Parser.parse) to match
+ supplied arguments in case they are different than the defaults.
+
+ The @rhombus(cmdline.current_flag_string) and
+ @rhombus(cmdline.current_containing_flag_string) parameters are set when
+ a flag handler is called to report the flag as written by the user. When
+ the value of @rhombus(cmdline.current_flag_string) is a short-form flag
+ like @rhombus("-h"), then
+ @rhombus(cmdline.current_containing_flag_string) may be set to a
+ combination flag like @rhombus("-vh") to report more precisely how it
+ was written by the user.
+
+}
+
+@doc(
+  annot.macro '(cmdline.String.to_lib_module_path)'
+){
+
+ A @tech(~doc: guide_doc){converter annotation} that recognizes strings
+ that are suitable for a @rhombus(lib, ~modpath) module-path form. Unlike
+ a string used directly with @rhombus(lib, ~modpath), the string is
+ allowed to contain @litchar{!} separating non-empty submodule names, and
+ the result @rhombus(ModulePath, ~annot) rotates the submodule
+ selections to outside the @rhombus(lib, ~modpath) part.
+
+ This annotation is particularly intended for use with
+ @rhombus(cmdline.flag) and @rhombus(cmdline.args).
+
+@examples(
+  ~hidden:
+    import rhombus/cmdline
+  ~repl:
+    def mp :: cmdline.String.to_lib_module_path = "rhombus/pict!private"
+    mp
+)
+
+}

--- a/rhombus/rhombus/scribblings/reference/cmdline-make.scrbl
+++ b/rhombus/rhombus/scribblings/reference/cmdline-make.scrbl
@@ -1,0 +1,318 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open:
+      except: def
+    "nonterminal.rhm" open
+    meta_label:
+      rhombus/cmdline
+      rhombus/cmdline!class open)
+
+@(def dots = @rhombus(..., ~bind))
+
+@title(~tag: "cmdline-make"){Command Line Parser Construction}
+
+@(~version_at_least "8.14.0.4")
+
+@doc(
+  expr.macro 'cmdline.parser:
+                $option
+                ...
+                $content_expr
+                ...'
+
+  expr.macro 'cmdline.parse:
+                $option
+                ...
+                $content_expr
+                ...'
+
+  grammar option:
+    ~init $expr
+    ~init: $body; ...
+    ~no_builtin
+){
+
+ The @rhombus(cmdline.parser) form produces a @rhombus(Parser), where
+ the @rhombus(content_expr) expressions produce flag and argument
+ handlers, especially using @rhombus(cmdline.flag) and
+ @rhombus(cmdline.args). The @rhombus(cmdline.parse) form has the same
+ syntax to create the same @rhombus(Parser), but it immediately calls the
+ @rhombus(Parser.parse) method on the resulting @rhombus(Parser) object.
+
+ The @rhombus(Parser.parse) method returns a @tech{map} representing the
+ final parse state. If @rhombus(~init) is provided as an @rhombus(option)
+ form, the result of the @rhombus(body) sequence produces a map to serve
+ as the parser's initial state.
+
+ Unless @rhombus(~no_builtin) is provided as an @rhombus(option), then
+ @litchar{--help}/@litchar{-h} and @litchar{--} flag support is
+ implicitly added to the @rhombus(content_expr)s.
+
+ The result of @rhombus(content_expr) must be either
+
+@itemlist(
+
+ @item{a @rhombus(Flag) object, usually as produced by
+  @rhombus(cmdline.flag);}
+
+ @item{a @rhombus(Multi), @rhombus(OnceEach), or @rhombus(OnceAny) set
+  of flags, usually as produced by @rhombus(cmdline.multi),
+  @rhombus(cmdline.once_any), or @rhombus(cmdline.once_each);}
+
+ @item{a @rhombus(Handler) object for arguments after all flags, usually
+  produced by @rhombus(cmdline.args);}
+
+ @item{a @rhombus(Text) object, usually produced by
+  @rhombus(cmdline.help); or}
+
+ @item{or a list of otherwise valid @rhombus(content_expr) results,
+  including nested lists.}
+
+)
+
+}
+
+@doc(
+  expr.macro 'cmdline.flag $flag_string $arg ... $maybe_ellipsis'
+
+  expr.macro 'cmdline.flag $flag_string $arg ... $maybe_ellipsis:
+                $option
+                ...
+                $body
+                ...'
+  grammar arg:
+    $identifier
+    ($identifier #,(@rhombus(::, ~bind)) $annot)
+    ($identifier #,(@rhombus(as, ~impo)) $identifier)
+    ($identifier #,(@rhombus(as, ~impo)) $identifier #,(@rhombus(::, ~bind)) $annot)
+
+  grammar option:
+    ~alias $flag_string ...
+    ~alias: $flag_string ...; ...
+    ~help $expr
+    ~help: $body; ...
+    ~key $expr
+    ~key: $body; ...
+    ~init $expr
+    ~init: $body; ...  
+    ~multi
+    ~final
+
+  grammar maybe_ellipsis:
+    #,(dots)
+    #,(epsilon)
+
+){
+
+ Creates a @rhombus(Flag) object to describe the handling of a
+ command-line flag for @rhombus(cmdline.parse) and related forms. The
+ only required component is a @rhombus(flag_string), which must be a
+ literal string starting with either @litchar{-} or @litchar{+}. The
+ @rhombus(flag_string) content must either continue with the same
+ @litchar{-} or @litchar{+} character followed by one or more characters
+ (for a long-form flag), or that has a single character after the leading
+ @litchar{-} or @litchar{+} (for a short-form flag).
+
+ Arguments to the flag are described by subsequent @rhombus(arg)s. If
+ @rhombus(maybe_ellipsis) after the @rhombus(arg)s is @dots, then the
+ last @rhombus(arg) can be repeated any number of times, and its binding
+ is a repetition. When an @rhombus(arg) has @rhombus(as, ~impo), then the
+ identifier before @rhombus(as, ~impo) is used as the argument name in
+ help text, while the identifier after @rhombus(as, ~impo) is bound to
+ the argument value for use in a @rhombus(body) sequence at the end of
+ the @rhombus(cmdline.flag) body. If @rhombus(annot) is included, it
+ should recognize allowed strings, and it might convert an allowed string
+ to a different representation like the @rhombus(String.to_int, ~annot)
+ annotation.
+
+ After @rhombus(option)s, an optional @rhombus(body) sequence can be
+ provided. If this @rhombus(body) sequence is non-empty, then it is
+ responsible for updating the parser's state via @rhombus(cmdline.state);
+ the result of the @rhombus(body) sequence is ignored. If the
+ @rhombus(body) sequence is empty, then a body is created automatically:
+
+@itemlist(
+
+ @item{The body will update the current parser state with a new
+  value for @rhombus(key, ~var), where @rhombus(key, ~var) is the value
+  produced by an @rhombus(expr) or @rhombus(body) sequence if a
+  @rhombus(~key) option if provided. If @rhombus(~key) is not provided,
+  then @rhombus(key, ~var) is a symbol derived from
+  the initial @rhombus(flag_string) by dropping the leading @litchar{-}
+  or @litchar{+} for a short-form flag or the leading two @litchar{-}s
+  or @litchar{+}s of a long-form flag.}
+
+ @item{If the flag's @rhombus(arg ... maybe_ellipsis) allows multiple
+  arguments, then received arguments are combined in a list to add to the
+  parser state @rhombus(key, ~var). If a single argument is allowed, the
+  received argument will be added directly to the parser state. If no
+  arguments are allowed, then @rhombus(#true) will be added to the parser
+  state.}
+
+ @item{If the @rhombus(~multi) option is specified or if the
+  @rhombus(cmdline.flag) form appears syntactically with a
+  @rhombus(cmdline.multi) form, then @rhombus(key, ~var) is updated in the
+  parser state by adding to the end of an existing list value in the map,
+  starting with the empty list if @rhombus(key, ~var) is not in the map.
+  Otherwise, any existing value of @rhombus(key, ~var) is replaced with a
+  new value.}
+
+)
+
+ The @rhombus(~alias) option can provide additional
+ @rhombus(flag_string)s that serve as an alias for the flag. Typically,
+ the main flag is short-form and an alias is long-form or vice versa.
+
+ The @rhombus(~help) option provides text to show with the flag in help
+ output. The string produced by the @rhombus(expr) or @rhombus(body)
+ sequence in @rhombus(~help) can contain newline characters, and space is
+ added to the start of lines as needed.
+
+ The @rhombus(~key) option specifies a key used for a default flag
+ body, if one is created. The key is not used if the
+ @rhombus(cmdline.flag) form has a non-empty @rhombus(body) sequence.
+
+ The @rhombus(~init) option provides an @rhombus(expr) or @rhombus(body)
+ sequence that must produce a @tech{map}. The keys and values of the map
+ are added to the parser's initial state map. Keys must be distinct
+ across all flag handlers for a parser.
+
+ The @rhombus(~multi) option causes a parser using the flag to allow
+ multiple instances of the flag in a command line. If @rhombus(~multi) is
+ not present, but the the @rhombus(cmdline.flag) form is syntactically
+ within a @rhombus(cmdline.multi) form, then @rhombus(~multi) mode is
+ automatically enabled. Otherwise, the flag can appear at most once
+ within a command line. A flag without @rhombus(~multi) can be used in
+ @rhombus(cmdline.multi) to allow it multiple times, but the default flag
+ body sequence (if generated) depends only on whether the
+ @rhombus(~multi) option is present or a syntactically enclosing
+ @rhombus(cmdline.multi) form is present.
+
+ The @rhombus(~final) option causes all arguments that appears after he
+ flag to be treated as non-flag arguments. This is the behavior of the
+ builtin @litchar{--} flag, and it is rarely needed for other flags.
+
+}
+
+
+@doc(
+  expr.macro 'cmdline.multi:
+                $content_expr
+                ...'
+  expr.macro 'cmdline.once_each:
+                $content_expr
+                ...'
+  expr.macro 'cmdline.once_any:
+                $content_expr
+                ...'
+){
+
+
+ Combines a set of flags and constrains the way that the flags can
+ appear in a command line. Flags grouped with @rhombus(cmdline.multi) can
+ be used any number of times. Flags grouped with @rhombus(cmdline.once_each) can
+ be used a single time each. Flags grouped with @rhombus(cmdline.once_any) can
+ be used a single time and only when no other flag in the same set is used.
+
+ The result of a @rhombus(content_expr) can be a @rhombus(Flag), as
+ usually produced by @rhombus(cmdline.flag), a set of flags that already
+ have the new set's property, or a list of otherwise acceptable
+ @rhombus(content_expr) results (including nested lists).
+
+}
+
+@doc(
+  ~nonterminal:
+    arg: cmdline.flag
+    maybe_ellipsis: cmdline.flag
+
+  expr.macro 'cmdline.args $arg ... $maybe_ellipsis'
+
+  expr.macro 'cmdline.args $arg ... $maybe_ellipsis:
+                $option
+                ...
+                $body
+                ...'
+  grammar option:
+    ~init $expr
+    ~init: $body; ...
+){
+
+ Like @rhombus(cmdline.flag), but creates a @rhombus(Handler) object to
+ describe the handling of arguments after command-line flags for
+ @rhombus(cmdline.parse) and related forms.
+
+ The set of @rhombus(option)s for @rhombus(cmdline.args) is more limited
+ than @rhombus(cmdline.flags), since it does not include flag string or
+ flag-specific help text.
+
+ The @rhombus(body) sequence implements argument parsing the same way as
+ for @rhombus(cmdline.flag). If the @rhombus(body) sequence is empty, the
+ default implementation always maps @rhombus(#'args) to a list of
+ arguments, even if that list is always empty or always contains only one
+ item.
+
+}
+
+@doc(
+  ~nonterminal:
+    key_expr: block expr
+    val_expr: block expr
+              
+  expr.macro 'cmdline.state'
+  expr.macro 'cmdline.state := $expr'
+  expr.macro 'cmdline.state[$key_expr] := $val_expr'
+){
+
+ For use with a @rhombus(cmdline.flag) or @rhombus(cmdline.args) body
+ sequence, accesses or updates the parser's state, which is represented
+ as a @tech{map}.
+
+ A parser state map is immutable, but @rhombus(cmdline.state) acts like
+ a mutable variable. The mutable variable backing @rhombus(cmdline.state)
+ is specific to one evaluation of a handler body, so mutations to
+ @rhombus(cmdline.state) after the handler body returns cannot affect the
+ result state of a parse.
+
+ The @rhombus(cmdline.state[key_expr] := val_expr) form is allowed even
+ though @rhombus(cmdline.state) refers to an immutable map. It is a
+ shorthand for an assignment to @rhombus(cmdline.state):
+
+@rhombusblock(
+  cmdline.state := cmdline.state ++ { key_expr: val_expr }
+)
+
+}
+
+@doc(
+  ~nonterminal:
+    arg: cmdline.flag
+    maybe_ellipsis: cmdline.flag
+
+  expr.macro 'cmdline.help:
+                $option
+                ...
+                $body
+                ...'
+
+  grammar option:
+    ~end
+){
+
+ Creates a @rhombus(Text) object to provide help text for
+ @rhombus(cmdline.parse) and related forms. The @rhombus(body) sequence
+ must produce a string. The string can contain newline characters to
+ create multiline help text.
+
+ Helps text can be intermingled with flags in a form like
+ @rhombus(cmdline.parse), and the text will be rendered in the same
+ relative order as the flag and help-text implementations.
+
+ If @rhombus(~end) is provided as an @rhombus(option) and the help text
+ is after all flags and other help text, then it is placed after the
+ builtin flags when those flags are not disabled (e.g., using
+ @rhombus(~no_builtin) in @rhombus(cmdline.parse)). Without
+ @rhombus(~end), trailing help text is rendered after all other text and
+ flags, but before the help text for builtin options.
+
+}

--- a/rhombus/rhombus/scribblings/reference/cmdline.scrbl
+++ b/rhombus/rhombus/scribblings/reference/cmdline.scrbl
@@ -1,0 +1,21 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open:
+      except: def
+    "nonterminal.rhm" open
+    meta_label:
+      rhombus/cmdline)
+
+@title(~style: #'toc, ~tag: "cmdline"){Command Line Parsing}
+
+@docmodule(rhombus/cmdline)
+
+The @rhombusmodname(rhombus/cmdline) library provides access to
+command-line arguments and forms for parsing those arguments in a
+consistent way. For an overview, see @secref(~doc: guide_doc, "cmdline").
+
+@local_table_of_contents()
+
+@include_section("cmdline-make.scrbl")
+@include_section("cmdline-help.scrbl")
+@include_section("cmdline-class.scrbl")

--- a/rhombus/rhombus/scribblings/reference/os.scrbl
+++ b/rhombus/rhombus/scribblings/reference/os.scrbl
@@ -11,3 +11,4 @@
 @include_section("filesystem.scrbl")
 @include_section("subprocess.scrbl")
 @include_section("system.scrbl")
+@include_section("cmdline.scrbl")

--- a/rhombus/rhombus/scribblings/rhombus.scrbl
+++ b/rhombus/rhombus/scribblings/rhombus.scrbl
@@ -19,3 +19,4 @@ see @docref(ref_doc).
 @include_section("guide/macro.scrbl")
 @include_section("guide/class-overview.scrbl")
 @include_section("guide/static-overview.scrbl")
+@include_section("guide/running.scrbl")

--- a/rhombus/rhombus/tests/cmdline.rhm
+++ b/rhombus/rhombus/tests/cmdline.rhm
@@ -1,0 +1,501 @@
+#lang rhombus/static
+import:
+  rhombus/cmdline open
+
+def invalid_argument = "invalid argument"
+
+macro 'with_line $args: $body':
+  'parameterize { current_command_line: $args }:
+     $body'
+
+check:
+  with_line []:
+    parse:«»
+  ~is {}
+
+check:
+  with_line ["--"]:
+    parse:«»
+  ~is {}
+
+check:
+  with_line []:
+    parse:
+      args
+  ~is { #'args: [] }
+
+check:
+  with_line ["ex", "why"]:
+    parse:
+      args x y
+  ~is { #'args: ["ex", "why"] }
+
+block:
+  let p:
+    parser:
+      args x y ...
+  check p.parse(~line: ["ex", "why"]) ~is { #'args: ["ex", "why"] }
+  check p.parse(~line: ["ex"]) ~is { #'args: ["ex"] }
+  check p.parse(~line: ["ex", "why", "more"]) ~is { #'args: ["ex", "why", "more"] }
+
+check:
+  with_line ["ex", "why"]:
+    parse:
+      args x y:
+        state := state ++ { #'x: x, #'y: y }
+  ~is { #'x: "ex", #'y: "why" }
+
+check:
+  with_line ["ex", "why"]:
+    parse:
+      args x y:
+        state[#'x] := x
+        state[#'y] := y
+  ~is { #'x: "ex", #'y: "why" }
+
+check:
+  with_line ["ex", "why"]:
+    parse:
+      args (x as x) (x as y):
+        state := state ++ { #'x: x, #'y: y }
+  ~is { #'x: "ex", #'y: "why" }
+
+check:
+  with_line ["ex", "why"]:
+    parse:
+      ~init { #'base: 7 }
+      args x y
+  ~is { #'args: ["ex", "why"], #'base: 7 }
+
+check:
+  with_line ["ex"]:
+    parse:
+      args x y
+  ~throws "expected <x> <y> on the command line"
+
+check:
+  with_line ["100.0"]:
+    parse:
+      args (n :: Int)
+  ~throws invalid_argument
+
+block:
+  let p:
+    parser:
+      args (n :: String.to_int)
+  check p.parse(~line: ["-n"]) ~throws "unrecognized flag -n"
+  check p.parse(~line: ["n"]) ~throws invalid_argument
+  check p.parse(~line: ["100"]) ~is { #'args: [100] }
+
+check:
+  with_line ["-n", "100"]:
+    parse:
+      flag "-n" (n as N :: String.to_int)
+  ~is { #'n: 100 }
+
+check:
+  with_line ["-n", "100"]:
+    parse:
+      flag "-n" (n as N :: String.to_int):
+        state := state ++ { #'EN: N }
+  ~is { #'EN: 100 }
+
+block:
+  let p:
+    parser:
+      flag "-n" (n :: String.to_int):
+        ~alias: "--number"
+  check p.parse(~line: ["--number", "100"]) ~is { #'n: 100 }
+  check p.parse(~line: ["-n", "100"]) ~is { #'n: 100 }
+
+block:
+  let p:
+    parser:
+      flag "--number" (n :: String.to_int):
+        ~alias: "-n"
+  check p.parse(~line: ["--number", "100"]) ~is { #'number: 100 }
+  check p.parse(~line: ["-n", "100"]) ~is { #'number: 100 }
+
+check:
+  with_line ["-n", "100.0"]:
+    parse:
+      flag "-n" (n :: String.to_int)
+  ~throws invalid_argument
+
+check:
+  with_line ["-n", "100", "-n", "200"]:
+    parse:
+      flag "-n" (n :: String.to_int)
+  ~throws "the -n flag can only be used once"
+
+check:
+  with_line ["-n", "100", "-n", "200"]:
+    parse:
+      flag "-n" (n :: String.to_int):
+        ~multi
+  ~is { #'n: [100, 200] }
+
+check:
+  with_line ["-n", "100", "-n", "200"]:
+    parse:
+      flag "-n" (n :: String.to_int):
+        ~multi
+  ~is { #'n: [100, 200] }
+
+check:
+  with_line []:
+    parse:
+      flag "-n" (n :: String.to_int):
+        ~multi
+  ~is { #'n: [] }
+
+check:
+  with_line ["-n", "100"]:
+    parse:
+      flag "-n" (n :: String.to_int):
+        ~multi
+  ~is { #'n: [100] }
+
+check:
+  with_line ["-n", "100", "-n", "200"]:
+    parse:
+      multi:
+        flag "-n" (n :: String.to_int)
+  ~is { #'n: [100, 200] }
+
+check:
+  with_line ["-n", "100", "-n", "200"]:
+    parse:
+      once_each:
+        flag "-n" (n :: String.to_int):
+          ~multi
+  ~throws "not a valid element"
+
+check:
+  with_line ["-m", "99", "-n", "100"]:
+    parse:
+      flag "-n" (n :: String.to_int)
+      flag "-m" (m :: String.to_int)
+  ~is { #'m: 99, #'n: 100 }
+
+check:
+  with_line ["-m", "99", "-n", "100"]:
+    parse:
+      [flag "-n" (n :: String.to_int),
+       flag "-m" (m :: String.to_int)]
+  ~is { #'m: 99, #'n: 100 }
+
+check:
+  with_line ["-m", "99", "-n", "100"]:
+    parse:
+      [[flag "-n" (n :: String.to_int)],
+       flag "-m" (m :: String.to_int)]
+  ~is { #'m: 99, #'n: 100 }
+
+check:
+  with_line ["-m", "99", "-n", "100"]:
+    parse:
+      once_each:
+        flag "-n" (n :: String.to_int)
+        flag "-m" (m :: String.to_int)
+  ~is { #'m: 99, #'n: 100 }
+
+check:
+  with_line ["-m", "99", "-n", "100"]:
+    parse:
+      once_any:
+        flag "-n" (n :: String.to_int)
+        flag "-m" (m :: String.to_int)
+  ~throws "the -n flag cannot be used after -m"
+
+check:
+  with_line ["-m", "99", "-n", "100", "-m", "98"]:
+    parse:
+      multi:
+        flag "-n" (n :: String.to_int)
+        flag "-m" (m :: String.to_int)
+  ~is { #'m: [99, 98], #'n: [100] }
+
+check:
+  with_line ["-mnm", "99", "100", "98"]:
+    parse:
+      multi:
+        flag "-n" (n :: String.to_int)
+        flag "-m" (m :: String.to_int)
+  ~is { #'m: [99, 98], #'n: [100] }
+
+check:
+  with_line ["-m", "99", "-n", "100"]:
+    parse:
+      once_any:
+        flag "-n" (n :: String.to_int)
+      once_any:
+        flag "-m" (m :: String.to_int)
+  ~is { #'m: 99, #'n: 100 }
+
+check:
+  with_line []:
+    parse:
+      flag "-n":
+        ~init: { #'n: #false }
+  ~is { #'n: #false }
+
+check:
+  with_line ["-n"]:
+    parse:
+      flag "-n":
+        ~init: { #'n: #false }
+  ~is { #'n: #true }
+
+
+check:
+  with_line ["-n"]:
+    parse:
+      flag "-n":
+        ~init: { #'n: #false }
+        state := state ++ { #'n: #'on }
+  ~is { #'n: #'on }
+
+block:
+  def p:
+    parser:
+      flag "-n"
+      args dest ...
+  check p.parse(~line: ["-n"]) ~is { #'n: #true, #'args: [] }
+  check p.parse(~line: ["-n", "m"]) ~is { #'n: #true, #'args: ["m"] }
+  check p.parse(~line: ["n", "o", "p"]) ~is { #'args: ["n", "o", "p"] }
+  check p.parse(~line: ["-n", "m", "o", "p"]) ~is { #'n: #true, #'args: ["m", "o", "p"] }
+  check p.parse(~line: ["n"]) ~is { #'args: ["n"] }
+  check p.parse(~line: ["--", "-n"]) ~is { #'args: ["-n"] }
+
+check:
+  let p:
+    parser:
+      ~no_builtin
+  p.print_help(~program: "demo")
+  ~prints "usage: demo\n"
+
+def one_option = "The <option>, if present, starts with the flag listed below."
+def many_option = "Each <option> starts with the flag listed below."
+def many_options = "Each <option> starts with one of the flags listed below."
+
+def mutually_exclusive = "/|\\ Brackets indicate mutually exclusive options."
+def can_combine = "Multiple single-letter flags can be combined after one `-`."
+
+check:
+  let p:
+    parser:
+      ~no_builtin
+      flag "-x"
+  p.print_help(~program: "demo")      
+  ~prints @str{usage: demo [<option>]
+
+               @one_option
+
+                 -x
+               @""}
+
+check:
+  let p:
+    parser:
+      flag "-x"
+  p.print_help(~program: "demo")      
+  ~prints @str{usage: demo [<option> ...]
+
+               @many_options
+
+                 -x
+                 --help, -h
+                   Show this information and exit, ignoring remaining arguments.
+                 --
+                   No argument after this flag is a flag.
+
+                @can_combine
+                For example, `-h-` is the same as `-h --`.
+               @""}
+
+check:
+  let p:
+    parser:
+      ~no_builtin
+      multi:
+        flag "-x"
+  p.print_help(~program: "demo")      
+  ~prints @str{usage: demo [<option> ...]
+
+               @many_option
+
+               * -x
+
+                * Asterisks indicate options allowed multiple times.
+               @""}
+
+check:
+  let p:
+    parser:
+      ~no_builtin
+      flag "-x":
+        ~help: "The X factor."
+      flag "-y":
+        ~alias "--yes"
+  p.print_help(~program: "demo")      
+  ~prints @str{usage: demo [<option> ...]
+
+               @many_options
+
+                 -x
+                   The X factor.
+                 -y, --yes
+
+                @can_combine
+                For example, `-xy` is the same as `-x -y`.
+               @""}
+
+check:
+  let p:
+    parser:
+      ~no_builtin
+      once_any:
+        flag "-x" degree:
+          ~help: "The X factor.\nIt needs two lines of description."
+        flag "-y":
+          ~alias "--yes"
+      args name rank
+  p.print_help(~program: "demo")      
+  ~prints @str{usage: demo [<option> ...] <name> <rank>
+
+               @many_options
+
+               / -x <degree>
+               |   The X factor.
+               |   It needs two lines of description.
+               \ -y, --yes
+
+               @mutually_exclusive
+
+                @can_combine
+                For example, `-xy <degree>` is the same as `-x <degree> -y`.
+               @""}
+
+check:
+  let p:
+    parser:
+      ~no_builtin      
+      once_any:
+        flag "-y" language:
+          ~alias "--yes"
+        flag "-x" degree:
+          ~help: "The X factor.\nIt needs two lines of description."
+      args name ...
+  p.print_help(~program: "demo")      
+  ~prints @str{usage: demo [<option> ...] <name> ...
+
+               @many_options
+
+               / -y <language>, --yes <language>
+               | -x <degree>
+               |   The X factor.
+               \   It needs two lines of description.
+
+               @mutually_exclusive
+
+                @can_combine
+                For example, `-yx <language> <degree>` is the same as `-y <language> -x <degree>`.
+               @""}
+
+check:
+  let p:
+    parser:
+      ~no_builtin
+      help: "Positive flags:\n"
+      flag "-y" language:
+        ~alias "--yes"
+      help: "\nNegative flags:\n"
+      flag "-x" degree:
+        ~help: "The X factor."
+      args name ...
+  p.print_help(~program: "demo")      
+  ~prints @str{usage: demo [<option> ...] <name> ...
+
+               @many_options
+
+               Positive flags:
+
+                 -y <language>, --yes <language>
+
+               Negative flags:
+
+                 -x <degree>
+                   The X factor.
+
+                @can_combine
+                For example, `-yx <language> <degree>` is the same as `-y <language> -x <degree>`.
+               @""}
+
+check:
+  let p:
+    parser:
+      help: "Positive flags:\n"
+      flag "-y" (language as lang):
+        ~alias "--yes"
+      help: "\nNegative flags:\n"
+      flag "-x" degree:
+        ~help: "The X factor."
+      help: "\nBuiltin flags:\n"
+      help:
+        ~end
+        "\nA final note."
+      args name ...
+  p.print_help(~program: "demo")      
+  ~prints @str{usage: demo [<option> ...] <name> ...
+
+               @many_options
+
+               Positive flags:
+
+                 -y <language>, --yes <language>
+
+               Negative flags:
+
+                 -x <degree>
+                   The X factor.
+
+               Builtin flags:
+
+                 --help, -h
+                   Show this information and exit, ignoring remaining arguments.
+                 --
+                   No argument after this flag is a flag.
+
+               A final note.
+
+                @can_combine
+                For example, `-h-` is the same as `-h --`.
+               @""}
+
+check:
+  ~eval
+  import rhombus/cmdline open
+  parse oops
+  ~throws "bad syntax"
+
+check:
+  parse:
+    "not a flag"
+  ~throws values("parse:",
+                 "not a valid element")
+
+check:
+  ~eval
+  import rhombus/cmdline open
+  parse:
+    flag "nope"
+  ~throws "invalid flag string"
+
+check:
+  ~eval
+  import rhombus/cmdline open
+  parse:
+    flag "--ok":
+      ~alias "nope"
+  ~throws "invalid flag string"


### PR DESCRIPTION
Includes improvements based on the [January 9 meeting](https://github.com/racket/rhombus/discussions/180#discussioncomment-11793351), but does not yet include support for subcommands (in the style of `raco` and `raco pkg`).