### PR TITLE
change `[]` on a `map` to return a `maybe` of a value

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/indexable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/indexable.rkt
@@ -207,7 +207,7 @@
     [(treelist? indexable) (treelist-ref indexable index)]
     [(list? indexable) (list-ref indexable index)]
     [(vector? indexable) (vector-ref indexable index)]
-    [(hash? indexable) (hash-ref indexable index)]
+    [(hash? indexable) (hash-ref indexable index #f)]
     [(set? indexable) (set-ref indexable index)]
     [(string? indexable) (string-ref indexable index)]
     [(bytes? indexable) (bytes-ref indexable index)]

--- a/rhombus-lib/rhombus/private/amalgam/map.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/map.rkt
@@ -24,6 +24,7 @@
          "function-arity-key.rkt"
          "sequence-constructor-key.rkt"
          "sequence-element-key.rkt"
+         "maybe-key.rkt"
          "values-key.rkt"
          "composite.rkt"
          (submod "list.rkt" for-compound-repetition)
@@ -137,7 +138,7 @@
   (provide build-map))
 
 (define-static-info-getter get-any-map-static-infos
-  (#%index-get Map.get)
+  (#%index-get Map.maybe_get)
   (#%sequence-constructor Map.to_sequence/optimize))
 
 (define-primitive-class ReadableMap readable-map hash
@@ -438,7 +439,7 @@
 
 (define-for-syntax map-annotation-make-static-info
   (lambda (static-infoss)
-    #`((#%index-result #,(cadr static-infoss))
+    #`((#%index-result ((#%maybe #,(cadr static-infoss))))
        (#%sequence-element ((#%values (#,(car static-infoss)
                                        #,(cadr static-infoss))))))))
 
@@ -484,7 +485,7 @@
   #f
   (make-map-later-chaperoner 'Map)
   (lambda (static-infoss)
-    #`((#%index-result #,(cadr static-infoss))))
+    #`((#%index-result ((#%maybe #,(cadr static-infoss))))))
   "converter annotation not supported for elements;\n checking needs a predicate annotation for the map content"
   #'()
   #:parse-of parse-annotation-of/chaperone)
@@ -603,7 +604,7 @@
   #f
   (make-map-later-chaperoner 'MutableMap)
   (lambda (static-infoss)
-    #`((#%index-result #,(cadr static-infoss))))
+    #`((#%index-result ((#%maybe #,(cadr static-infoss))))))
   #'mutable-map-build-convert #'()
   #:parse-of parse-annotation-of/chaperone)
 
@@ -898,6 +899,7 @@
                                        #'())
                                      #:static-infos (get-map-static-infos)
                                      #:index-result-info? #t
+                                     #:index-result-maybe? #t
                                      #:sequence-element-info? #t
                                      #:rest-accessor (and maybe-rest #`(lambda (v) #,rest-tmp))
                                      #:rest-to-repetition #'in-immutable-hash-pairs
@@ -1082,6 +1084,10 @@
   (case-lambda
     [(ht key) (hash-ref ht key)]
     [(ht key default) (hash-ref ht key default)]))
+
+(define Map.maybe_get
+  (case-lambda
+    [(ht key) (hash-ref ht key #f)]))
 
 (define (check-map who ht)
   (unless (immutable-hash? ht)

--- a/rhombus-lib/rhombus/private/amalgam/maybe.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/maybe.rhm
@@ -40,27 +40,30 @@ meta:
     | statinfos
 
 expr.macro '$e !!':
+  ~all_stx: stx
   ~op_stx: self
   let statinfos = statinfo_meta.gather(e)
   statinfo_meta.replace('match $(statinfo_meta.replace(e, '()'))
-                         | #false: definitely_failed(#' $(Symbol.from_string(self.to_source_string())))
-                         | v: v',
+                         | #false: definitely_failed(#' $(Symbol.from_string(self.to_source_string())),
+                                                     $(stx.srcloc()))
+                         | v: v'.relocate_group_span([stx]),
                         demaybe_statinfos(statinfos))
 
 expr.macro '$e !!. $tail ... ~nonempty':
   ~order: member_access
   ~op_stx: self
   let dot = syntax_meta.dynamic_name('.', ~as_static: syntax_meta.is_static(self))
-  values('($e !!)', '$dot $tail ...')
+  values('($e $('!!'.relocate(self)))', '$dot $tail ...')
 
 repet.macro '$e !!':
   ~op_stx: self
   ~all_stx: stx
   let '($_, $expr, $depth, $use_depth, $statinfos)' = repet_meta.unpack_list(e)
   repet_meta.pack_list('($stx,
-                         'check_definitely_at_depth(#' $(Symbol.from_string(self.to_source_string())),
-                                                    $expr,
-                                                    $depth - $use_depth)',
+                         check_definitely_at_depth(#' $(Symbol.from_string(self.to_source_string())),
+                                                   $expr,
+                                                   $(depth.unwrap() - use_depth.unwrap()),
+                                                   $(stx.srcloc())),
                          $depth,
                          $use_depth,
                          $(demaybe_statinfos(statinfos)))')
@@ -128,16 +131,19 @@ repet.macro '$e ?. $(id :: Identifier) $(args && '($_, ...)') ... ~once $tail ..
   | ~else:
       syntax_meta.error("repetition expansion does not have a single input", '$e $self $id $args ...')
 
-fun definitely_failed(who):
+fun definitely_failed(who, srcloc):
   throw Exn.Fail.Annot(who +& ": claimed not false, but actual value is false",
                        Continuation.Marks.current(),
-                       PairList[])
+                       if srcloc
+                       | PairList[srcloc]
+                       | PairList[])
 
-fun check_definitey_at_depth(who, v, depth):
+fun check_definitely_at_depth(who, v, depth, srcloc):
   if depth == 0
-  | v || definitely_failed(who)
+  | v || definitely_failed(who, srcloc)
   | for (e: (v :~ List)):
-      check_definitey_at_depth(who, e, depth-1)
+      check_definitely_at_depth(who, e, depth-1, srcloc)
+  v
 
 bind.macro '$b !!':
   ~op_stx: self

--- a/rhombus-lib/rhombus/private/amalgam/parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/parse.rkt
@@ -173,7 +173,8 @@
          (syntax-parse #'form
            [(~var e (:nestable-declaration d-prefix)) #'(begin . e.parsed)]
            [(~var e (:definition d-prefix)) #'(begin . e.parsed)]
-           [_ #`(#%expression (rhombus-expression form))]))
+           [_ (relocate (maybe-respan #'form)
+                        #`(#%expression (rhombus-expression form)))]))
        (define parsed
          (if (syntax-e #'decl-ok?)
              (syntax-parse #'form
@@ -192,7 +193,8 @@
       [(_) #'(begin)]
       [(_ (group (parsed #:rhombus/defn defn))) #'defn]
       [(_ (~var e (:definition #f))) #'(begin . e.parsed)]
-      [(_ form) #'(#%expression (rhombus-expression form))])))
+      [(_ form) (relocate (maybe-respan #'form)
+                          #'(#%expression (rhombus-expression form)))])))
 
 ;; For an expression context, interleaves expansion and enforestation:
 (define-syntax (rhombus-body stx)
@@ -253,7 +255,7 @@
            (rhombus-body-sequence . tail))]
       [(_ g . tail)
        #`(begin
-           (#%expression (rhombus-expression g))
+           #,(relocate (maybe-respan #'g) #`(#%expression (rhombus-expression g)))
            (rhombus-body-sequence . tail))])))
 
 ;; Wraps a `parsed` term that can be treated as a definition:

--- a/rhombus-lib/rhombus/private/amalgam/repetition.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/repetition.rkt
@@ -103,7 +103,7 @@
                           id))
     (make-repetition-info (list id)
                           null
-                          #`(rhombus-expression (group #,id))
+                          (relocate id #`(rhombus-expression (group #,id)))
                           #`((#%indirect-static-info #,id))
                           0))
 

--- a/rhombus-scribble-lib/rhombus/scribble/private/rhombus-spacer.rhm
+++ b/rhombus-scribble-lib/rhombus/scribble/private/rhombus-spacer.rhm
@@ -902,6 +902,10 @@ meta:
                   | ~else: 'Set'
         let braces = braces.property(#'annot, Pair(#'as_export, id), #true)
         '$(self || '') $(spacer.adjust_rest_sequence(braces, '$tail ...', context, esc))'
+    | '$(parens && '($g, ...)') $tail ...' when id:
+        let parens = '{$(spacer.adjust_group(g, context, esc)), ...}'.relocate(parens)
+        let parens = parens.property(#'annot, Pair(#'as_export, id), #true)
+        '$(self || '') $(spacer.adjust_rest_sequence(parens, '$tail ...', context, esc))'
     | ~else:
         spacer.adjust_rest_sequence(self, tail, context, esc)
 

--- a/rhombus/rhombus/run.rhm
+++ b/rhombus/rhombus/run.rhm
@@ -5,6 +5,7 @@ import:
     expose:
       flag
       multi
+      help
       state
 
 fun file_to_mod_path(str :: String):
@@ -14,75 +15,167 @@ fun file_to_mod_path(str :: String):
         && ModulePath.try('file($base) $(List.append(['!', Symbol.from_string(submod)], ...))')
   | ~else: #false
 
+// Keys for `args` map
+enum S:
+  evals
+  leftover_args
+  action
+  repl
+  init_lib
+  no_lib
+  no_make
+  version
+
 def args :~ Map:
   cmdline.parse:
+    ~init: { S.evals: [],
+             S.init_lib: ModulePath 'rhombus' }
+    help:
+      "Evaluation options:\n"
     multi:
-      flag "-l" (mod_path :: cmdline.String.to_lib_module_path):
-        ~alias "--lib"
-        ~help (@str{Loads the collection-based module <mod_path>
-                    Use `!` at end to refer to a submodule.})
-        state[#'lib] := (state.get(#'lib, []) :~ List) ++ [mod_path]
-        state[#'eval] := #true
       flag "-f" path:
         ~alias "--file"
-        ~help (@str{Loads the module <path>.
-                    Use `!` at end to refer to a submodule.})
+        ~help (@str{Loads the module <path>, where `!` can appear in <path>
+                    as a submodule separator.})
         let mod_path = file_to_mod_path(path)
         unless mod_path
         | error(~who: to_string(cmdline.current_program()),
                 "expected a module path",
                 error.text(~label: "given", path),
                 error.text(~label: "for flag", cmdline.current_flag_string()))
-        state[#'lib] := (state.get(#'lib, []) :~ List) ++ [mod_path]
-        state[#'eval] := #true
+        when state[S.evals] == []
+        | state[S.no_lib] := #true
+        state[S.evals] := (state[S.evals] :~ List) ++ [mod_path]
+        state[S.action] := #true
       flag "-t" (path :: PathString):
         ~alias "--require"
-        ~help (@str{Loads the module <path> exactly, without treating
-                    `!` as a submodule separator.})
-        state[#'lib] := (state.get(#'lib, []) :~ List) ++ [ModulePath('file($path)')]
-        state[#'eval] := #true
+        ~help (@str{Loads the module <path> exactly, without treating `!`
+                    as a submodule separator.})
+        when state[S.evals] == []
+        | state[S.no_lib] := #true
+        state[S.evals] := (state[S.evals] :~ List) ++ [ModulePath('file($path)')]
+        state[S.action] := #true
+      flag "-l" (mod_path :: cmdline.String.to_lib_module_path):
+        ~alias "--lib"
+        ~help (@str{Loads the collection-based module <mod_path>, where `!` can
+                    be used in <mod_path> as a submodule separator.})
+        when state[S.evals] == []
+        | state[S.no_lib] := #true
+        state[S.evals] := (state[S.evals] :~ List) ++ [mod_path]
+        state[S.action] := #true
+      flag "-e" expr:
+        ~alias "--eval"
+        ~help (@str{Evaluates <expr>.})
+        state[S.evals] := (state[S.evals] :~ List) ++ [expr]
+        state[S.action] := #true
+    help:
+      "\nInteraction options:\n"
     flag "-i":
       ~alias "--repl"
-      ~key: #'repl
       ~help: "Run a read-eval-print-loop."
-    flag "-u":
-      ~alias "--no-make"
-      ~key: #'no_make
-      ~help: "Disable automatic compilation of modules."
+      state[S.repl] := #true
+      state[S.action] := #true
+    flag "-n":
+      ~alias "--no-lib"
+      ~help: "Skip load of <init-lib>."
+      state[S.no_lib] := #true
+      state[S.action] := #true
     flag "-v":
       ~alias "--version"
       ~help: "Show version."
-      state[#'version] := #true
-      state[#'eval] := #true
+      state[S.version] := #true
+      state[S.action] := #true
+    help:
+      "\nConfiguration options:\n"
+    flag "-I" (mod_path :: cmdline.String.to_lib_module_path):
+      ~help: "Set <init-lib> to <mod-path> (i.e., sets the language)."
+      state[S.init_lib] := mod_path
+    flag "-u":
+      ~alias "--no-make"
+      ~key: S.no_make
+      ~help: "Disable compilation of modules to \"compiled\" directories."
+    help:
+      "\nMeta options:\n"
+    help:
+      ~after_notation
+      "\n"
+        ++ (@str{Defaults:
+
+                   If only configuration options are provided, `-i` is added.
+                   If only configuration options are before the first argument, `-f` is added.
+                   If `-f`, `-t`, `or `-l` appear before the first `-e`, `-n` is added.
+                   The <init-lib> library defaults to `rhombus`.
+
+                 Startup sequence:
+
+                   1. Set `cmdline.current_command_line` to remaining non-flag arguments.
+                   2. Load compilation manager unless `-u` or no `-i`/`-f`/`-t`/`-l`/`-e`.
+                   3. Import <init-lib> unless `-n`.
+                   4. Perform `-f`/`-t`/`-l`/`-e` in order.
+                   5. Run read-eval-print loop when `-i`.
+
+                   During steps 3 and 4: Before loading the first module, load its
+                   `configure_runtime` module, if any. For any module, load its
+                   `main` submodule, if any, after loading the module.
+
+               })
+
     cmdline.args arg ...:
       let args = [arg, ...]
-      if !state.get(#'eval, #false) && (args.length() != 0)
+      if !state[S.action] && (args.length() != 0)
       | let mp = file_to_mod_path(args.first)
         unless mp
         | error(~who: to_string(cmdline.current_program()),
                 "expected a module path as first argument",
                 error.text(~label: "given", args.first))
-        state[#'lib] := [mp]
-        state[#'args] := args.rest
-        state[#'eval] := #true
-      | state[#'args] := [arg, ...]
+        state[S.evals] := [mp]
+        state[S.leftover_args] := args.rest
+        state[S.action] := #true
+      | state[S.leftover_args] := [arg, ...]
 
-cmdline.current_command_line(args[#'args])
+cmdline.current_command_line(args[S.leftover_args])
 
-when args.get(#'version, #false) || !args.get(#'eval, #false)
+when args[S.version] || !args[S.action]
 | println(@str{Welcome to Rhombus v@(system.version())})
 
-when args.get(#'eval, #false) && !args.get(#'no_make, #false)
+when !args[S.no_make] && (args[S.repl] || !args[S.no_lib] || args[S.evals] != [])
 | let make:
     rkt.#{dynamic-require}(ModulePath('lib("compiler/private/cm-minimal.rkt")').s_exp(),
                            #'#{make-compilation-manager-load/use-compiled-handler})
   rkt.#{current-load/use-compiled}(make())
 
-for (mp :~ ModulePath: args.get(#'lib, []) :~ List):
+fun import_module(mp :~ ModulePath, can_configure):
+  fun try_load_submodule(mp :~ ModulePath, submod):
+    let rt_mp = mp.add(ModulePath('self ! $submod'))
+    when Evaluator.module_is_declared(rt_mp, ~load: #true)
+    | Evaluator.instantiate(rt_mp)
+  when can_configure
+  | try_load_submodule(mp, '#{configure-runtime}')
   Evaluator.import(mp)
+  try_load_submodule(mp, 'main')
 
-when args.get(#'repl, #false) || !args.get(#'eval, #false)
-| when !args.get(#'eval, #false)
-  | Evaluator.import(ModulePath 'rhombus')
-  Evaluator.import(ModulePath 'lib("racket/interactive.rkt")')
+def can_configure:
+  if args[S.no_lib]
+  | #true
+  | import_module(args[S.init_lib], #true)
+    #false
+
+block:
+  for values(can_configure = can_configure) (e: args[S.evals] :~ List):
+    match e
+    | mp :: ModulePath:
+        import_module(mp, can_configure)
+        #false
+    | str :: String:
+        let shrubbery_read = Evaluator.instantiate(ModulePath 'rhombus/shrubbery',
+                                                   #'read)
+        let v = shrubbery_read(Port.Input.open_string(str),
+                               ~mode: #'interactive)
+        call_with_values(fun (): eval(v, ~as_interaction: #true),
+                         println)
+        can_configure
+  #void
+
+when args[S.repl] || !args[S.action]
+| Evaluator.import(ModulePath 'lib("racket/interactive.rkt")')
   rkt.#{read-eval-print-loop}()

--- a/rhombus/rhombus/scribblings/guide/map.scrbl
+++ b/rhombus/rhombus/scribblings/guide/map.scrbl
@@ -27,8 +27,21 @@ it accepts keys paired with values in two-item lists to create a map:
     )
   ~repl:
     neighborhood["alice"]
+)
+
+When a map does not have a key requested via @brackets, then the result
+is @rhombus(#false). Use the @rhombus(Map.get) methods to have an
+exception thrown, instead, or use @rhombus(!!) to check for a
+@rhombus(#false) result.
+
+@examples(
+  ~eval: map_eval
+  ~repl:
+    neighborhood["clara"]
     ~error:
-      neighborhood["clara"]
+      neighborhood.get("clara")
+    ~error:
+      neighborhood["clara"]!!
 )
 
 Curly braces @braces can be used as a shorthand
@@ -95,7 +108,7 @@ for keys and one for values:
   ~eval: map_eval
   ~defn:
     fun locale(who, neighborhood :~ Map.of(String, Posn)):
-      let p = neighborhood[who]
+      let p = neighborhood[who]!!
       p.x +& ", " +& p.y
   ~repl:
     locale("alice", neighborhood)

--- a/rhombus/rhombus/scribblings/reference/map.scrbl
+++ b/rhombus/rhombus/scribblings/reference/map.scrbl
@@ -19,7 +19,9 @@ use of curly braces with no preceding expression is parsed as an
 implicit use of the @rhombus(#%braces) form.
 
 A map is @tech{indexable} using @brackets after a map expression with an
-expression for the key within @brackets. Mutable maps can be
+expression for the key within @brackets, where @rhombus(#false) is returned
+when the key is not mapped; use @rhombus(!!) or use @rhombus(Map.get), instead,
+to have an exception thrown for an unmapped key. Mutable maps can be
 updated with a combination of @brackets and @tech{assignment operators}
 such as @rhombus(:=) (but use @rhombus(++) to functionally update an
 immutable map). These uses of square brackets are implemented by
@@ -76,6 +78,12 @@ in an unspecified order.
 
  Static information associated by @rhombus(Map, ~annot), etc., makes an
  expression acceptable as a sequence to @rhombus(for) in static mode.
+ Static information from @rhombus(Map.of(key_annot, val_annot), ~annot), etc.,
+ propagates the static information of @rhombus(maybe(val_annot), ~annot) for the
+ result of an indexing operation (such as via @brackets) and static
+ information of @rhombus(key_annot) and @rhombus(val_annot) for
+ iteration operations (such as @rhombus(each, ~for_clause) in
+ @rhombus(for)).
 
 }
 
@@ -495,9 +503,12 @@ in an unspecified order.
     :: Any
 ){
 
- Equivalent @rhombus(mp[key]) (with the default implicit
- @rhombus(#%index) form) when @rhombus(default) is not provided,
- otherwise @rhombus(default) is used when @rhombus(mp) does
+ Returns the same value as @rhombus(mp[key]) (with the default implicit
+ @rhombus(#%index) form) when @rhombus(key) is mapped or when
+ @rhombus(default) is @rhombus(#false). If @rhombus(key) is not mapped
+ and @rhombus(default) is not provided, an exception is thrown.
+
+ More generally, @rhombus(default) is used when @rhombus(mp) does
  not contain a mapping for @rhombus(key). In that case, if
  @rhombus(default) is a function, then the function is called with zero
  arguments to get a result, otherwise @rhombus(default) is returned as

--- a/rhombus/rhombus/tests/equality-map-set.rhm
+++ b/rhombus/rhombus/tests/equality-map-set.rhm
@@ -61,7 +61,7 @@ check:
   ~is 3
 
 check:
-  {mcons(1, 2): 3}[mcons(1, 2)]
+  {mcons(1, 2): 3}.get(mcons(1, 2))
   ~throws "Map.get: no value found for key"
 
 block:
@@ -169,7 +169,7 @@ def local_map = Map{#'alice: Posn(4, 5),
                     #'bob: Posn(7, 9)}
 
 fun locale(who, neighborhood :: Map.of(Symbol, Posn)):
-  def p = neighborhood[who]
+  def p = neighborhood[who]!!
   p.x +& ", " +& p.y
 
 check:

--- a/rhombus/rhombus/tests/map.rhm
+++ b/rhombus/rhombus/tests/map.rhm
@@ -950,7 +950,7 @@ block:
 check:
   use_static
   def m :: MutableMap.later_of(Int, String) = MutableMap{100: "1"}
-  m[100] ++ "!"
+  m[100]!! ++ "!"
   ~is "1!"
 
 block:

--- a/rhombus/rhombus/tests/maybe.rhm
+++ b/rhombus/rhombus/tests/maybe.rhm
@@ -58,3 +58,5 @@ block:
   def [x :: maybe(String), ...] = [#false, "abc", #false]
   check: [x?.length(), ...]
          ~is [#false, 3, #false]
+  check: [(x || 0)!!, ...]
+         ~is [0, "abc", 0]

--- a/rhombus/rhombus/tests/ref.rhm
+++ b/rhombus/rhombus/tests/ref.rhm
@@ -123,7 +123,7 @@ def local_map = Map{#'alice: Posn(4, 5),
                     #'bob: Posn(7, 9)}
 
 fun locale(who, neighborhood :: Map.of(Symbol, Posn)):
-  def p = neighborhood[who]
+  def p = neighborhood[who]!!
   p.x +& ", " +& p.y
 
 check:

--- a/rhombus/rhombus/tests/syntax-object.rhm
+++ b/rhombus/rhombus/tests/syntax-object.rhm
@@ -84,7 +84,7 @@ block:
     equal_name('a.b.(+)', 'a.b.#{+}') ~is #false
     Map.by(equal_name){ 'x': 1, 'X': 2 }['x'] ~is 1
     Map.by(equal_name){ 'x': 1, 'X': 2 }['X'] ~is 2
-    Map.by(equal_name){ 'x': 1, 'X': 2 }['y'] ~throws "no value found for key"
+    Map.by(equal_name){ 'x': 1, 'X': 2 }['y'] ~is #false
     Map.by(equal_name){ 'x': 1, '+': 2 }['+'] ~is 2
     Map.by(equal_name){ 'a.x': 1, 'a.(+)': 2 }['a.x'] ~is 1
     Map.by(equal_name){ 'a.x': 1, 'a.(+)': 2 }['a.(+)'] ~is 2


### PR DESCRIPTION
Until very recently, it seemed clear to me that `map[key]` should throw an exception if `key` is not mapped to a value within `map`. When writing Rhombus programs, though, I have wanted `#false` for unmapped keys about half of the time that I write `map[key]`. I can always write `map.get(key, #false)`, but that departs from the `[]` syntax that's intended for map lookups (to avoid having everything look like a function/method call).

After trying out different directions and defaults (listed below), it seems like my Rhombus programs are nicest when `map[key]` returns `#false` for an unmapped key, after all.

After the commit here:

 * `map[key]` returns `#false` for unmapped keys. If `map` has annotation `Map(Key, Val)`, then `map[key]` has annotation `maybe(Val)`.

 * `map[key]!!` is a way of saying that `key` needs to be mapped (but also that it needs to be mapped to a non-`#false` value). This is using the existing `!!` operation, so `map[key]!!` has annotation `Val` when `map` has `Map(Key, Val)`.

 * `map.get(key)` throws an exception if `key` is not mapped (and this is not a change). Nothing about the annotation of `map` is propagated in `map.get(val)`, however, since method result annotations are not parameteric (at least not currently).

 * `map.get(key, default_val)` returns `default_val` when `key` is not mapped (and this is not a change).

A post-hoc rationalization for why this works out:

 * The new `map[key]` is exactly what I want about half the time.

 * Most of the time that I want an error, `map[key]!!` catches errors early, it's easy to write, and it's reasonably clear to read.

 * Much of the time that I write `map[key]` and want an error for an unmapped key, I'm in a static-mode context where I get a type-like reminder to use `!!`.

 * I can still write `map.get(key)` to opt into checking, but the cases where that's needed are rarer than places where I want the new `map[key]` behavior.

Some other things I tried:

 * Using a veneer to change the static resolution of `map[key]`. This worked ok for bindings that I control completely, but it was awkward to combine with `cmdline.state`.

 * Adding a new operator like `?` to change from an exception-throwing `map[key]` to a `#false`-returning `map?[key]`. The drawback here is using up another operator and introducing a new concept, while the other direction of writing `map[key]!!` uses an existing `!!` operator.

 * Adding a property like `maybe` so that `map.maybe[key]` corresponds to `map.get(key, #false)`. This sort of works, but static-information propagation is fragile without method result annotations that are parameteric in argument annotations, and I'm doubtful of that direction for the annotation layer.

It's certainly possible, of course, that there's a better solution that I missed!

A reminder of what some other languages do:

 * JavaScript: Returns `undefined` for `map[key]` when `key` is not mapped. This is particularly a problem in JavaScript, because `map.field` corresponds to `map[key]` (where `key` is the string form of `field`). Of course, `map.field` in Rhombus remains an error if `field` does not exist. JavaScript also has a `Map` class; if `map` is a `Map` then `map.get(key)` produces `undefined` when `key` is not in `map`.

 * Lua: Like JavaScript.

 * Python: Errors for `map[key]` when `key` is unmapped. The `get` method for maps, meanwhile, returns `None` for unmapped keys by default and accepts an optional value to return insteda of `None`.

 * Groovy: Returns false for `map[key]` when `key` is unmapped. That convention is meant to be combined with `?:` (which is `||` in Rhombus) and `?.` (which Rhombus inherits as `?.` by way of Kotlin and Rust).

 * Kotlin: Returns `null` for `map[key]` when `key` is unmapped, reflected in the type system by a nullable result type. In addition to `?:` and `?.`, Kotlin has `!!` (which Rhombus inherits) to work with nullable types. A `map.get(key)` method call is like `map[key]`, while `map.get_value(key)` throws an exception if `key` is not mapped.

 * Java: Returns `null` for `map.get(key)` when `key` is not mapped, and does not support `[]` notation for maps. There seems to be no method that reports an error, instead; when a key is not mapped, but `map.getOrDefault(key, default_val)` can replace the `null` result compated to `map.get(key)`.

 * Rust: The `get` method of `HashMap` returns an `OptionOf`, the `index` method errors when a key is not found, and `[]` notation uses `index`.

So, the commit proposed here makes Rhombus less Python/Rust-like and more Kotlin/Groovy-like.
