### PR TITLE
add `in`, `contains`, and `MembershipTestable`

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -570,22 +570,22 @@ check_later()
 // for
 
 fun enumerate(l :: List):
-  for (v: l,
-       i: 0..):
+  for (v in l,
+       i in 0..):
     println(i +& ". " +& v)
 
 enumerate(["a", "b", "c"])
 
 fun grid(m, n):
   for List:
-    each i: 0..m
-    each j: 0..n
+    each i in 0..m
+    each j in 0..n
     [i, j]
 
 grid(2, 3)
 
 fun loop_sum(l :: List):
-  for values(sum = 0) (i: l):
+  for values(sum = 0) (i in l):
     sum+i
 
 loop_sum([2, 3, 4])

--- a/demo.rhm
+++ b/demo.rhm
@@ -220,6 +220,10 @@ def yep_nums :: List.of(Int) = nums
 // `[]` on a list accesses by a 0-based index
 nums[1]
 
+// `in` searches a list
+3 in nums
+"hi" in ["hi", "bye"]
+
 block:
   // `use_dynamic` because `also_nums` is not declared to be a list
   use_dynamic
@@ -235,6 +239,7 @@ def yep_nums_a :: Array.now_of(Int): nums_a
 nums_a[1]
 nums_a[2] := 30
 nums_a[2]
+30 in nums_a
 
 // `later_of` doesn't check immediately, but checks on read/write
 def really_nums_a :: Array.later_of(Int): nums_a
@@ -253,6 +258,9 @@ map
 
 // `[]` on a map find the value for a key
 map[17]
+
+// `in` checks for a key in a map
+17 in map
 
 // `Map` is also bound as a constructor function, in which case
 // it expects 2-argument lists for the keys and values
@@ -280,8 +288,8 @@ mut_map[2]
 // using `{}` without `:` creates a set instead of a map
 def a_set = {1, 3, 5, 7, 9}
 
-// `[]` on a set checks whether something is in a set
-if a_set[1] && !a_set[2]
+// `in` on a set checks whether something is in a set
+if 1 in a_set && 2 !in a_set
 | "ok"
 | error("no way!")
 

--- a/design/treelist/bm.rhm
+++ b/design/treelist/bm.rhm
@@ -17,117 +17,117 @@ macro 'bm $who: $body':
      #void' 
 
 bm "+ Pair.cons":
-  for values(r = #false) (i: 0..M):
-    for values(l = []) (i: 0..N):
+  for values(r = #false) (i in 0..M):
+    for values(l = []) (i in 0..N):
       Pair.cons(i, l)
 
 bm "+ PairList.for":
-  for values(r = #false) (i: 0..M):
-    for PairList (i: 0..N):
+  for values(r = #false) (i in 0..M):
+    for PairList (i in 0..N):
       i
 
 bm "+ PairList.cons":
-  for values(r = #false) (i: 0..M):
-    for values(l = PairList[]) (i: 0..N):
+  for values(r = #false) (i in 0..M):
+    for values(l = PairList[]) (i in 0..N):
       PairList.cons(i, l)
 
 bm "+ List.for":
-  for values(r = #false) (i: 0..M):
-    for List (i: 0..N):
+  for values(r = #false) (i in 0..M):
+    for List (i in 0..N):
       i
 
 bm "+ List.add":
-  for values(r = #false) (i: 0..M):
-    for values(l = []) (i: 0..N):
+  for values(r = #false) (i in 0..M):
+    for values(l = []) (i in 0..N):
       List.add(l, i)
 
 bm "+ List.cons":
-  for values(r = #false) (i: 0..M):
-    for values(l = []) (i: 0..N):
+  for values(r = #false) (i in 0..M):
+    for values(l = []) (i in 0..N):
       List.cons(i, l)
 
 when show_TreeList
 | bm "+ TreeList.add":
-    for values(r = #false) (i: 0..M):
-      for values(l = TreeList.empty) (i: 0..N):
+    for values(r = #false) (i in 0..M):
+      for values(l = TreeList.empty) (i in 0..N):
         TreeList.add(l, i)
 
 when show_TreeList
 | bm "+ TreeList.cons":
-    for values(r = #false) (i: 0..M):
-      for values(l = TreeList.empty) (i: 0..N):
+    for values(r = #false) (i in 0..M):
+      for values(l = TreeList.empty) (i in 0..N):
         TreeList.cons(l, i)
 
 bm "+ Set.add":
-  for values(r = #false) (i: 0..M):
-    for values(l = Set.empty) (i: 0..N):
+  for values(r = #false) (i in 0..M):
+    for values(l = Set.empty) (i in 0..N):
       l ++ { i }
 
 bm "- Pair.rest":
   let init:
-    for values(l = []) (i: 0..N):
+    for values(l = []) (i in 0..N):
       Pair.cons(i, l)
-  for values(r = #false) (i: 0..M):
-    for values(l = init) (i: 0..N):
+  for values(r = #false) (i in 0..M):
+    for values(l = init) (i in 0..N):
       Pair.rest(l)
 
 bm "- PairList.rest":
   let init:
-    for PairList (i: 0..N): i
-  for values(r = #false) (i: 0..M):
-    for values(l = init) (i: 0..N):
+    for PairList (i in 0..N): i
+  for values(r = #false) (i in 0..M):
+    for values(l = init) (i in 0..N):
       PairList.rest(l)
 
 bm "- List.rest":
   let init:
-    for List (i: 0..N): i
-  for values(r = #false) (i: 0..M):
-    for values(l = init) (i: 0..N):
+    for List (i in 0..N): i
+  for values(r = #false) (i in 0..M):
+    for values(l = init) (i in 0..N):
       List.rest(l)
 
 when show_TreeList
 | bm "- TreeList.drop":
     let init:
-      for values(l = TreeList.empty) (i: 0..N):
+      for values(l = TreeList.empty) (i in 0..N):
         TreeList.cons(l, i)
-    for values(r = #false) (i: 0..M):
-      for values(l = init) (i: 0..N):
+    for values(r = #false) (i in 0..M):
+      for values(l = init) (i in 0..N):
         TreeList.drop(l, 1)
 
 bm "- Set.remove":
   let init:
-    for values(l = Set.empty) (i: 0..N):
+    for values(l = Set.empty) (i in 0..N):
       l ++ { i }
-  for values(r = #false) (i: 0..M):
-    for values(l = init) (i: 0..N):
+  for values(r = #false) (i in 0..M):
+    for values(l = init) (i in 0..N):
       Set.remove(l, i)
 
 bm "^ PairList.iter":
   let init :~ PairList:
-    for PairList (i: 0..N): i
-  for values(r = #false) (i: 0..M):
-    for values(r = r) (e: init):
+    for PairList (i in 0..N): i
+  for values(r = #false) (i in 0..M):
+    for values(r = r) (e in init):
       e
 
 bm "^ List.iter":
   let init :~ List:
-    for List (i: 0..N): i
-  for values(r = #false) (i: 0..M):
-    for values(r = r) (e: init):
+    for List (i in 0..N): i
+  for values(r = #false) (i in 0..M):
+    for values(r = r) (e in init):
       e
 
 when show_TreeList
 | bm "^ TreeList.iter":
     let init :~ TreeList:
-      for values(l = TreeList.empty) (i: 0..N):
+      for values(l = TreeList.empty) (i in 0..N):
         TreeList.cons(l, i)
-    for values(r = #false) (i: 0..M):
-      for values(r = r) (e: init):
+    for values(r = #false) (i in 0..M):
+      for values(r = r) (e in init):
         e
 
 bm "^ Set.iter":
   let init :~ Set:
-    for Set (i: 0..N): i
-  for values(r = #false) (i: 0..M):
-    for values(r = r) (e: init):
+    for Set (i in 0..N): i
+  for values(r = #false) (i in 0..M):
+    for values(r = r) (e in init):
       e

--- a/design/treelist/equal.rhm
+++ b/design/treelist/equal.rhm
@@ -5,42 +5,42 @@ import:
 
 def N = 2000
 def M = 10000
-def lst = (for PairList (i: 0..N): i)
-def alt_lst = (for PairList (i: 0..N): i)
+def lst = (for PairList (i in 0..N): i)
+def alt_lst = (for PairList (i in 0..N): i)
 
-def tl = for List (e: lst): e
+def tl = for List (e in lst): e
 def alt = tl.add("x").take_left(N)
 def alt2 = tl.insert(N div 2, "x").delete(N div 2)
-def fresh = for List (e: lst): e
+def fresh = for List (e in lst): e
 
 measure.time:
   ~gc
-  for values(v = #false) (i: 0..M):
+  for values(v = #false) (i in 0..M):
     tl == tl
 
 measure.time:
   ~gc
-  for values(v = #false) (i: 0..M):
+  for values(v = #false) (i in 0..M):
     tl == alt
 
 measure.time:
   ~gc
-  for values(v = #false) (i: 0..M):
+  for values(v = #false) (i in 0..M):
     tl == alt2
 
 measure.time:
   ~gc
-  for values(v = #false) (i: 0..M):
+  for values(v = #false) (i in 0..M):
     tl == fresh
 
 measure.time:
   ~gc
-  for values(v = #false) (i: 0..M):
+  for values(v = #false) (i in 0..M):
     lst == alt_lst
 
 measure.time:
   ~gc
-  for (i: 0..N):
+  for (i in 0..N):
     ((tl == tl.insert(i, "x").delete(i))
        && (tl == tl.remove(i).insert(i, tl[i])))
      || error(#'equal, "bad result at " +& i)

--- a/design/treelist/random.rhm
+++ b/design/treelist/random.rhm
@@ -25,10 +25,10 @@ fun rand_test(plst, tl, lst, n, history):
     | unless lst == tl.to_list()
       | error(#'rand_test, "fail " +& lst +& " vs. " +& tl +& " using " +& PairList.reverse(history))
     when do_pairlist && do_list
-    | unless plst == (for PairList (e: lst): e)
+    | unless plst == (for PairList (e in lst): e)
       | error(#'rand_test, "fail " +& plst +& " vs. " +& lst +& " using " +& PairList.reverse(history))
     when do_list
-    | let lst2 = (for List (e: (for PairList (e: lst): e)): e)
+    | let lst2 = (for List (e in (for PairList (e in lst): e)): e)
       unless (lst2 == lst) && (lst == lst2) && Equatable.hash(lst) == Equatable.hash(lst2)
       | error(#'rand_test, "equal fails " +& lst)
   cond
@@ -51,5 +51,5 @@ fun rand_test(plst, tl, lst, n, history):
                   List.cons(pos, history))
 
 measure.time:
-  for (i: 0..1000):
+  for (i in 0..1000):
     rand_test(PairList[], TreeList[], [], 0, [])

--- a/design/treelist/treelist.rhm
+++ b/design/treelist/treelist.rhm
@@ -29,10 +29,10 @@ macro 'radix($index, $height)':
   '((($index) bits.(>>) (BITS * ($height))) bits.and MASK)'
 
 module test:
-  for (i: 0 .. MAX_WIDTH):
+  for (i in 0 .. MAX_WIDTH):
     check: radix(i, 0) ~is i
     check: radix(i, 1) ~is 0
-  for (i: MAX_WIDTH .. 2*MAX_WIDTH):
+  for (i in MAX_WIDTH .. 2*MAX_WIDTH):
     check: radix(i, 1) ~is 1
 
 /* a node in the RRB Tree
@@ -183,7 +183,7 @@ class TreeList(root :~ Node,
   // TODO i want it to be equal if the represented sequence is equal which requires walking the tree
   // how to do efficiently?
   private override equals(rhs :~ TreeList, recur):
-    (size == rhs.size) && (for all (i: 0..size):
+    (size == rhs.size) && (for all (i in 0..size):
                              recur(rhs[i], this[i]))
 
   private override hash_code(recur):
@@ -256,7 +256,7 @@ class TreeList(root :~ Node,
   // rather than traverse once per element of represented vector
   method to_list() :~ List:
     for List:
-      each idx: 0..size
+      each idx in 0..size
       get(idx)
 
   method length() :~ Int:
@@ -325,7 +325,7 @@ class TreeList(root :~ Node,
                   new_sizes[0] := size0
               | ~else:
                   def step = 1 bits.(<<) (depth * BITS)
-                  for (i: 0 .. new_len - 1):
+                  for (i in 0 .. new_len - 1):
                     new_sizes[i] := (size0 + i * step)
                   let sizeN = size_subtree(new_children[new_len-1], depth-1)
                   new_sizes[new_len - 1] := size0 + (new_len - 2) * step + sizeN
@@ -335,7 +335,7 @@ class TreeList(root :~ Node,
               def (branch_index, subindex) = step(node, index, depth)
               def new_children :~ Array.now_of(Node) = node.children.drop(branch_index)
               def new_sizes = for Array.of_length((node.sizes :~ Array.now_of(Int)).length() - branch_index):
-                each i: branch_index .. (node.sizes :~ Array.now_of(Int)).length()
+                each i in branch_index .. (node.sizes :~ Array.now_of(Int)).length()
                 (node.sizes :~ Array.now_of(Int))[i] - index
               def new_child = drop(node.get(branch_index), subindex, depth - 1)
                 
@@ -376,7 +376,7 @@ class TreeList(root :~ Node,
                          block:
                            let sizes :~ Array: a.sizes
                            for Array.of_length(sizes.length()) ():
-                             each n: sizes
+                             each n in sizes
                              n+1)
       let new_root = insert_left(root, height)
       if new_root
@@ -516,7 +516,7 @@ fun set_sizes(children :~ Array, height :~ Int) :~ Node:
   if height == 0:
   | Node(children)
   | def sizes = Array.make(children.length())
-    for values(sum = 0) (i: 0 .. children.length()):
+    for values(sum = 0) (i in 0 .. children.length()):
       def new_sum = sum + size_subtree(children[i], height - 1)
       sizes[i] := new_sum
       new_sum
@@ -527,7 +527,7 @@ fun set_sizes(children :~ Array, height :~ Int) :~ Node:
 fun concat_plan(slots :~ Array) :~ maybe(Array):
   def plan = Array.make(slots.length())
   def child_count:
-    for values(count = 0) (i: 0 .. slots.length()):
+    for values(count = 0) (i in 0 .. slots.length()):
       def sz = (slots[i] :~ Node).size
       plan[i] := sz
       count + sz
@@ -553,7 +553,7 @@ fun distribute(plan :~ Array, target :~ Int, count :~ Int, node_idx :~ Int = 0) 
 
     /* we've removed a node (conceptually) at this point,
        so move nodes to the right of current node left by one */
-    for (j: i .. count - 1):
+    for (j in i .. count - 1):
       plan[j] := plan[j + 1]
 
     distribute(plan, target, count - 1, i - 1)
@@ -578,17 +578,17 @@ fun exec_concat_plan(slots :~ Array,
     def flattened:
       for Array.of_length(flattened_size):
         each node :~ Node: slots
-        each child: node.children
+        each child in node.children
         child
 
     def new_slots = Array.make(plan.length())
     for values(sum = 0):
-      each i: 0..plan.length()
+      each i in 0..plan.length()
               
       let new_sum = sum + plan[i]
       let new_node:
         for Array.of_length(new_sum - sum):
-          each j: sum .. new_sum
+          each j in sum .. new_sum
           flattened[j]
       new_slots[i] :=  set_sizes(new_node, height - 1)
       
@@ -654,7 +654,7 @@ fun new_branch(el, height):
 fun
 | from() :~ TreeList: TreeList[]
 | from(s :~ Sequence) :~ TreeList:
-    for values(v :~ TreeList = TreeList[]) (el: s):
+    for values(v :~ TreeList = TreeList[]) (el in s):
       v.add(el)
                    
 module test:
@@ -664,11 +664,11 @@ module test:
 
   fun
   | array_from(s :: Sequence) :~ Array:
-      for Array (si: s): si
+      for Array (si in s): si
 
   fun
   | list_from(s :: Sequence) :~ List:
-      for List (i: s): i
+      for List (i in s): i
 
   /* Node tests */ 
   let leaf_n :~ Node = Node(Array(1, 2, 3, 4))
@@ -919,7 +919,7 @@ module test:
 
   let (vec :~ TreeList, lst :~ List):
     for values(v :~ TreeList = TreeList[1], l :~ List = [1]):
-      each i: 0..10
+      each i in 0..10
       match math.random(4)
       | 0: values(v.add(i), l ++ [i])
       | 1: values(v.insert(0, i), List.cons(i, l))
@@ -970,7 +970,7 @@ module test:
 //    large_ub ++? medium_ub ~is #true
 //    large_ub ++? medium ~is #true
 
-  for (i: 0 .. 100): // pop of singleton => empty
+  for (i in 0 .. 100): // pop of singleton => empty
     def n = math.random(100)
     check: TreeList[n].pop()
            ~is TreeList.empty

--- a/gui_demo.rhm
+++ b/gui_demo.rhm
@@ -48,7 +48,7 @@ fun draw_face(dc :: draw.DC, config :: Map):
     let dot_size = [4, 4]
     for values(brush :~ draw.Brush:
                  draw.Brush(~color: draw.Color(0, 0, 0, 0.25))):
-      each [x, y]: (config["ghosts"] :: List).reverse()
+      each [x, y] in (config["ghosts"] :: List).reverse()
       dc.brush := brush
       let x = x/scale
       let y = y/scale

--- a/rhombus-draw-lib/rhombus/draw/private/rkt.rhm
+++ b/rhombus-draw-lib/rhombus/draw/private/rkt.rhm
@@ -31,8 +31,8 @@ expr.macro 'send $target ... . $(method :: Identifier)($(kw :: Keyword): $kw_arg
                         expr_meta.pack_expr('$target ...'),
                         method,
                         & (for List:
-                             each p: [[kw, expr_meta.pack_expr(kw_arg)], ...]
-                             each i: p
+                             each p in [[kw, expr_meta.pack_expr(kw_arg)], ...]
+                             each i in p
                              i),
                         expr_meta.pack_expr(arg), ...])
 

--- a/rhombus-gui-lib/rhombus/gui/private/event.rhm
+++ b/rhombus-gui-lib/rhombus/gui/private/event.rhm
@@ -85,11 +85,11 @@ class MouseEvent():
                ~timestamp: timestamp :: Int = 0):
     super(rkt.make_object(gui.#{mouse-event%},
                           convert_kind(kind),
-                          down[#'left], down[#'middle], down[#'right],
+                          #'left in down, #'middle in down, #'right in down,
                           x, y,
-                          down[#'shift], down[#'control], down[#'meta], down[#'alt],
+                          #'shift in down, #'control in down, #'meta in down, #'alt in down,
                           timestamp,
-                          down[#'caps], down[#'mod3], down[#'mod4], down[#'mod5]))()
+                          #'caps in down, #'mod3 in down, #'mod4 in down, #'mod5 in down))()
 
   property kind:
     unconvert_kind(rkt.send handle.#{get-event-type}())
@@ -161,10 +161,10 @@ class KeyEvent():
                               match code
                               | _ :: Char: code
                               | ~else: convert_key(code),
-                              down[#'shift], down[#'control], down[#'meta], down[#'alt],
+                              #'shift in down, #'control in down, #'meta in down, #'alt in down,
                               x, y,
                               timestamp,
-                              down[#'caps], down[#'mod3], down[#'mod4], down[#'mod5],
+                              #'caps in down, #'mod3 in down, #'mod4 in down, #'mod5 in down,
                               use_altgr && #true)
     rkt.send evt.#{set-key-release-code}(release_code)
     when other_caps_code | rkt.send evt.#{set-other-caps-key-code}(other_caps_code)

--- a/rhombus-lib/info.rkt
+++ b/rhombus-lib/info.rkt
@@ -16,5 +16,5 @@
 
 (define license '(Apache-2.0 OR MIT))
 
-;; keep in sync with runtime version at "rhombus/private/amalgam/info.rkt"
-(define version "0.32")
+;; keep in sync with runtime version at "rhombus/private/amalgam/version.rkt"
+(define version "0.33")

--- a/rhombus-lib/rhombus/cmdline.rhm
+++ b/rhombus-lib/rhombus/cmdline.rhm
@@ -313,7 +313,7 @@ fun flatten(who, args :~ List, srclocs :~ List, pred, desc, keep_srcloc = #false
                 srcloc: srclocs):
       cond
       | arg is_a List:
-          let srclocs: for List (a: arg :~ List): srcloc
+          let srclocs: for List (a in arg :~ List): srcloc
           flatten(who, arg, srclocs, pred, desc, keep_srcloc)
       | pred(arg): (if keep_srcloc | [[arg, srcloc]] | [arg])
       | ~else:

--- a/rhombus-lib/rhombus/private/amalgam/annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation.rkt
@@ -548,13 +548,16 @@
    (lambda () (order-quote equivalence))
    '()
    'macro
-   (lambda (form tail)
+   (lambda (form tail [mode 'normal])
      (syntax-parse tail
        [(op . (~var t (:annotation-seq #'is_a)))
         (values
          (syntax-parse #'t.parsed
            [c-parsed::annotation-predicate-form
-            #`(c-parsed.predicate #,form)]
+            (let ([r #`(c-parsed.predicate #,form)])
+              (if (eq? mode 'invert)
+                  #`(not #,r)
+                  r))]
            [c-parsed::annotation-binding-form
             #:with arg-parsed::binding-form #'c-parsed.binding
             #:with arg-impl::binding-impl #'(arg-parsed.infoer-id () arg-parsed.data)
@@ -564,8 +567,8 @@
                 (arg-info.matcher-id val-in
                                      arg-info.data
                                      if/blocked
-                                     #t
-                                     #f))])
+                                     #,(eq? mode 'normal)
+                                     #,(not (eq? mode 'normal))))])
          #'t.tail)]))
    'none))
 

--- a/rhombus-lib/rhombus/private/amalgam/array.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/array.rkt
@@ -15,6 +15,7 @@
          "call-result-key.rkt"
          "index-result-key.rkt"
          "sequence-constructor-key.rkt"
+         "contains-key.rkt"
          "composite.rkt"
          "op-literal.rkt"
          "reducer.rkt"
@@ -44,6 +45,7 @@
   #:constructor-arity -1
   #:instance-static-info ((#%index-get Array.get)
                           (#%index-set Array.set)
+                          (#%contains Array.contains)
                           (#%append Array.append)
                           (#%sequence-constructor Array.to_sequence/optimize))
   #:existing
@@ -60,6 +62,7 @@
   (length
    get
    set
+   contains
    append
    copy
    copy_from
@@ -221,6 +224,10 @@
 (define/method (Array.set v i x)
   #:primitive (vector-set!)
   (vector-set! v i x))
+
+(define/method (Array.contains v i [eql equal-always?])
+  #:primitive (vector-member)
+  (and (vector-member i v eql) #t))
 
 (define (check-array who v)
   (unless (vector? v)

--- a/rhombus-lib/rhombus/private/amalgam/charset.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/charset.rhm
@@ -30,7 +30,7 @@ class Charset(private _ranges):
           super([[start, end]])
   | (pred :: Function, ~only_ascii: only_ascii):
       if only_ascii
-      | for values(cs :~ Charset = Charset()) (i: 0..128):
+      | for values(cs :~ Charset = Charset()) (i in 0..128):
           if pred(Char.from_int(i))
           | cs.union(Charset(Char.from_int(i)))
           | cs
@@ -41,7 +41,7 @@ class Charset(private _ranges):
   fun build_unicode(pred):
     let u_ranges :~ PairList = base.#{make-known-char-range-list}()
     let ranges:
-      for values(ranges :~ List = []) (ur: u_ranges):
+      for values(ranges :~ List = []) (ur in u_ranges):
         fun add(ranges :~ List, [s, e]):
           match ranges
           | [r, ..., [ls, le]] when le+1 == s:
@@ -54,7 +54,7 @@ class Charset(private _ranges):
             | if pred(Char.from_int(s))
               | add(ranges, [s, e])
               | ranges
-            | for values(ranges :~ List = ranges) (i: s..e):
+            | for values(ranges :~ List = ranges) (i in s..e):
                 if pred(Char.from_int(i))
                 | add(ranges, [i, i])
                 | ranges

--- a/rhombus-lib/rhombus/private/amalgam/class-able.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-able.rkt
@@ -33,7 +33,8 @@
              [(set) (class-desc-index-set-method-id super)]
              [(append) (class-desc-append-method-id super)]
              [(compare) (class-desc-compare-method-id super)]
-             [else (error "unknown able")]))))
+             [(contains) (class-desc-contains-method-id super)]
+             [else (error "unknown able" which)]))))
 
 ;; gets public or private id, whatever is available to supply arity info in case
 ;; it's not overridden
@@ -98,5 +99,6 @@
                             [(set) (class-desc-index-set-method-id super)]
                             [(append) (class-desc-append-method-id super)]
                             [(compare) (class-desc-compare-method-id super)]
-                            [else (error "unknown able")])]))]
+                            [(contains) (class-desc-contains-method-id super)]
+                            [else (error "unknown able" which)])]))]
     [else #'#f]))

--- a/rhombus-lib/rhombus/private/amalgam/class-define-method-result.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-define-method-result.rkt
@@ -11,6 +11,7 @@
          "index-key.rkt"
          "append-key.rkt"
          "compare-key.rkt"
+         "contains-key.rkt"
          "values-key.rkt"
          (submod "function-parse.rkt" for-build)
          (only-in "function-arity.rkt"
@@ -26,7 +27,8 @@
         maybe-ref-statinfo-id+id
         maybe-set-statinfo-id+id
         maybe-append-statinfo-id+id
-        maybe-compare-statinfo-id+id)
+        maybe-compare-statinfo-id+id
+        maybe-contains-statinfo-id+id)
      #:do [(define-values (proc predicate? count annot-str static-infos)
              (cond
                [(attribute ret.converter)
@@ -188,7 +190,8 @@
                         ;; boxed identifier means "checked" for `#%append`
                         #:box-id? (syntax-e #'checked-append?))
          #,@(gen-bounce #'maybe-compare-statinfo-id+id #'#%compare #f
-                        #:box-id? (syntax-e #'checked-compare?)))]))
+                        #:box-id? (syntax-e #'checked-compare?))
+         #,@(gen-bounce #'maybe-contains-statinfo-id+id #'#%contains #f))]))
 
 (define-for-syntax (de-method-arity arity)
   (datum->syntax #f

--- a/rhombus-lib/rhombus/private/amalgam/class-method.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-method.rkt
@@ -20,6 +20,7 @@
          "index-key.rkt"
          "append-key.rkt"
          "compare-key.rkt"
+         "contains-key.rkt"
          "static-info.rkt"
          "indirect-static-info-key.rkt"
          (submod "dot.rkt" for-dot-provider)
@@ -413,6 +414,7 @@
                                          index-set-statinfo-indirect-stx setable?
                                          append-statinfo-indirect-stx appendable?
                                          compare-statinfo-indirect-stx comparable?
+                                         contains-statinfo-indirect-stx container?
                                          super-call-statinfo-indirect-id
                                          #:checked-append? [checked-append? #t]
                                          #:checked-compare? [checked-compare? #t])
@@ -468,7 +470,10 @@
                                       [op (in-list ops)])
                              #`(#,op #,(or (let ([a (hash-ref addeds name #f)])
                                              (and a (added-method-rhs-id a)))
-                                           (box (added-method-rhs-id added))))))])]))))
+                                           (box (added-method-rhs-id added))))))])])
+          #,(and container?
+                 (eq? 'contains (syntax-e (added-method-id added)))
+                 #`[#,contains-statinfo-indirect-stx #,(added-method-rhs-id added)]))))
 
   ;; may need to add info for inherited `call`, etc.:
   (define (add-able which statinfo-indirect-stx able? key defs abstract-args
@@ -504,7 +509,8 @@
                          ;; boxed means "checked" for `#%append`:
                          #:box-id? checked-append?)]
          [defs (add-able 'compare_to compare-statinfo-indirect-stx comparable? #'#%compare defs #'(val)
-                         #:const '#:method)])
+                         #:const '#:method)]
+         [defs (add-able 'contains contains-statinfo-indirect-stx container? #'#%contains defs #'(val))])
     defs))
 
 (define-for-syntax (build-method-result-expression method-result)

--- a/rhombus-lib/rhombus/private/amalgam/class-parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-parse.rkt
@@ -66,7 +66,7 @@
    dots          ; list of symbols for dot syntax
    dot-provider  ; #f or compile-time identifier
    static-infos  ; syntax object for additional instance static-infos
-   flags))       ; 'call (=> public `call` is Callable), 'get, 'set, 'append, 'compare; others specific to class/interface/veneer
+   flags))       ; 'call (=> public `call` is Callable), 'get, 'set, 'append, 'compare, 'contains; others specific to class/interface/veneer
 
 (struct class-desc objects-desc
   ;; `flags` from `objects-desc` can include 'authentic, 'prefab, 'no-recon
@@ -90,7 +90,8 @@
    index-method-id       ; for `get`
    index-set-method-id   ; for `set`
    append-method-id      ; for `append`
-   compare-method-id      ; for `compare`
+   compare-method-id     ; for `compare`
+   contains-method-id ; for `contains`
    indirect-call-method-id ; #f or identifier for `call`
    prefab-guard-id))
 

--- a/rhombus-lib/rhombus/private/amalgam/class-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-primitive.rkt
@@ -316,6 +316,7 @@
                                     #f ; not mutable indexable
                                     #f ; not appendable
                                     #f ; not comparable
+                                    #f ; not container
                                     #f ; not callable (again)
                                     #f ; not prefab
                                     )))))

--- a/rhombus-lib/rhombus/private/amalgam/class-static-info.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-static-info.rkt
@@ -30,6 +30,8 @@
     (able-statinfo-indirect-id 'append super interfaces name-id intro))
   (define compare-statinfo-indirect-id
     (able-statinfo-indirect-id 'compare super interfaces name-id intro))
+  (define contains-statinfo-indirect-id
+    (able-statinfo-indirect-id 'contains super interfaces name-id intro))
 
   (define super-call-statinfo-indirect-id
     (able-super-statinfo-indirect-id 'call super interfaces))
@@ -74,6 +76,9 @@
               #'())
        #,@(if compare-statinfo-indirect-id
               #`((#%indirect-static-info #,compare-statinfo-indirect-id))
+              #'())
+       #,@(if contains-statinfo-indirect-id
+              #`((#%indirect-static-info #,contains-statinfo-indirect-id))
               #'())))
 
   (define indirect-static-infos
@@ -88,6 +93,7 @@
           index-set-statinfo-indirect-id
           append-statinfo-indirect-id
           compare-statinfo-indirect-id
+          contains-statinfo-indirect-id
 
           super-call-statinfo-indirect-id
 

--- a/rhombus-lib/rhombus/private/amalgam/compound-repetition.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/compound-repetition.rkt
@@ -81,9 +81,13 @@
   ;;  - 'mixfix  -- both infix and postfix, depending on the tail
   (define (make-expression&repetition-infix-operator order prec kind exp assc
                                                      #:element-statinfo? [element-statinfo? #f])
-    (define (infix-exp form1 form2 self-stx)
-      (exp form1 form2 self-stx))
-    (define (infix-rep form1 form2 self-stx)
+    (define infix-exp
+      (case-lambda
+        [(form1 form2 self-stx)
+         (exp form1 form2 self-stx)]
+        [(form1 form2 self-stx mode)
+         (exp form1 form2 self-stx mode)]))
+    (define (do-rep-infix form1 form2 self-stx exp)
       (build-compound-repetition self-stx
                                  (list form1 form2)
                                  (lambda (form1 form2)
@@ -91,6 +95,13 @@
                                    (values (discard-static-infos expr)
                                            (extract-static-infos expr)))
                                  #:element-statinfo? element-statinfo?))
+    (define infix-rep
+      (case-lambda
+        [(form1 form2 self-stx)
+         (do-rep-infix form1 form2 self-stx exp)]
+        [(form1 form2 self-stx mode)
+         (do-rep-infix form1 form2 self-stx (lambda (form1 form2 self-stx)
+                                              (exp form1 form2 self-stx mode)))]))
     (define (postfix-exp form stx)
       (syntax-parse stx
         [(self . tail)

--- a/rhombus-lib/rhombus/private/amalgam/contains-key.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/contains-key.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt")
+
+(define-static-info-key-syntax/provide #%contains
+  (static-info-key static-info-identifier-union
+                   static-info-identifier-intersect))

--- a/rhombus-lib/rhombus/private/amalgam/contains-property.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/contains-property.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+
+(provide prop:contains
+         contains-ref)
+
+(define-values (prop:contains has-contains? contains-ref)
+  (make-struct-type-property 'contains))

--- a/rhombus-lib/rhombus/private/amalgam/core.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core.rkt
@@ -105,6 +105,8 @@
         "appendable.rkt"
         "comparable.rkt"
         "listable.rkt"
+        "membership-testable.rkt"
+        "not-infix.rkt"
         "assign.rkt"
         "equal.rkt"
         "function.rkt"

--- a/rhombus-lib/rhombus/private/amalgam/enum.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/enum.rhm
@@ -69,7 +69,7 @@ meta:
             let seen:
               for values (seen :~ Set = seen):
                 each sym: new_syms
-                when seen[sym.unwrap()]
+                when sym.unwrap() in seen
                 | syntax_meta.error("duplicate enum identifier",
                                     stx,
                                     sym)

--- a/rhombus-lib/rhombus/private/amalgam/enum.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/enum.rhm
@@ -49,7 +49,7 @@ meta:
     let ([parsed, ...], _):
       for values (parseds :~ List = [],
                   seen :~ Set = Set.by(===){}):
-        each c: [clause, ...]
+        each c in [clause, ...]
         match c
         | (pattern:
              kind ~group
@@ -68,7 +68,7 @@ meta:
             let new_syms = [sym, ...]
             let seen:
               for values (seen :~ Set = seen):
-                each sym: new_syms
+                each sym in new_syms
                 when sym.unwrap() in seen
                 | syntax_meta.error("duplicate enum identifier",
                                     stx,
@@ -88,7 +88,7 @@ meta:
                               c)
     let [sym, ...]:
       for values (syms :~ List = []):
-        each parsed: [parsed, ...]
+        each parsed in [parsed, ...]
         match parsed
         | Parsed.Symbol([sym, ...]): syms ++ [sym, ...]
         | ~else: syms
@@ -103,7 +103,7 @@ meta:
             statinfo
       let ann_statinfos:
         for values (statinfos :~ List = []):
-          each parsed: [parsed, ...]
+          each parsed in [parsed, ...]
           match parsed
           | Parsed.Annot([ann, ...]): statinfos ++ [unpack_statinfo(ann), ...]
           | ~else: statinfos

--- a/rhombus-lib/rhombus/private/amalgam/error.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/error.rhm
@@ -153,7 +153,7 @@ fun reindent(s :~ String,
              ~max_len: max_len :: NonnegInt
                          = 72 - (2 + label.length() + 1 + space.length())) :~ String:
   if (s.length() > max_len
-        || (for any (c: s):
+        || (for any (c in s):
               c == Char"\n"))
   | "\n" ++ tab
       ++ (block:

--- a/rhombus-lib/rhombus/private/amalgam/filesystem.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/filesystem.rhm
@@ -96,7 +96,7 @@ namespace filesystem:
       let files :~ PairList:
         rkt_error.local_error_adjust { #'#{directory-list}: who }:
           rkt.#{directory-list}(p, #{#:build?}: !onto_path && add_path)
-      for values (accum :~ List = accum) (file: files):
+      for values (accum :~ List = accum) (file in files):
         let file = (if onto_path | Path.add(onto_path, file) | file)
         keep_when keep(file)
         skip_when skip(file)
@@ -157,7 +157,7 @@ namespace filesystem:
               | let files :~ PairList:
                   rkt_error.local_error_adjust { #'#{directory-list}: who }:
                     rkt.#{directory-list}(p, #{#:build?}: #true)
-                for (f: files):
+                for (f in files):
                   delete(f)
               rkt_error.local_error_adjust { #'#{delete-directory}: who }:
                 rkt.#{delete-directory}(p)
@@ -311,7 +311,7 @@ namespace filesystem:
             let files :~ PairList:
               rkt_error.local_error_adjust { #'#{directory-list}: who }:
                 rkt.#{directory-list}(src_path)
-            for (file: files):
+            for (file in files):
               recur(Path.add(src_path, file), Path.add(dest_path, file))
           match file_type(who, src_path)
           | #'file: copy_file(src_path, dest_path)

--- a/rhombus-lib/rhombus/private/amalgam/for.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/for.rkt
@@ -25,26 +25,31 @@
          "syntax-parameter.rkt"
          "if-blocked.rkt"
          (only-in "for-clause-primitive.rkt"
-                  each))
+                  each)
+         (submod "membership-testable.rkt" in-operator))
 
 (provide (rename-out [rhombus-for for]))
 
-(begin-for-syntax
+(begin-for-syntax  
   (define-syntax-class :maybe-ends-each
     #:attributes (each red-parsed)
     #:datum-literals (group)
-    (pattern ((_::parens (~and g (group bind ...+ (_::block . _))) ...))
+    (pattern ((_::parens (~and g (~or (group bind ...+ _::in _ ...+)
+                                      (group bind ...+ (_::block . _))))
+                         ...))
              #:with each #`(#,group-tag each (block g ...))
              #:attr red-parsed #f)
     (pattern ()
              #:attr each #f
              #:attr red-parsed #f)
     (pattern (red ...)
-             #:with (~var redr (:infix-op+reducer+tail #'#%call)) #`(#,group-tag red ...)
+             #:with (~var redr (:infix-op+reducer+tail #'#%call)) (no-srcloc #`(#,group-tag red ...))
              #:attr each (syntax-parse #'redr.tail
                            #:datum-literals (group)
-                           [((_::parens (~and g (group bind ...+ (_::block . _))) ...))
-                            #`(#,group-tag each (block g ...))]
+                           [((_::parens (~and g (~or (group bind ...+ _::in _ ...+)
+                                                     (group bind ...+ (_::block . _))))
+                                        ...))
+                            (no-srcloc #`(#,group-tag each (block g ...)))]
                            [()
                             #f])
              #:with red-parsed #'redr.parsed)))

--- a/rhombus-lib/rhombus/private/amalgam/indexable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/indexable.rkt
@@ -16,7 +16,6 @@
          "call-result-key.rkt"
          "static-info.rkt"
          (submod "assign.rkt" for-assign)
-         (submod "set.rkt" for-index)
          "repetition.rkt"
          "compound-repetition.rkt"
          "index-property.rkt"
@@ -55,7 +54,6 @@
       (list? v)
       (vector? v)
       (hash? v)
-      (set? v)
       (string? v)
       (bytes? v)
       (mutable-treelist? v)
@@ -95,7 +93,6 @@
 (define (mutable-indexable? v)
   (or (mutable-vector? v)
       (mutable-hash? v)
-      (mutable-set? v)
       (mutable-bytes? v)
       (mutable-treelist? v)
       (MutableIndexable? v)))
@@ -208,7 +205,6 @@
     [(list? indexable) (list-ref indexable index)]
     [(vector? indexable) (vector-ref indexable index)]
     [(hash? indexable) (hash-ref indexable index)]
-    [(set? indexable) (set-ref indexable index)]
     [(string? indexable) (string-ref indexable index)]
     [(bytes? indexable) (bytes-ref indexable index)]
     [(mutable-treelist? indexable) (mutable-treelist-ref indexable index)]
@@ -222,7 +218,6 @@
   (cond
     [(mutable-vector? indexable) (vector-set! indexable index val)]
     [(mutable-hash? indexable) (hash-set! indexable index val)]
-    [(mutable-set? indexable) (set-set! indexable index val)]
     [(mutable-bytes? indexable) (bytes-set! indexable index val)]
     [(mutable-treelist? indexable) (mutable-treelist-set! indexable index val)]
     [else

--- a/rhombus-lib/rhombus/private/amalgam/interface.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/interface.rkt
@@ -116,6 +116,7 @@
                        index-set-statinfo-indirect-id
                        append-statinfo-indirect-id
                        compare-statinfo-indirect-id
+                       contains-statinfo-indirect-id
 
                        super-call-statinfo-indirect-id
 
@@ -142,6 +143,7 @@
                      [index-set-statinfo-indirect index-set-statinfo-indirect-id]
                      [append-statinfo-indirect append-statinfo-indirect-id]
                      [compare-statinfo-indirect compare-statinfo-indirect-id]
+                     [contains-statinfo-indirect contains-statinfo-indirect-id]
                      [super-call-statinfo-indirect super-call-statinfo-indirect-id])
          (values
           #`(begin
@@ -161,7 +163,8 @@
                                           #,internal-internal-name
                                           instance-static-infos
                                           call-statinfo-indirect index-statinfo-indirect
-                                          index-set-statinfo-indirect append-statinfo-indirect compare-statinfo-indirect
+                                          index-set-statinfo-indirect append-statinfo-indirect
+                                          compare-statinfo-indirect contains-statinfo-indirect
                                           super-call-statinfo-indirect]
                                 exports
                                 [option stx-param] ...))))])))
@@ -176,7 +179,8 @@
                     internal-internal-name-id
                     instance-static-infos
                     call-statinfo-indirect index-statinfo-indirect
-                    index-set-statinfo-indirect append-statinfo-indirect compare-statinfo-indirect
+                    index-set-statinfo-indirect append-statinfo-indirect
+                    compare-statinfo-indirect contains-statinfo-indirect
                     super-call-statinfo-indirect]
           exports
           [option stx-param] ...)
@@ -230,6 +234,9 @@
        (define-values (comparable? here-comparable? public-comparable?)
          (able-method-status 'compare #f supers method-mindex method-vtable method-private
                              #:name 'compare_to))
+       (define-values (container? here-container? public-container?)
+         (able-method-status 'contains #f supers method-mindex method-vtable method-private
+                             #:name 'contains))
 
        (define (temporary template #:name [name #'name])
          (and name
@@ -293,7 +300,7 @@
                                      method-mindex method-names method-vtable method-results method-private
                                      dots
                                      internal-name
-                                     callable? indexable? setable? appendable? comparable?
+                                     callable? indexable? setable? appendable? comparable? container?
                                      primitive-properties
                                      #'(name name-extends prop:name name-ref name-ref-or-error
                                              prop:internal-name internal-name? internal-name-ref
@@ -310,6 +317,7 @@
                                      #'index-set-statinfo-indirect setable?
                                      #'append-statinfo-indirect appendable?
                                      #'compare-statinfo-indirect comparable?
+                                     #'contains-statinfo-indirect container?
                                      #'super-call-statinfo-indirect))))
            #`(begin . #,defns)))])))
 
@@ -376,7 +384,7 @@
                                          method-mindex method-names method-vtable method-results method-private
                                          dots
                                          internal-name
-                                         callable? indexable? setable? appendable? comparable?
+                                         callable? indexable? setable? appendable? comparable? container?
                                          primitive-properties
                                          names)
   (with-syntax ([(name name-extends prop:name name-ref name-ref-or-error
@@ -437,7 +445,8 @@
                                   (if indexable? '(get) '())
                                   (if setable? '(set) '())
                                   (if appendable? '(append) '())
-                                  (if comparable? '(compare) '()))
+                                  (if comparable? '(compare) '())
+                                  (if container? '(contains) '()))
                               ;; ----------------------------------------
                               (quote-syntax name)
                               #,(and internal-name

--- a/rhombus-lib/rhombus/private/amalgam/list.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/list.rkt
@@ -21,6 +21,7 @@
          "sequence-constructor-key.rkt"
          "list-bounds-key.rkt"
          "maybe-key.rkt"
+         "contains-key.rkt"
          "op-literal.rkt"
          "literal.rkt"
          (submod "ellipsis.rkt" for-parse)
@@ -85,6 +86,7 @@
   #:lift-declaration
   #:constructor-arity -1
   #:instance-static-info ((#%index-get List.get)
+                          (#%contains List.contains)
                           (#%append List.append)
                           (#%sequence-constructor List.to_sequence/optimize))
   #:existing
@@ -126,7 +128,7 @@
    drop
    drop_last
    sublist
-   has_element
+   contains
    find
    index
    remove
@@ -143,6 +145,7 @@
   #:lift-declaration
   #:constructor-arity -1
   #:instance-static-info ((#%index-get PairList.get)
+                          (#%contains PairList.contains)
                           (#%append PairList.append)
                           (#%sequence-constructor PairList.to_sequence/optimize))
   #:existing
@@ -178,7 +181,7 @@
    take_last
    drop
    drop_last
-   has_element
+   contains
    find
    index
    remove
@@ -195,6 +198,7 @@
   #:constructor-arity -1
   #:instance-static-info ((#%index-get MutableList.get)
                           (#%index-set MutableList.set)
+                          (#%contains MutableList.contains)
                           (#%sequence-constructor MutableList.to_sequence/optimize))
   #:existing
   #:opaque
@@ -219,7 +223,7 @@
    drop
    drop_last
    sublist
-   has_element
+   contains
    find
    index
    remove
@@ -1158,16 +1162,16 @@
               [else #f])
     (void)))
 
-(define/method (List.has_element l v [eql equal-always?])
+(define/method (List.contains l v [eql equal-always?])
   #:primitive (treelist-member?)
   (treelist-member? l v eql))
 
-(define/method (PairList.has_element l v [eql equal-always?])
+(define/method (PairList.contains l v [eql equal-always?])
   (check-list who l)
   (check-function-of-arity 2 who eql)
   (and (member v l eql) #t))
 
-(define/method (MutableList.has_element l v [eql equal-always?])
+(define/method (MutableList.contains l v [eql equal-always?])
   #:primitive (mutable-treelist-member?)
   (mutable-treelist-member? l v eql))
 

--- a/rhombus-lib/rhombus/private/amalgam/map.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/map.rkt
@@ -25,6 +25,7 @@
          "sequence-constructor-key.rkt"
          "sequence-element-key.rkt"
          "values-key.rkt"
+         "contains-key.rkt"
          "composite.rkt"
          (submod "list.rkt" for-compound-repetition)
          "parse.rkt"
@@ -138,6 +139,7 @@
 
 (define-static-info-getter get-any-map-static-infos
   (#%index-get Map.get)
+  (#%contains Map.contains)
   (#%sequence-constructor Map.to_sequence/optimize))
 
 (define-primitive-class ReadableMap readable-map hash
@@ -158,6 +160,7 @@
    [values Map.values]
    [get Map.get]
    [has_key Map.has_key]
+   [contains Map.contains]
    [copy Map.copy]
    [snapshot Map.snapshot]
    [to_sequence Map.to_sequence]))
@@ -179,6 +182,7 @@
    [keys Map.keys]
    [get Map.get]
    [has_key Map.has_key]
+   [contains Map.contains]
    [copy Map.copy]
    [snapshot Map.snapshot]
    [to_sequence Map.to_sequence]
@@ -189,7 +193,8 @@
   ()
   #:methods
   (append
-   remove))
+   remove
+   add))
 
 (void (set-primitive-contract! '(and/c hash? (not/c immutable?)) "MutableMap"))
 (define-primitive-class MutableMap mutable-map mutable-hash
@@ -209,7 +214,7 @@
   ()
   #:methods
   (set
-   delete))
+   remove))
 
 (define-primitive-class WeakMutableMap weak-mutable-map
   #:lift-declaration
@@ -1083,6 +1088,10 @@
     [(ht key) (hash-ref ht key)]
     [(ht key default) (hash-ref ht key default)]))
 
+(define/method (Map.add ht key val)
+  #:primitive (hash-set)
+  (hash-set ht key val))
+
 (define (check-map who ht)
   (unless (immutable-hash? ht)
     (raise-annotation-failure who ht "Map")))
@@ -1115,6 +1124,10 @@
        (hash-append new-ht ht))]))
 
 (define/method (Map.has_key ht key)
+  (check-readable-map who ht)
+  (hash-has-key? ht key))
+
+(define/method (Map.contains ht key)
   (check-readable-map who ht)
   (hash-has-key? ht key))
 
@@ -1159,6 +1172,6 @@
   #:primitive (hash-set!)
   (hash-set! ht key val))
 
-(define/method (MutableMap.delete ht key)
+(define/method (MutableMap.remove ht key)
   #:primitive (hash-remove!)
   (hash-remove! ht key))

--- a/rhombus-lib/rhombus/private/amalgam/membership-testable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/membership-testable.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
+                     enforest/name-parse
                      "srcloc.rkt"
                      "statically-str.rkt"
                      "interface-parse.rkt"
@@ -31,6 +32,9 @@
          (for-spaces (#f
                       rhombus/repet)
                      in))
+
+(module+ in-operator
+  (provide (for-syntax :in)))
 
 (define-values (prop:MembershipTestable MembershipTestable? MembershipTestable-ref)
   (make-struct-type-property 'MembershipTestable))
@@ -98,6 +102,14 @@
                               (if (eq? mode 'invert)
                                   `(not ,r)
                                   r))))))
+
+(begin-for-syntax
+  (define-syntax-class :in
+    #:description "a membership operator"
+    #:opaque
+    [pattern ::name
+             #:when (free-identifier=? #'name
+                                       (expr-quote in))]))
 
 (define-syntax in
   (expression-infix-operator

--- a/rhombus-lib/rhombus/private/amalgam/membership-testable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/membership-testable.rkt
@@ -1,0 +1,164 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     "srcloc.rkt"
+                     "statically-str.rkt"
+                     "interface-parse.rkt"
+                     "class-method-result.rkt")
+         (only-in racket/vector
+                  vector-member)
+         "treelist.rkt"
+         "provide.rkt"
+         "expression.rkt"
+         "repetition.rkt"
+         (submod "annotation.rkt" for-class)
+         "parse.rkt"
+         (submod "range.rkt" for-container)
+         "contains-key.rkt"
+         "contains-property.rkt"
+         "static-info.rkt"
+         (submod "set.rkt" for-container)
+         "repetition.rkt"
+         "compound-repetition.rkt"
+         (only-in "class-desc.rkt" define-class-desc-syntax)
+         "is-static.rkt"
+         "order.rkt"
+         "order-primitive.rkt")
+
+(provide (for-spaces (rhombus/class
+                      rhombus/annot)
+                     MembershipTestable)
+         (for-spaces (#f
+                      rhombus/repet)
+                     in))
+
+(define-values (prop:MembershipTestable MembershipTestable? MembershipTestable-ref)
+  (make-struct-type-property 'MembershipTestable))
+
+(define-annotation-syntax MembershipTestable
+  (identifier-annotation container? ((#%contains general-contains))))
+(define (container? v)
+  (or (treelist? v)
+      (list? v)
+      (hash? v)
+      (set? v)
+      (vector? v)
+      (range? v)
+      (MembershipTestable? v)))
+
+(define-class-desc-syntax MembershipTestable
+  (interface-desc-maker
+   (lambda ()
+     (interface-desc #'()
+                     '#(#&contains)
+                     #'#(#:abstract)
+                     (hasheq 'contains 0)
+                     (hasheq 'contains #'contains-result)
+                     '()
+                     #f
+                     #'()
+                     '(contains veneer)
+                     ;; --------------------
+                     #'MembershipTestable
+                     #'MembershipTestable
+                     #'prop:MembershipTestable
+                     #'prop:MembershipTestable
+                     #'MembershipTestable-ref
+                     #'MembershipTestable-ref
+                     #t
+                     #f
+                     null))))
+
+(define-syntax contains-result
+  (method-result-maker
+   (lambda ()
+     (method-result #'(lambda (x) (boolean? x)) #t 1 "Boolean" #'() 4))))
+
+(define-for-syntax (parse-contains form1 form2 self-stx form2-in
+                                   static?
+                                   container-static-info
+                                   k)
+  (define direct-contains-id (container-static-info #'#%contains))
+  (define contains-id (or direct-contains-id
+                             (if static?
+                                 (raise-syntax-error #f
+                                                     (string-append "specialization not known" statically-str)
+                                                     self-stx
+                                                     form2-in)
+                                 #'general-contains)))
+  (k contains-id form1 form2))
+
+(define-for-syntax (build-contains contains-id form1 form2 mode orig-stxes)
+  (relocate+reraw
+   (respan (datum->syntax #f orig-stxes))
+   (datum->syntax (quote-syntax here)
+                  `(,#'let ([a1 ,form1]
+                            [a2 ,form2])
+                           ,(let ([r `(,contains-id a2 a1)])
+                              (if (eq? mode 'invert)
+                                  `(not ,r)
+                                  r))))))
+
+(define-syntax in
+  (expression-infix-operator
+   (lambda () (order-quote equivalence))
+   '()
+   'automatic
+   (lambda (form1 form2-in self-stx [mode 'normal])
+     (define static? (is-static-context? self-stx))
+     (define form2 (rhombus-local-expand form2-in))
+     (parse-contains
+      form1 form2 self-stx form2-in
+      static?
+      (lambda (key) (syntax-local-static-info form2 key))
+      (lambda (contains-id form1 form2)
+        (build-contains contains-id form1 form2 mode
+                           (list form1 self-stx form2-in)))))
+   'left))
+
+(define-repetition-syntax in
+  (repetition-infix-operator
+   (lambda () (order-quote equivalence))
+   '()
+   'automatic
+   (lambda (form1 form2 self-stx [mode 'normal])
+     (define static? (is-static-context? self-stx))
+     (syntax-parse form1
+       [form1-info::repetition-info
+        (build-compound-repetition
+         self-stx
+         (list form1 form2)
+         (lambda (form1 form2)
+           (parse-contains
+            form1 form2 self-stx form2
+            static?
+            (lambda (key)
+              (repetition-static-info-lookup #'form1-info.element-static-infos key))
+            (lambda (contains-id form1 form2)
+              (values
+               (build-contains contains-id form1 form2 mode
+                                  (list form1 self-stx form2))
+               #'())))))]))
+   'left))
+
+(define contains-who/method 'MembershipTestable.contains)
+
+(define (general-contains v1 v2)
+  (cond
+    [(treelist? v1)
+     (treelist-member? v1 v2)]
+    [(list? v1)
+     (and (member v1 v2) #t)]
+    [(hash? v1)
+     (hash-has-key? v1 v2)]
+    [(set? v1)
+     (hash-has-key? (set-ht v1) v2)]
+    [(vector? v1)
+     (and (vector-member v1 v2) #t)]
+    [(range? v1)
+     (Range.contains v1 v2)]
+    [else
+     (define in1 (contains-ref v1 #f))
+     (unless in1
+       (raise-annotation-failure contains-who/method v1 "MembershipTestable"))
+     (in1 v1 v2)]))

--- a/rhombus-lib/rhombus/private/amalgam/not-infix.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/not-infix.rkt
@@ -1,0 +1,60 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     enforest/name-parse
+                     enforest/hier-name-parse
+                     enforest/syntax-local
+                     enforest/operator
+                     "name-path-op.rkt")
+         "provide.rkt"
+         "expression.rkt"
+         "repetition.rkt"
+         "dotted-sequence-parse.rkt"
+         "name-root-space.rkt"
+         "name-root-ref.rkt"
+         "parse.rkt"
+         "membership-testable.rkt"
+         (only-in "annotation.rkt" is_a)
+         (only-in "arithmetic.rkt" is_now)
+         (submod "arithmetic.rkt" parse-not))
+
+(define-for-syntax (parse-not form1 tail repet?)
+  (syntax-parse tail
+    [(self::name seq::dotted-operator-or-identifier-sequence . tail)
+     (define in-space (if repet? in-repetition-space in-expression-space))
+     (syntax-parse #'seq
+       [(~var op (:hier-name-seq in-name-root-space in-space name-path-op name-root-ref))
+        (define mode
+          (cond
+            [(free-identifier=? #'op.name #'in) 'in]
+            [(free-identifier=? #'op.name #'is_a) 'is_a]
+            [(free-identifier=? #'op.name #'is_now) 'is_now]
+            [else #f]))
+        (unless mode
+          (raise-syntax-error #f "expected a negatable operator" #'self #'op))
+        (define infix-op (syntax-local-value* (in-space #'op.name) (if repet?
+                                                                       repetition-infix-operator-ref
+                                                                       expression-infix-operator-ref)))
+        (define (apply-op form1 form2)
+          ((operator-proc infix-op) form1 form2 #'op.name 'invert))
+        (case mode
+          [(in is_now)
+           (cond
+             [(not repet?)
+              (syntax-parse #'(group . tail)
+                [(~var form2 (:infix-op+expression+tail #'self.name))
+                 (values (apply-op form1 #'form2.parsed)
+                         #'form2.tail)])]
+             [else
+              (syntax-parse #'(group . tail)
+                [(~var form2 (:infix-op+repetition-use+tail #'self.name))
+                 (values (apply-op form1 #'form2.parsed)
+                         #'form2.tail)])])]
+          [(is_a)
+           ((operator-proc infix-op) form1 (cons #'op.name #'tail) 'invert)])])]
+    [(self next . _)
+     (raise-syntax-error #f "expected negatable operator" #'self #'next)]))
+
+(begin-for-syntax
+  (set-parse-not! parse-not))
+

--- a/rhombus-lib/rhombus/private/amalgam/order-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/order-primitive.rkt
@@ -63,17 +63,18 @@
       (order-quote exponentiation)
       (order-quote integer_division)))))
 
-(define-order-syntax enumeration
+(define-order-syntax equivalence
   (make-order
    (lambda ()
      (list
       (cons (order-quote addition) 'weaker)
       (cons (order-quote multiplication) 'weaker)
       (cons (order-quote exponentiation) 'weaker)
-      (cons (order-quote integer_division) 'weaker)))
+      (cons (order-quote integer_division) 'weaker)
+      (cons (order-quote enumeration) 'weaker)))
    'none))
 
-(define-order-syntax equivalence
+(define-order-syntax enumeration
   (make-order
    (lambda ()
      (list

--- a/rhombus-lib/rhombus/private/amalgam/range.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/range.rkt
@@ -31,6 +31,7 @@
          (submod "dot.rkt" for-dot-provider)
          "define-arity.rkt"
          "call-result-key.rkt"
+         "contains-key.rkt"
          "sequence-constructor-key.rkt"
          "order.rkt"
          "order-primitive.rkt")
@@ -51,10 +52,14 @@
                      (rename-out [<.. <..<])
                      <..=))
 
+(module+ for-container
+  (provide range?
+           Range.contains))
+
 (define-primitive-class Range range
   #:lift-declaration
   #:no-constructor-static-info
-  #:instance-static-info ()
+  #:instance-static-info ((#%contains Range.contains))
   #:existing
   #:just-annot #:no-primitive
   #:fields ()
@@ -78,7 +83,7 @@
    end
    includes_start
    includes_end
-   has_element
+   contains
    encloses
    is_connected
    overlaps
@@ -88,7 +93,8 @@
 
 (define-static-info-getter get-sequence-range-static-infos/sequence
   (#%sequence-constructor Range.to_sequence/optimize)
-  (#%sequence-element #,(get-int-static-infos)))
+  (#%sequence-element #,(get-int-static-infos))
+  #,@(get-range-static-infos))
 
 (define-primitive-class SequenceRange sequence-range
   #:lift-declaration
@@ -643,7 +649,7 @@
            (not other-upper?)
            (= point other-point))))
 
-(define/method (Range.has_element r i)
+(define/method (Range.contains r i)
   (check-range who r)
   (check-int who i)
   (define-values (start in-start? end in-end?)

--- a/rhombus-lib/rhombus/private/amalgam/recur.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/recur.rhm
@@ -28,7 +28,7 @@ expr.macro 'recur $(name :: Identifier) ($(arg :: bind_meta.Argument),
   // duplicating the binding machinery for the initial call and recursive calls,
   // we'll expand in a way that uses `#{unsafe-undefined}` on the initial call
   let all_immediate: for values(immed = #true):
-                       each info: [arg_info, ...]
+                       each info in [arg_info, ...]
                        immed && bind_meta.is_immediate(info)
   let ['($_, $a_name, $_, ...)', ...] = [bind_meta.unpack_info(arg_info), ...]
   let [arg_id, ...] = [Syntax.make_id(a_name +& "_arg"), ...]
@@ -111,7 +111,7 @@ meta:
                                              #%literal $annotation_string))'
       | let [arg, ...]:
           for List:
-            each i: 0..count
+            each i in 0..count
             Syntax.make_id("arg" +& i)
         'block:
            fun fail(): bad_result(#' $name, #%literal $annotation_string)

--- a/rhombus-lib/rhombus/private/amalgam/rx_charset.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx_charset.rhm
@@ -70,7 +70,7 @@ rx_charset.macro '#%parens ($(charset :: rx_charset_meta.Parsed))':
 rx_charset.macro '#%literal $(s :: String)':
   let str :~ String = s.unwrap()
   let cs:
-    for values(cs :~ Charset = Charset()) (ch: str):
+    for values(cs :~ Charset = Charset()) (ch in str):
       cs.union(Charset(ch, ch))
   rx_charset_meta.pack(cs, s)
 

--- a/rhombus-lib/rhombus/private/amalgam/rx_compile.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx_compile.rhm
@@ -22,7 +22,7 @@ meta:
 
   // create a map from symbols to indices
   fun map_vars(var_seq :~ List):
-    for values(vars :~ Map: {}, di = 0) (var: var_seq):
+    for values(vars :~ Map: {}, di = 0) (var in var_seq):
       match var
       | var :: Identifier:
           values(vars ++ { var.unwrap(): di+1 }, di+1)
@@ -33,7 +33,7 @@ meta:
 
   // create a list expression that records names and where splices happen
   fun describe_splice_vars(var_seq :~ List, vars :~ Map):
-    for List (var: var_seq):
+    for List (var in var_seq):
       skip_when:
         match var
         | '[~maybe_splice, $id]': vars.has_key(id.unwrap())
@@ -147,7 +147,7 @@ meta:
           let elem:
             match str.unwrap()
             | str :: String:
-                if (for all (c: str):
+                if (for all (c in str):
                       c.to_int() < 256)
                 | #'any
                 | #'char

--- a/rhombus-lib/rhombus/private/amalgam/rx_object.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx_object.rhm
@@ -60,7 +60,7 @@ class RX(private _rkt_partial_rx,
   private method
   | strings_result(#false): #false
   | strings_result(m :~ PairList):
-      def mList = (for List (elem: m): freeze(elem))
+      def mList = (for List (elem in m): freeze(elem))
       RXMatch(mList[0], mList.rest, _vars)
 
   match_method match(input, start_pos, end_pos, output_port, input_prefix):
@@ -109,7 +109,7 @@ class RX(private _rkt_partial_rx,
                  ~end: end_pos :: maybe(Int) = #false,
                  ~input_prefix: input_prefix :: Bytes = #"") :~ List:
     def m :~ PairList = base.#{regexp-match*}(_rkt_partial_rx, input, start_pos, end_pos, input_prefix)
-    for List (elem: m):
+    for List (elem in m):
       freeze(elem)
 
   method split(input :: String || Bytes || Port.Input,
@@ -117,7 +117,7 @@ class RX(private _rkt_partial_rx,
                ~end: end_pos :: maybe(Int) = #false,
                ~input_prefix: input_prefix :: Bytes = #"") :~ List:
     def m :~ PairList = base.#{regexp-split}(_rkt_partial_rx, input, start_pos, end_pos, input_prefix)
-    for List (elem: m):
+    for List (elem in m):
       freeze(elem)
 
   fun check_filter(who, in, out):

--- a/rhombus-lib/rhombus/private/amalgam/veneer.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/veneer.rkt
@@ -108,6 +108,7 @@
                        index-set-statinfo-indirect-id
                        append-statinfo-indirect-id
                        compare-statinfo-indirect-id
+                       contains-statinfo-indirect-id
 
                        super-call-statinfo-indirect-id
 
@@ -132,6 +133,7 @@
                      [index-set-statinfo-indirect index-set-statinfo-indirect-id]
                      [append-statinfo-indirect append-statinfo-indirect-id]
                      [compare-statinfo-indirect compare-statinfo-indirect-id]
+                     [contains-statinfo-indirect contains-statinfo-indirect-id]
                      [super-call-statinfo-indirect super-call-statinfo-indirect-id]
                      [indirect-static-infos indirect-static-infos]
                      [instance-static-infos instance-static-infos])
@@ -148,7 +150,7 @@
                          name? name-convert check?
                          name-instance
                          call-statinfo-indirect index-statinfo-indirect index-set-statinfo-indirect
-                         append-statinfo-indirect compare-statinfo-indirect
+                         append-statinfo-indirect compare-statinfo-indirect contains-statinfo-indirect
                          super-call-statinfo-indirect
                          indirect-static-infos
                          instance-static-infos
@@ -164,7 +166,7 @@
                     name? name-convert check?
                     name-instance
                     call-statinfo-indirect index-statinfo-indirect index-set-statinfo-indirect
-                    append-statinfo-indirect compare-statinfo-indirect
+                    append-statinfo-indirect compare-statinfo-indirect contains-statinfo-indirect
                     super-call-statinfo-indirect
                     indirect-static-infos
                     instance-static-infos
@@ -233,6 +235,9 @@
        (define-values (comparable? here-comparable? public-comparable?)
          (able-method-status 'compare super interfaces method-mindex method-vtable method-private
                              #:name 'compare_to))
+       (define-values (container? here-container? public-container?)
+         (able-method-status 'contains super interfaces method-mindex method-vtable method-private
+                             #:name 'contains))
 
        (define (temporary template)
          ((make-syntax-introducer) (datum->syntax #f (string->symbol (format template (syntax-e #'name))))))
@@ -322,6 +327,7 @@
                                   public-setable?
                                   public-appendable?
                                   public-comparable?
+                                  public-container?
                                   #'(name name-extends class:name constructor-maker-name name-defaults name-ref
                                           name? name-convert check? converter?
                                           dot-provider-name prefab-guard-name
@@ -336,6 +342,7 @@
                                      #'index-set-statinfo-indirect setable?
                                      #'append-statinfo-indirect appendable?
                                      #'compare-statinfo-indirect comparable?
+                                     #'contains-statinfo-indirect container?
                                      #'super-call-statinfo-indirect
                                      #:checked-append? #f
                                      #:checked-compare? #f))))
@@ -519,6 +526,7 @@
                                       public-setable?
                                       public-appendable?
                                       public-comparable?
+                                      public-container?
                                       names)
   (with-syntax ([(name name-extends class:name constructor-maker-name name-defaults name-ref
                        name? name-convert check? converter?
@@ -531,7 +539,8 @@
           [flags #`(#,@(if public-indexable? '(get) null)
                     #,@(if public-setable? '(set) null)
                     #,@(if public-appendable? '(append) null)
-                    #,@(if public-comparable? '(compare) null))]
+                    #,@(if public-comparable? '(compare) null)
+                    #,@(if public-container? '(contains) null))]
           [interface-names (interface-names->quoted-list interface-names all-interfaces
                                                          private-interfaces protected-interfaces
                                                          'public)])

--- a/rhombus-lib/rhombus/private/amalgam/version.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/version.rkt
@@ -3,4 +3,4 @@
 (provide version)
 
 ;; keep in sync with package version at "../../../info.rkt"
-(define version "0.32")
+(define version "0.33")

--- a/rhombus-lib/rhombus/private/cmdline.rhm
+++ b/rhombus-lib/rhombus/private/cmdline.rhm
@@ -191,7 +191,7 @@ fun command_line_parser(
                     | // short flag(s)
                       let (state, once, line, is_final):
                         for values(state = state, once = once, line = [rest, ...], is_final = #false):
-                          each i: 1 .. first.length()
+                          each i in 1 .. first.length()
                           let flag = first[0] +& first[i]
                           apply_flag(flag, first, short_flags.get(flag, #false), state, line,
                                      once_keys, once, is_final,
@@ -218,7 +218,7 @@ fun gather_flags(flags :~ List, args, init_state,
     match c
     | [c, ...]:
         for values(state = state, long_flags = long_flags, short_flags = short_flags, once_keys = once_keys):
-          each c: [c, ...]
+          each c in [c, ...]
           setup(c, state, long_flags, short_flags, once_keys, once_key)
     | h :: Handler:
         let once_keys:
@@ -239,7 +239,7 @@ fun gather_flags(flags :~ List, args, init_state,
             let (long_flags, short_flags):
               for values(long_flags :~ Map = long_flags,
                          short_flags :~ Map = short_flags):
-                each flag_str: f.flag_strs
+                each flag_str in f.flag_strs
                 let is_short = flag_str.length() == 2
                 when (if is_short
                       | short_flags.get(flag_str, #false)
@@ -257,7 +257,7 @@ fun gather_flags(flags :~ List, args, init_state,
         setup(fs.choices, state, long_flags, short_flags, once_keys, #false)
     | fs :: OnceEach:
         for values(state = state, long_flags = long_flags, short_flags = short_flags, once_keys = once_keys):
-          each c: fs.choices
+          each c in fs.choices
           setup(c, state, long_flags, short_flags, once_keys, #'self)
     | fs :: OnceAny:
         setup(fs.choices, state, long_flags, short_flags, once_keys, Symbol.gen())
@@ -350,7 +350,7 @@ fun show_help(~program: exe_who :: String || Path = current_program(),
               ~args: args :: Handler):
   let (min_flags, max_flags, num_flags):
     recur seek(flags :~ List = flags, just_once = #true):
-      for values(min_flags = 0, max_flags = 0, num_flags = 0) (flag: flags):
+      for values(min_flags = 0, max_flags = 0, num_flags = 0) (flag in flags):
         let (min_flag, max_flag, a_flag):
           match flag
           | f :: Flag: values(1, if just_once | 1 | #inf, f.flag_strs.length())
@@ -430,7 +430,7 @@ fun show_help(~program: exe_who :: String || Path = current_program(),
           println("")
           when f.help:
           | let help = f.help!!.split("\n")
-            for (h: help.drop_last(1)):
+            for (h in help.drop_last(1)):
               match mode
               | #'multi || #'once_each: print("    ")
               | ~else: print("|   ")
@@ -452,7 +452,7 @@ fun show_help(~program: exe_who :: String || Path = current_program(),
     when any_once
     | println("/|\\ Brackets indicate mutually exclusive options.")
     fun find_single_flag(f :~ Flag):
-      for any (flag_str: f.flag_strs):
+      for any (flag_str in f.flag_strs):
         flag_str.length() == 2 && flag_str
     let singles = mode_and_flags.filter(~keep: fun([mode, flag]):
                                                  match flag

--- a/rhombus-pict-lib/rhombus/pict/private/anim.rhm
+++ b/rhombus-pict-lib/rhombus/pict/private/anim.rhm
@@ -241,7 +241,7 @@ class TransitionPictEpoch(epochs :~ List.of(PictEpoch),
                           splice):
   extends PictEpoch
   field starts :~ List:
-    for values(sums :~ List = [0]) (e: extents):
+    for values(sums :~ List = [0]) (e in extents):
       sums.add(sums.last + e)
   override pict(n :: Real.in(0, 1)):
     let s_n = n * starts.last
@@ -320,7 +320,7 @@ class AnimPict(_epochs :~ List.of(PictEpoch),
     match _child_starts
     | starts :: List: starts
     | ~else:
-        for List (c: children):
+        for List (c in children):
           _child_starts
 
   override property duration: _duration
@@ -369,12 +369,12 @@ class AnimPict(_epochs :~ List.of(PictEpoch),
     | this
     | let ([new_prefix :~ PictEpoch, ...] && prefix, _):
         for values(prefix :~ List = [], first :~ PictEpoch = _epochs[0]):
-          each i: 0 .. math.max(0, -min_epoch - _duration_start)
+          each i in 0 .. math.max(0, -min_epoch - _duration_start)
           let new = first.before()
           values(prefix.insert(0, new), new)
       let ([new_suffix :~ PictEpoch, ...] && suffix, _):
         for values(suffix :~ List = [], last :~ PictEpoch = _epochs[_epochs.length() - 1]):
-          each i: 0 .. math.max(0, max_epoch - now_max_epoch)
+          each i in 0 .. math.max(0, max_epoch - now_max_epoch)
           let new = last.after()
           values(suffix.add(new), new)
       anim_pict_like(this,
@@ -547,7 +547,7 @@ class AnimPict(_epochs :~ List.of(PictEpoch),
     | amt < 0:
         let ([new :~ PictEpoch, ...] && suffix, _):
           for values(suffix :~ List = [], last :~ PictEpoch = _epochs[_epochs.length()-1]):
-            each i: 0 .. math.max(0, _duration_start - amt - _epochs.length())
+            each i in 0 .. math.max(0, _duration_start - amt - _epochs.length())
             let new = last.after()
             values(suffix.add(new), new)
         anim_pict_like(this,
@@ -566,7 +566,7 @@ class AnimPict(_epochs :~ List.of(PictEpoch),
     | ~else:
         let ([new :~ PictEpoch, ...] && prefix, _):
           for values(prefix :~ List = [], first :~ PictEpoch = _epochs[0]):
-            each i: 0 .. math.max(0, amt - _duration_start)
+            each i in 0 .. math.max(0, amt - _duration_start)
             let new = first.before()
             values(prefix.insert(0, new), new)
         anim_pict_like(this,
@@ -589,7 +589,7 @@ class AnimPict(_epochs :~ List.of(PictEpoch),
     | amt < 0:
         let ([new :~ PictEpoch, ...] && prefix, _):
           for values(prefix :~ List = [], first :~ PictEpoch = _epochs[0]):
-            each i: 0 .. math.max(0, _duration - amt)
+            each i in 0 .. math.max(0, _duration - amt)
             let new = first.before()
             values(prefix.insert(0, new), new)
         anim_pict_like(this,
@@ -820,7 +820,7 @@ fun merge_anim_epochs([p :~ _AnimPict, ...], dalign):
   let max_epoch = math.max(math.max(0, epochs_length(p) - duration_start(p) - 1), ...)
   let ps && [p :~ AnimPict, ...] = [reify_epochs(p, min_epoch, max_epoch), ...]
   let all_epochs:
-    for List (i: min_epoch ..= max_epoch):
+    for List (i in min_epoch ..= max_epoch):
       math.max(p.epoch_extent(i), ...)
   values (ps, -min_epoch, max_duration_epoch + 1, all_epochs)
 
@@ -867,7 +867,7 @@ fun rebuildable_list(ps :~ List, orig_ps, rebuild):
                        ~dependencies: [container_p],
                        ~rebuild: fun ([container_p]):
                                    extract_from_container(container_p, i))
-  for List (i: 0..ps.length()):
+  for List (i in 0..ps.length()):
     extract_from_container(container_p, i)
 
 // keeps `nothing`s so that result is parallel to input
@@ -880,7 +880,7 @@ fun sequential(~join: mode :: SequentialJoin = #'step,
   | []: []
   | [p]: orig_ps
   | ~else:
-      let (ps, starts) = make_sequential(for List (p: orig_ps):
+      let (ps, starts) = make_sequential(for List (p in orig_ps):
                                            cond
                                            | p == nothing: p
                                            | p is_a StaticPict: AnimPict(p)
@@ -939,14 +939,14 @@ fun make_sequential(ps :~ List.of(AnimPict),
     let next_splice = mode == #'splice
     values(offset + p.duration - (if next_splice | 1 | 0),
            !next_splice)
-  for values(offset = 0, splice = #false) (p: ps):
+  for values(offset = 0, splice = #false) (p in ps):
     if p == nothing
     | values(offset, splice)
     | bump_extents(p, adjust_offset(p, offset, splice), extents)
   let used_extents = MutableMap{}
   let (accum, starts_accum, t, _):
     for values(accum :~ List = [], starts_accum :~ List = [], offset = 0, splice = #false):          
-      each p: ps
+      each p in ps
       if p == nothing
       | values(if keep_nothing | accum.add(p) | accum,
                starts_accum,
@@ -976,10 +976,10 @@ fun concurrent(~epoch: ealign :: EpochAlignment = #'center,
                p :: Pict, ...) :~ List.of(Pict):
   let orig_ps = [p, ...]
   let ps:
-    if (for all (p: orig_ps):
+    if (for all (p in orig_ps):
           p is_a StaticPict)
     | orig_ps
-    | let (ps, _) = make_concurrent(for List (p: orig_ps):
+    | let (ps, _) = make_concurrent(for List (p in orig_ps):
                                       cond
                                       | p == nothing: p
                                       | p is_a StaticPict: AnimPict(p)
@@ -1072,7 +1072,7 @@ class CombinePictEpoch(combine,
      CombinePictEpoch(combine, pad_combine, dt+1, orig_picts, orig_sustainings, [post, ...]),
      math.max(post_extent, ...)]     
   override metadata():
-    for values(metadata :~ Map = {}) (orig: origs):
+    for values(metadata :~ Map = {}) (orig in origs):
       metadata ++ orig.metadata()
 
 private.set_convert(
@@ -1080,14 +1080,14 @@ private.set_convert(
     // can assume that `nothing`s have been filtered out and `ps` is non-empty
     recur rebuild (ps :~ List = ps):
       let ([p :~ _AnimPict, ...] && [p0 :~ _AnimPict, & _], m_duration):
-        make_concurrent(for List (p: ps):
+        make_concurrent(for List (p in ps):
                           when p == nothing | error("nothing in convert!")
                           if p is_a StaticPict
                           | AnimPict(p)
                           | p,
                         ~epoch: ealign,
                         ~duration: dalign)
-      anim_pict(for List (i: 0..p0._epochs.length()):
+      anim_pict(for List (i in 0..p0._epochs.length()):
                   let dt = i - p0._duration_start
                   CombinePictEpoch(combine, pad_combine, dt, [p, ...], [p._sustaining, ...], [p._epochs[i], ...]),
                 p0._epoch_extents,

--- a/rhombus-pict-lib/rhombus/pict/private/explain_anim.rhm
+++ b/rhombus-pict-lib/rhombus/pict/private/explain_anim.rhm
@@ -31,8 +31,8 @@ fun explain_anim(p :: Pict,
 fun gen_times(start, end, steps, pre_extra, post_extra):
   let l:
     for List:
-      each i: start .. end
-      each step: 0 .. steps
+      each i in start .. end
+      each step in 0 .. steps
       if step == 0
       | i
       | i + (step * math.inexact(1/steps))
@@ -40,7 +40,7 @@ fun gen_times(start, end, steps, pre_extra, post_extra):
     if n == 0
     | []
     | for List:
-        each i: 1 ..= n
+        each i in 1 ..= n
         let j = i mod steps
         let delta:
           if j == 0

--- a/rhombus-pict-lib/rhombus/pict/private/static.rhm
+++ b/rhombus-pict-lib/rhombus/pict/private/static.rhm
@@ -379,7 +379,7 @@ class StaticPict(private _handle,
     | _children
 
   override property _children_starts:
-    for List (c: children):
+    for List (c in children):
       0
 
   override method launder() :~ Pict:
@@ -601,7 +601,7 @@ class NothingPict():
 def nothing = NothingPict()
 
 fun remove_nothings(ps :~ List):
-  for List (p: ps):
+  for List (p in ps):
     skip_when p == nothing
     p
 
@@ -624,7 +624,7 @@ fun static_instance([p :: Pict, ...], as_p :: _StaticPict,
 
 fun find_instance(p :: _StaticPict, q :~ Pict):
   recur loop (instances :: List = p._instances):
-    for any (inst: instances):
+    for any (inst in instances):
       match inst
       | Pair(key, handle):
           key === q && handle
@@ -797,7 +797,7 @@ fun overlay(~dx: dx :: maybe(Real) = #false,
             let (min_x, min_y, max_x, max_y):
               for values(min_x = init_x, min_y = init_y,
                          max_x = init_x, max_y = init_y):
-                each p: ps.rest
+                each p in ps.rest
                 let (x, y) = get_pt(p, 1)
                 values(math.min(min_x, x),
                        math.min(min_y, y),
@@ -1796,13 +1796,13 @@ fun table(rows :: List.of(List.of(Pict)),
       | let picts = [& picts]
         let col_length = rows.length()
         let ws:
-          for List (i: 0 .. row_length):
-            let [p, ...]: for List (r: 0 .. col_length):
+          for List (i in 0 .. row_length):
+            let [p, ...]: for List (r in 0 .. col_length):
                             picts[i + r * row_length]
             math.max(rkt.#{pict-width}(p), ...)
         let hs:
-          for List (i: 0 .. col_length):
-            let [p, ...]: for List (r: 0 .. row_length):
+          for List (i in 0 .. col_length):
+            let [p, ...]: for List (r in 0 .. row_length):
                             picts[r + i * row_length]
             math.max(rkt.#{pict-height}(p), ...)
         let r: rkt.inset(r, & if ins is_a List | ins | [ins])

--- a/rhombus-pict/rhombus/pict/scribblings/text.scrbl
+++ b/rhombus-pict/rhombus/pict/scribblings/text.scrbl
@@ -199,7 +199,7 @@ paragraph typesetting.
   @para{Say ``hello'' for me!}
   @para(~width: 50){Say ``hello'' for me!}
   @para(~width: 50, ~horiz: #'right){Say ``hello'' for me!}
-  para(& for List (i: 0..50): @t{Echo}.scale((50 - i)/50))
+  para(& for List (i in 0..50): @t{Echo}.scale((50 - i)/50))
   parameterize { current_font:
                    current_font() with (size = 18, kind = #'roman) }:
     para(@{There's a fine line between fishing},

--- a/rhombus-scribble-lib/rhombus/scribble/private/rhombus-spacer.rhm
+++ b/rhombus-scribble-lib/rhombus/scribble/private/rhombus-spacer.rhm
@@ -70,6 +70,7 @@ export:
       s_MutableSet as MutableSet
       s_WeakMutableSet as WeakMutableSet
     for
+    each
     import
     export
     Any
@@ -974,6 +975,18 @@ spacer.bridge WeakMutableSet.by(self, tail, context, esc):
 meta:
   def for_spaces = [#'#{rhombus/for_clause}, & body_spaces]
 
+  fun adjust_bind_each(s_g, context, esc):
+    match s_g
+    | '$s_bind ... $(s_body && ': $_')':
+        '$(spacer.adjust_sequence('$s_bind ...', #'~bind, esc))
+           $(spacer.adjust_term(s_body, context, esc))'.relocate_group(s_g)
+    | '$s_bind ... $(in_op && 'in') $s_expr ...':
+        '$(spacer.adjust_sequence('$s_bind ...', #'~bind, esc))
+           $in_op
+           $(spacer.adjust_sequence('$s_expr ...', context, esc))'.relocate_group(s_g)
+    | ~else:
+        spacer.adjust_group(s_g, context, esc)
+
 spacer.bridge for(self, tail, context, esc):
   ~in: ~expr
   match tail
@@ -987,11 +1000,10 @@ spacer.bridge for(self, tail, context, esc):
           '$kw $new_reduce'.relocate_group(into)
         ': $new_g; ...; $new_gn; $new_into'.relocate_group(b)
       '$self $new_b'
-  | '$reduce ... $(s && '($(s_g && '$s_bind ... $(s_body && ': $_')'), ...)') $(b && ': $g; ...; $gn')':
+  | '$reduce ... $(s && '($s_bind_each, ...)') $(b && ': $g; ...; $gn')':
       // shorthand form before body
-      let new_reduce = spacer.adjust_sequence('$reduce ...', #'~reducer, esc)
-      let new_s = '($('$(spacer.adjust_sequence('$s_bind ...', #'~bind, esc))
-                         $(spacer.adjust_term(s_body, context, esc))'.relocate_group(s_g)),
+      let new_reduce = spacer.adjust_sequence('$reduce ...', #'~reducer, esc)       
+      let new_s = '($(adjust_bind_each(s_bind_each, context, esc)),
                     ...)'.relocate(s)
       let new_b:
         let [new_g, ...] = [spacer.adjust_group(g, for_spaces, esc), ...]
@@ -1006,6 +1018,13 @@ spacer.bridge for(self, tail, context, esc):
         ': $new_g; ...; $new_gn'.relocate(b)
       '$self $new_reduce $new_b'
   | ~else: '$self $tail'
+
+spacer.bridge each(self, tail, context, esc):
+  ~in: ~for_clause
+  match tail
+  | '': self
+  | ~else:
+      '$self $(adjust_bind_each(tail, context, esc))'
 
 spacer.bridge import(self, tail, context, esc):
   ~in: ~defn

--- a/rhombus-scribble/rhombus/scribble/tests/rhombus-spacer.rhm
+++ b/rhombus-scribble/rhombus/scribble/tests/rhombus-spacer.rhm
@@ -1088,7 +1088,7 @@ check_spacer:
 
 check_spacer:
   for List:
-    each v: ["a", "b", "c"]
+    each v in ["a", "b", "c"]
     skip_when v == "b"
     v
   $(expr.full) $reducer:
@@ -1109,7 +1109,7 @@ check_spacer:
 
 check_spacer:
   for:
-    each v: ["a", "b", "c"]
+    each v in ["a", "b", "c"]
     skip_when v == "b"
     v
     ~into List

--- a/rhombus-slideshow-lib/slideshow/content.rhm
+++ b/rhombus-slideshow-lib/slideshow/content.rhm
@@ -27,7 +27,7 @@ module private:
 
 fun
 | nonarchival(p :: Pict) :~ Pict:
-    for values(p = p) (i: 0..p.duration):
+    for values(p = p) (i in 0..p.duration):
       nonarchival(p, i)
 | nonarchival(p :: Pict, epoch :: Int) :~ Pict:
     p.epoch_set_metadata(epoch, p.epoch_metadata(epoch) ++ { #'nonarchival: #true })
@@ -162,7 +162,7 @@ fun align_content(sep, horiz, contents):
   let [width, recorded :~ List]:
     recur gather_widths (cs :: List = contents):
       let (max_w, accum):
-        for values(max_w = 0, accum :~ List = []) (c: cs):
+        for values(max_w = 0, accum :~ List = []) (c in cs):
           match c
           | p :: Pict: values(math.max(max_w, p.width),
                               accum.add(p))
@@ -191,7 +191,7 @@ fun align_content(sep, horiz, contents):
   recur widen (w = width, sep = sep, cs :: List = recorded,
                widener = make_widener(width, horiz, values)):
     List.append(
-      & for List (c: cs):
+      & for List (c in cs):
         match c
         | p :: Pict:
             [widener(p)]

--- a/rhombus-slideshow/rhombus/slideshow/scribblings/show.rhm
+++ b/rhombus-slideshow/rhombus/slideshow/scribblings/show.rhm
@@ -49,10 +49,10 @@ block:
           rectangle(~around: p.scale(0.33), ~width: 150, ~height: 100)
         let p = switch(frame(p), ...)
         timeline(p, List.append(
-                      & for List (i: 0..p.duration):
+                      & for List (i in 0..p.duration):
                         if p.epoch_extent(i) == 0
                         | [i]
-                        | for List (j: 0..3):
+                        | for List (j in 0..3):
                             i + j/3))
   )
   #void

--- a/rhombus/rhombus/run.rhm
+++ b/rhombus/rhombus/run.rhm
@@ -5,6 +5,7 @@ import:
     expose:
       flag
       multi
+      help
       state
 
 fun file_to_mod_path(str :: String):
@@ -14,75 +15,167 @@ fun file_to_mod_path(str :: String):
         && ModulePath.try('file($base) $(List.append(['!', Symbol.from_string(submod)], ...))')
   | ~else: #false
 
+// Keys for `args` map
+enum S:
+  evals
+  leftover_args
+  action
+  repl
+  init_lib
+  no_lib
+  no_make
+  version
+
 def args :~ Map:
   cmdline.parse:
+    ~init: { S.evals: [],
+             S.init_lib: ModulePath 'rhombus' }
+    help:
+      "Evaluation options:\n"
     multi:
-      flag "-l" (mod_path :: cmdline.String.to_lib_module_path):
-        ~alias "--lib"
-        ~help (@str{Loads the collection-based module <mod_path>
-                    Use `!` at end to refer to a submodule.})
-        state[#'lib] := (state.get(#'lib, []) :~ List) ++ [mod_path]
-        state[#'eval] := #true
       flag "-f" path:
         ~alias "--file"
-        ~help (@str{Loads the module <path>.
-                    Use `!` at end to refer to a submodule.})
+        ~help (@str{Loads the module <path>, where `!` can appear in <path>
+                    as a submodule separator.})
         let mod_path = file_to_mod_path(path)
         unless mod_path
         | error(~who: to_string(cmdline.current_program()),
                 "expected a module path",
                 error.text(~label: "given", path),
                 error.text(~label: "for flag", cmdline.current_flag_string()))
-        state[#'lib] := (state.get(#'lib, []) :~ List) ++ [mod_path]
-        state[#'eval] := #true
+        when state[S.evals] == []
+        | state[S.no_lib] := #true
+        state[S.evals] := (state[S.evals] :~ List) ++ [mod_path]
+        state[S.action] := #true
       flag "-t" (path :: PathString):
         ~alias "--require"
-        ~help (@str{Loads the module <path> exactly, without treating
-                    `!` as a submodule separator.})
-        state[#'lib] := (state.get(#'lib, []) :~ List) ++ [ModulePath('file($path)')]
-        state[#'eval] := #true
+        ~help (@str{Loads the module <path> exactly, without treating `!`
+                    as a submodule separator.})
+        when state[S.evals] == []
+        | state[S.no_lib] := #true
+        state[S.evals] := (state[S.evals] :~ List) ++ [ModulePath('file($path)')]
+        state[S.action] := #true
+      flag "-l" (mod_path :: cmdline.String.to_lib_module_path):
+        ~alias "--lib"
+        ~help (@str{Loads the collection-based module <mod_path>, where `!` can
+                    be used in <mod_path> as a submodule separator.})
+        when state[S.evals] == []
+        | state[S.no_lib] := #true
+        state[S.evals] := (state[S.evals] :~ List) ++ [mod_path]
+        state[S.action] := #true
+      flag "-e" expr:
+        ~alias "--eval"
+        ~help (@str{Evaluates <expr>.})
+        state[S.evals] := (state[S.evals] :~ List) ++ [expr]
+        state[S.action] := #true
+    help:
+      "\nInteraction options:\n"
     flag "-i":
       ~alias "--repl"
-      ~key: #'repl
       ~help: "Run a read-eval-print-loop."
-    flag "-u":
-      ~alias "--no-make"
-      ~key: #'no_make
-      ~help: "Disable automatic compilation of modules."
+      state[S.repl] := #true
+      state[S.action] := #true
+    flag "-n":
+      ~alias "--no-lib"
+      ~help: "Skip load of <init-lib>."
+      state[S.no_lib] := #true
+      state[S.action] := #true
     flag "-v":
       ~alias "--version"
       ~help: "Show version."
-      state[#'version] := #true
-      state[#'eval] := #true
+      state[S.version] := #true
+      state[S.action] := #true
+    help:
+      "\nConfiguration options:\n"
+    flag "-I" (mod_path :: cmdline.String.to_lib_module_path):
+      ~help: "Set <init-lib> to <mod-path> (i.e., sets the language)."
+      state[S.init_lib] := mod_path
+    flag "-u":
+      ~alias "--no-make"
+      ~key: S.no_make
+      ~help: "Disable compilation of modules to \"compiled\" directories."
+    help:
+      "\nMeta options:\n"
+    help:
+      ~after_notation
+      "\n"
+        ++ (@str{Defaults:
+
+                   If only configuration options are provided, `-i` is added.
+                   If only configuration options are before the first argument, `-f` is added.
+                   If `-f`, `-t`, `or `-l` appear before the first `-e`, `-n` is added.
+                   The <init-lib> library defaults to `rhombus`.
+
+                 Startup sequence:
+
+                   1. Set `cmdline.current_command_line` to remaining non-flag arguments.
+                   2. Load compilation manager unless `-u` or no `-i`/`-f`/`-t`/`-l`/`-e`.
+                   3. Import <init-lib> unless `-n`.
+                   4. Perform `-f`/`-t`/`-l`/`-e` in order.
+                   5. Run read-eval-print loop when `-i`.
+
+                   During steps 3 and 4: Before loading the first module, load its
+                   `configure_runtime` module, if any. For any module, load its
+                   `main` submodule, if any, after loading the module.
+
+               })
+
     cmdline.args arg ...:
       let args = [arg, ...]
-      if !state.get(#'eval, #false) && (args.length() != 0)
+      if S.action !in state && (args.length() != 0)
       | let mp = file_to_mod_path(args.first)
         unless mp
         | error(~who: to_string(cmdline.current_program()),
                 "expected a module path as first argument",
                 error.text(~label: "given", args.first))
-        state[#'lib] := [mp]
-        state[#'args] := args.rest
-        state[#'eval] := #true
-      | state[#'args] := [arg, ...]
+        state[S.evals] := [mp]
+        state[S.leftover_args] := args.rest
+        state[S.action] := #true
+      | state[S.leftover_args] := [arg, ...]
 
-cmdline.current_command_line(args[#'args])
+cmdline.current_command_line(args[S.leftover_args])
 
-when args.get(#'version, #false) || !args.get(#'eval, #false)
+when S.version in args || S.action !in args
 | println(@str{Welcome to Rhombus v@(system.version())})
 
-when args.get(#'eval, #false) && !args.get(#'no_make, #false)
+when S.no_make in args && (S.repl in args || S.no_lib !in args || args[S.evals] != [])
 | let make:
     rkt.#{dynamic-require}(ModulePath('lib("compiler/private/cm-minimal.rkt")').s_exp(),
                            #'#{make-compilation-manager-load/use-compiled-handler})
   rkt.#{current-load/use-compiled}(make())
 
-for (mp :~ ModulePath: args.get(#'lib, []) :~ List):
+fun import_module(mp :~ ModulePath, can_configure):
+  fun try_load_submodule(mp :~ ModulePath, submod):
+    let rt_mp = mp.add(ModulePath('self ! $submod'))
+    when Evaluator.module_is_declared(rt_mp, ~load: #true)
+    | Evaluator.instantiate(rt_mp)
+  when can_configure
+  | try_load_submodule(mp, '#{configure-runtime}')
   Evaluator.import(mp)
+  try_load_submodule(mp, 'main')
 
-when args.get(#'repl, #false) || !args.get(#'eval, #false)
-| when !args.get(#'eval, #false)
-  | Evaluator.import(ModulePath 'rhombus')
-  Evaluator.import(ModulePath 'lib("racket/interactive.rkt")')
+def can_configure:
+  if S.no_lib in args
+  | #true
+  | import_module(args[S.init_lib], #true)
+    #false
+
+block:
+  for values(can_configure = can_configure) (e: args[S.evals] :~ List):
+    match e
+    | mp :: ModulePath:
+        import_module(mp, can_configure)
+        #false
+    | str :: String:
+        let shrubbery_read = Evaluator.instantiate(ModulePath 'rhombus/shrubbery',
+                                                   #'read)
+        let v = shrubbery_read(Port.Input.open_string(str),
+                               ~mode: #'interactive)
+        call_with_values(fun (): eval(v, ~as_interaction: #true),
+                         println)
+        can_configure
+  #void
+
+when S.repl in args || S.action !in args
+| Evaluator.import(ModulePath 'lib("racket/interactive.rkt")')
   rkt.#{read-eval-print-loop}()

--- a/rhombus/rhombus/run.rhm
+++ b/rhombus/rhombus/run.rhm
@@ -161,7 +161,7 @@ def can_configure:
     #false
 
 block:
-  for values(can_configure = can_configure) (e: args[S.evals] :~ List):
+  for values(can_configure = can_configure) (e in args[S.evals] :~ List):
     match e
     | mp :: ModulePath:
         import_module(mp, can_configure)

--- a/rhombus/rhombus/scribblings/guide/for.scrbl
+++ b/rhombus/rhombus/scribblings/guide/for.scrbl
@@ -21,7 +21,7 @@ from a starting integer (inclusive) to an ending integer (exclusive):
 
 @examples(
   for:
-    each i: 1..4
+    each i in 1..4
     println(i)
 )
 
@@ -29,7 +29,7 @@ As a shorthand, an initial @rhombus(each, ~for_clause) form can be written
 using parentheses before the @rhombus(for) body block:
 
 @examples(
-  for (i: 1..4):
+  for (i in 1..4):
     println(i)
 )
 
@@ -39,8 +39,8 @@ all elements are used for the second @rhombus(each, ~for_clause) clause, and so 
 
 @examples(
   for:
-    each friend: ["Alice", "Bob", "Carol"]
-    each say: ["Hello", "Goodbye"]
+    each friend in ["Alice", "Bob", "Carol"]
+    each say in ["Hello", "Goodbye"]
     println(say +& ", " +& friend +& "!")
 )
 
@@ -51,9 +51,9 @@ languages, is that definitions or expressions can be written among
 
 @examples(
   for:
-    each friend: ["Alice", "Bob", "Carol"]
+    each friend in ["Alice", "Bob", "Carol"]
     let dear_friend = "dear " +& friend
-    each say: ["Hello", "Goodbye"]
+    each say in ["Hello", "Goodbye"]
     println(say +& ", " +& dear_friend +& "!")
 )
 
@@ -63,8 +63,8 @@ immediately after @rhombus(each, ~for_clause).
 @examples(
   for:
     each:
-      friend: ["Alice", "Bob", "Carol"]
-      index: 1..4
+      friend in ["Alice", "Bob", "Carol"]
+      index in 1..4
     println(index +& ". " +& friend)
 )
 
@@ -73,8 +73,8 @@ Note that the shorthand form using parentheses for an initial
 since the short is for a single @rhombus(each, ~for_clause) clause:
 
 @examples(
-  for (friend: ["Alice", "Bob", "Carol"],
-       index: 1..4):
+  for (friend in ["Alice", "Bob", "Carol"],
+       index in 1..4):
     println(index +& ". " +& friend)
 )
 
@@ -91,11 +91,11 @@ accumulating the values produced by each iteration of the @rhombus(for)
 body.
 
 @examples(
-  for List (i: 1..4):
+  for List (i in 1..4):
     "number " +& i
   for List:
-    each i: [1, 2]
-    each j: ["a", "b", "c"]
+    each i in [1, 2]
+    each j in ["a", "b", "c"]
     [i, j]
 )
 
@@ -103,7 +103,7 @@ If you prefer, you can put the reducer at the end of a @rhombus(for)
 body with @rhombus(~into).
 
 @examples(
-  for (i: 1..4):
+  for (i in 1..4):
     "number " +& i
     ~into List
 )
@@ -113,8 +113,8 @@ body with @rhombus(~into).
 a value.
 
 @examples(
-  for Map (friend: ["alice", "bob", "carol"],
-           index: 1..):
+  for Map (friend in ["alice", "bob", "carol"],
+           index in 1..):
     values(index, friend)
 )
 
@@ -128,7 +128,7 @@ identifiers.
 
 @examples(
   fun sum(ns :~ List):
-    for values(sum = 0) (n: ns):
+    for values(sum = 0) (n in ns):
       sum+n
   sum([2, 3, 4])
 )
@@ -143,8 +143,8 @@ specialization is visible only as a change in performance, if at all.
 @examples(
   fun sum2d(nss :~ List.of(List.of(Number))):
     for values(sum = 0):
-      each ns: nss
-      each n: ns
+      each ns in nss
+      each n in ns
       sum+n
   sum2d([[1], [2, 3, 4], [5, 6, 7], [8, 9]])
 )

--- a/rhombus/rhombus/scribblings/guide/list.scrbl
+++ b/rhombus/rhombus/scribblings/guide/list.scrbl
@@ -22,12 +22,14 @@ A @brackets form as an expression creates a list:
 Operations on lists include functions like @rhombus(List.length), and
 some of those operations can be applied using @rhombus(.) directly on an
 expression that produces a list. The @rhombus(++) operator appends
-lists.
+lists. Lists support @tech(~doc: ref_doc){membership tests} with the
+@rhombus(in) operator.
 
 @examples(
    List.length(["a", "b", "c"])
    ["a", "b", "c"].length()
    ["a", "b"] ++ ["c", "d", "e"]
+   "b" in ["a", "b", "c"]
 )
 
 You can also use the @rhombus(List) constructor, which takes any number of

--- a/rhombus/rhombus/scribblings/guide/map.scrbl
+++ b/rhombus/rhombus/scribblings/guide/map.scrbl
@@ -13,7 +13,9 @@
 
 The @rhombus(Map) constructor creates an immutable mapping of arbitrary
 keys to values. A map is @tech(~doc: ref_doc){indexable} using @brackets with a key,
-and the result is the corresponding value.
+and the result is the corresponding value. A map also supports
+@tech(~doc: ref_doc){membership tests} with the @rhombus(in) operator to
+check whether a key has a value in the map.
 
 The @rhombus(Map) constructor can be used like a function, in which case
 it accepts keys paired with values in two-item lists to create a map:
@@ -29,6 +31,8 @@ it accepts keys paired with values in two-item lists to create a map:
     neighborhood["alice"]
     ~error:
       neighborhood["clara"]
+    "clara" in neighborhood
+    "alice" in neighborhood
 )
 
 Curly braces @braces can be used as a shorthand

--- a/rhombus/rhombus/scribblings/guide/more-arguments.scrbl
+++ b/rhombus/rhombus/scribblings/guide/more-arguments.scrbl
@@ -27,7 +27,7 @@ arguments:
   ~defn:
     fun add(x :~ Number, ...):
       for values(total = 0):
-        each v: [x, ...]
+        each v in [x, ...]
         total+v
   ~repl:
     add(1, 2, 3, 4)
@@ -64,7 +64,7 @@ its argument instead of @rhombus(...), like this:
   ~defn:
     fun add(& xs :~ List.of(Number)):
       for values(total = 0):
-        each v: xs
+        each v in xs
         total+v
   ~repl:
     add(1, 2, 3, 4)

--- a/rhombus/rhombus/scribblings/guide/set.scrbl
+++ b/rhombus/rhombus/scribblings/guide/set.scrbl
@@ -9,9 +9,8 @@
 When @braces is used with elements that do not
 have @colon to separate a key and value, then @braces creates a set. (If
 a set-element expression uses @colon, then it will need to be in
-parentheses to avoid being parsed as a key–value pair.) A set is @tech(~doc: ref_doc){indexable}
-with @brackets, where the set's elements act as indices to values of
-@rhombus(#true), while using any other value as an index produces @rhombus(#false).
+parentheses to avoid being parsed as a key–value pair.) A set
+supports @tech(~doc: ref_doc){membership tests} with the @rhombus(in) operator.
 There's a @rhombus(Set) constructor that's analogous to
 @rhombus(Map), but @rhombus(Set) accepts just values to include in the
 set. The @rhombus(++) operator effectively unions sets.
@@ -21,14 +20,14 @@ set. The @rhombus(++) operator effectively unions sets.
   ~defn:
     def friends = {"alice", "bob", "carol"}
   ~repl:
-    if friends["alice"] && friends["carol"]
+    if "alice" in friends && "carol" in friends
     | "I know both"
     | "Who are they?"
   ~defn:
     def new_friends = friends ++ {"david"}
   ~repl:
-    new_friends["david"]
-    friends["david"]
+    "david" in new_friends
+    "david" in friends
 )
 
 Using @rhombus(Set) explicitly before @braces

--- a/rhombus/rhombus/scribblings/reference/annotation.scrbl
+++ b/rhombus/rhombus/scribblings/reference/annotation.scrbl
@@ -101,12 +101,15 @@
 
 @doc(
   expr.macro '$expr is_a $annot'
+  non_target:
+    expr.macro '$expr !is_a $annot'
   operator_order:
     ~order: equivalence
 ){
 
  Produces @rhombus(#true) if the value of @rhombus(expr)
  satisfies @rhombus(annot), @rhombus(#false) otherwise.
+ The operator combination @rhombus(!is_a) inverts the test.
 
  If @rhombus(annot) is a @tech(~doc: guide_doc){converter annotation}, only the matching
  component of the annotation is used, and the converting part is not
@@ -178,7 +181,7 @@
   ~defn:
     fun
     | is_list_with_one(lst :: List):
-        lst.has_element(1)
+        lst.contains(1)
     | is_list_with_one(_):
         #false
   ~repl:

--- a/rhombus/rhombus/scribblings/reference/array.scrbl
+++ b/rhombus/rhombus/scribblings/reference/array.scrbl
@@ -10,8 +10,9 @@
 An @deftech{array} is @tech{indexable} using @brackets to access an array element
 by position (in constant time) via @rhombus(#%index), and it also support element
 assignment via @brackets and @rhombus(:=). An array also
-works with the @rhombus(++) operator to append arrays. An array can be
-used as @tech{sequence}, in which case it supplies its elements in
+works with the @rhombus(++) operator to append arrays.
+An array supports @tech{membership tests} using the @rhombus(in) operator.
+An array can be used as @tech{sequence}, in which case it supplies its elements in
 order.
 
 An array is normally mutable, but immutable arrays can originate from
@@ -222,6 +223,22 @@ contents, even if one is mutable and the other is immutable.
   a
   a[1] := "e"
   a
+)
+
+}
+
+
+@doc(
+  method (arr :: Array).contains(val :: Any,
+                                 eqls :: Function.of_arity(2) = (_ == _))
+    :: Boolean
+){
+
+ List @rhombus(List.contains), but for arrays. See also @rhombus(in).
+
+@examples(
+  Array("a", "b", "c").contains("b")
+  "b" in Array("a", "b", "c")
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/boolean.scrbl
+++ b/rhombus/rhombus/scribblings/reference/boolean.scrbl
@@ -118,9 +118,9 @@
  returns @rhombus(#false).
 
 @examples(
-  for any (i: 0..10):
+  for any (i in 0..10):
     i == 5 && to_string(i)
-  for any (i: 0..10):
+  for any (i in 0..10):
     i == 10
 )
 
@@ -240,9 +240,9 @@
  last iteration.
 
 @examples(
-  for all (i: 0..10):
+  for all (i in 0..10):
     i == 5
-  for all (i: 0..10):
+  for all (i in 0..10):
     i < 10 && to_string(i)
 )
 

--- a/rhombus/rhombus/scribblings/reference/boolean.scrbl
+++ b/rhombus/rhombus/scribblings/reference/boolean.scrbl
@@ -264,15 +264,25 @@
   operator (! (v :: Any)) :: Boolean
   operator_order:
     ~order: logical_negation
+  expr.macro '$expr !in $expr'
+  expr.macro '$expr !is_now $expr'
+  expr.macro '$expr !is_a $annot'
+  operator_order:
+    ~order: equivalence
 ){
 
- Returns @rhombus(#true) if @rhombus(v) is @rhombus(#false),
- @rhombus(#false) otherwise.
+ The prefix @rhombus(!) operator produces @rhombus(#true) if @rhombus(v)
+ is @rhombus(#false), @rhombus(#false) otherwise.
+
+ As an infix operator, @rhombus(!) modifies @rhombus(in),
+ @rhombus(is_now), or @rhombus(is_a). Any other infix use of @rhombus(!)
+ is an error.
 
 @examples(
   !#false
   !#true
   !"false"
+  1 !in [0, 2, 4]
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/dynamic-static.scrbl
+++ b/rhombus/rhombus/scribblings/reference/dynamic-static.scrbl
@@ -34,6 +34,11 @@
   @tech{list} or @tech{map} lookup), otherwise the lookup form is an
   error.}
 
+ @item{A static @rhombus(in) performs a @tech{membership test} only when
+  the test can be specialized statically (e.g., to a
+  @tech{set} or @tech{list} lookup), otherwise the membership test is an
+  error.}
+
  @item{A static @rhombus(++) works only when the append operation can be
   specialized statically (e.g., to a @tech{list} or @tech{map} append),
   otherwise the operator use is an error.}

--- a/rhombus/rhombus/scribblings/reference/equal.scrbl
+++ b/rhombus/rhombus/scribblings/reference/equal.scrbl
@@ -102,11 +102,14 @@ See also @secref("Equatables").
 @doc(
   operator ((v1 :: Any) is_now (v2 :: Any)) :: Boolean:
     ~order: equivalence
+  non_target:
+    expr.macro '$expr !is_now $expr'
   key_comp.def 'is_now'
 ){
 
  Reports whether @rhombus(v1) and @rhombus(v2) are equivalent @emph{now}
- in the sense that mutable fields of objects have the same values.
+ in the sense that mutable fields of objects have the same values. The
+ operator combination @rhombus(!is_now) inverts the test.
 
  Mutable and immutable strings, byte vectors, and arrays are considered
  the same if they have the same elements, even if one is mutable and the

--- a/rhombus/rhombus/scribblings/reference/export-macro.scrbl
+++ b/rhombus/rhombus/scribblings/reference/export-macro.scrbl
@@ -32,7 +32,7 @@
   ~defn:
     expo.macro 'range $(from :: Int) .. $(to :: Int): $id':
       let [name, ...]:
-        for List (i: from.unwrap()..to.unwrap()):
+        for List (i in from.unwrap()..to.unwrap()):
           Syntax.make_id(id +& i, id)
       'names: $name ...'
   ~repl:

--- a/rhombus/rhombus/scribblings/reference/for.scrbl
+++ b/rhombus/rhombus/scribblings/reference/for.scrbl
@@ -20,19 +20,17 @@
                 $body
                 ~into $reducer'
   grammar maybe_each:
-    ($bind:
-       $body
-       ...,
-     ...)
+    ($bind_each, ...)
     #,(epsilon)
+  grammar bind_each:
+    $bind in $expr
+    $bind:
+     $body
+     ...
   grammar clause_or_body:
-    #,(@rhombus(each, ~for_clause)) $bind:
-      $body
-      ...
+    #,(@rhombus(each, ~for_clause)) $bind_each
     #,(@rhombus(each, ~for_clause)):
-      $bind:
-        $body
-        ...
+      $bind_each
       ...
     #,(@rhombus(keep_when, ~for_clause)) $expr_or_block
     #,(@rhombus(skip_when, ~for_clause)) $expr_or_block
@@ -54,9 +52,10 @@
  iteration, and additional @rhombus(each, ~for_clause) groups form nested
  iterations.
 
- The block after a binding within an @rhombus(each, ~for_clause) clause must produce
+ The expression after @rhombus(in) or block after a binding within
+ an @rhombus(each, ~for_clause) clause must produce
  a @tech{sequence}. When @rhombus(for) is static (see
- @rhombus(use_static)), static information for the block must indicate
+ @rhombus(use_static)), static information for the expression or block must indicate
  a static sequence implementation that may specialize iteration over the
  sequence; see also @rhombus(Sequence, ~annot) and @rhombus(statinfo_meta.sequence_constructor_key).
  A fresh @tech{instantiation} of the sequence is used each
@@ -99,71 +98,73 @@
 
 @examples(
   ~repl:
+    for (v in ["a", "b", "c"]):
+      println(v)
     for (v: ["a", "b", "c"]):
       println(v)
     for:
-      each v: ["a", "b", "c"]
+      each v in ["a", "b", "c"]
       println(v)
     for:
-      each v: ["a", "b", "c"]
+      each v in ["a", "b", "c"]
       keep_when v == "b"
       println(v)
     for:
-      each v: ["a", "b", "c"]
+      each v in ["a", "b", "c"]
       skip_when v == "b"
       println(v)
     for:
-      each v: ["a", "b", "c"]
+      each v in ["a", "b", "c"]
       break_when v == "b"
       println(v)
     for:
-      each v: ["a", "b", "c"]
+      each v in ["a", "b", "c"]
       final_when v == "b"
       println(v)
-    for (v: ["a", "b", "c"],
-         i: 0..):
+    for (v in ["a", "b", "c"],
+         i in 0..):
       println(i +& ". " +& v)
     for:
       each:
-        v: ["a", "b", "c"]
-        i: 0..
+        v in ["a", "b", "c"]
+        i in 0..
       println(i +& ". " +& v)
   ~repl:
     fun grid(m, n):
       for List:
-        each i: 0..m
-        each j: 0..n
+        each i in 0..m
+        each j in 0..n
         [i, j]
     grid(2, 3)
   ~repl:
     fun sum(l :: List):
       for values(sum = 0):
-        each i: l
+        each i in l
         sum+i
     sum([2, 3, 4])
   ~repl:
     for:
-      each i: [1, 2, 3]
-      each j: 10..10+3
+      each i in [1, 2, 3]
+      each j in 10..10+3
       [i, j]
       ~into List
   ~repl:
     for values(x = 0, y = 2):
-      each j: 0..3
+      each j in 0..3
       values(x + y, j)
   ~repl:
     fun grid2(m, n):
       for List:
-        each i: 0..m
+        each i in 0..m
         let k = i + 1
-        each j: 0..n
+        each j in 0..n
         [k, j]
     grid2(2, 3)
   ~repl:
-    for Map (i: 0..3):
+    for Map (i in 0..3):
       values(i, i +& "!")
     for Map:
-      each i: 0..3
+      each i in 0..3
       values(i, i +& "!")
 )
 
@@ -171,14 +172,12 @@
 
 
 @doc(
+  ~nonterminal:
+    bind_each: for bind_each
   for_clause.macro 'each:
-                      $bind:
-                        $body
-                        ...
+                      $bind_each
                       ...'
-  for_clause.macro 'each $bind:
-                      $body
-                      ...'
+  for_clause.macro 'each $bind_each'
   for_clause.macro 'keep_when $expr'
   for_clause.macro 'keep_when: $body; ...'
   for_clause.macro 'skip_when $expr'

--- a/rhombus/rhombus/scribblings/reference/function.scrbl
+++ b/rhombus/rhombus/scribblings/reference/function.scrbl
@@ -364,10 +364,10 @@ Only one @rhombus(#,(@rhombus(~&, ~bind)) map_bind) can appear in a @rhombus(res
     fun fixnum_sum(ns :: List.of(Fixnum)) :: Fixnum:
       ~unsafe:
         // assume all fixnums and that result fits:
-        for values(res = 0) (n: ns):
+        for values(res = 0) (n in ns):
           res fixnum.(+) n
       // use generic arithmetic, check fixnum result at end:
-      for values(res = 0) (n: ns):
+      for values(res = 0) (n in ns):
           res + n
   ~repl:
     fixnum_sum([1, 2, 3])

--- a/rhombus/rhombus/scribblings/reference/indexable.scrbl
+++ b/rhombus/rhombus/scribblings/reference/indexable.scrbl
@@ -10,7 +10,7 @@
 
 An @deftech{indexable} value is one that supports @brackets afterward to
 extract an element at the index within @brackets. @tech{Maps},
-@tech{lists}, @tech{arrays}, @tech{sets}, @tech{strings}, and @tech{byte
+@tech{lists}, @tech{arrays}, @tech{strings}, and @tech{byte
  strings} are all indexable, as are instances of classes that implement
 @rhombus(Indexable, ~class).
 

--- a/rhombus/rhombus/scribblings/reference/list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/list.scrbl
@@ -18,7 +18,8 @@ construct a list.
 A list is @tech{indexable} using @brackets to access a list
 element by position---in @math{O(log N)} time---via
 @rhombus(#%index). A list also works with the @rhombus(++) operator
-to append lists. A list can be used as @tech{sequence}, in which case
+to append lists. A list supports @tech{membership tests} using
+the @rhombus(in) operator. A list can be used as @tech{sequence}, in which case
 it supplies its elements in order.
 
 @doc(
@@ -515,19 +516,21 @@ it supplies its elements in order.
 
 
 @doc(
-  method (lst :: List).has_element(v :: Any,
-                                   eqls :: Function.of_arity(2) = (_ == _))
+  method (lst :: List).contains(v :: Any,
+                                eqls :: Function.of_arity(2) = (_ == _))
     :: Boolean
 ){
 
  Returns @rhombus(#true) if @rhombus(lst) has an element equal to
  @rhombus(v), @rhombus(#false) otherwise, where @rhombus(eqls) determines
  equality. Searching the list takes @math{O(N)} time (multiplied by the
- cost of @rhombus(eqls)) to find an element as position @math{N}.
+ cost of @rhombus(eqls)) to find an element as position @math{N}. See
+ also @rhombus(in).
 
 @examples(
-  [1, 2, 3].has_element(2)
-  [1, 2, 3].has_element(200)
+  [1, 2, 3].contains(2)
+  [1, 2, 3].contains(200)
+  2 in [1, 2, 3]
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/map.scrbl
+++ b/rhombus/rhombus/scribblings/reference/map.scrbl
@@ -23,7 +23,9 @@ expression for the key within @brackets. Mutable maps can be
 updated with a combination of @brackets and @tech{assignment operators}
 such as @rhombus(:=) (but use @rhombus(++) to functionally update an
 immutable map). These uses of square brackets are implemented by
-@rhombus(#%index).  A map can be used as @tech{sequence}, in which case
+@rhombus(#%index).  A map is also supports @tech{membership tests} via
+@rhombus(in), which checks for keys (not values) the same as @rhombus(Map.has_key).
+A map can be used as @tech{sequence}, in which case
 it supplies a key and its associated value (as two result values)
 in an unspecified order.
 
@@ -550,16 +552,16 @@ in an unspecified order.
 
 
 @doc(
-  method (mp :: MutableMap).delete(key :: Any) :: Void
+  method (mp :: MutableMap).remove(key :: Any) :: Void
 ){
 
  Changes @rhombus(mp) to remove a mapping for @rhombus(key), if any.
 
 @examples(
   def m = MutableMap{"a": 1, "b": 2}
-  m.delete("c")
+  m.remove("c")
   m
-  m.delete("a")
+  m.remove("a")
   m
 )
 
@@ -568,14 +570,18 @@ in an unspecified order.
 
 @doc(
   method Map.has_key(mp :: ReadableMap, key :: Any) :: Boolean
+  method Map.contains(mp :: ReadableMap, key :: Any) :: Boolean
 ){
 
  Returns @rhombus(#true) if @rhombus(key) is mapped to a value in
- @rhombus(mp), @rhombus(#false) otherwise.
+ @rhombus(mp), @rhombus(#false) otherwise. The @rhombus(Map.contains)
+ method is a synonym for @rhombus(Map.has_key) and reflects how a
+ map supports @rhombus(in).
 
 @examples(
   Map.has_key({"a": 1, "b": 2}, "a")
   Map.has_key({"a": 1, "b": 2}, "c")
+  "a" in {"a": 1, "b": 2}
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/measure.scrbl
+++ b/rhombus/rhombus/scribblings/reference/measure.scrbl
@@ -34,7 +34,7 @@
   import rhombus/measure
   measure.time:
     for all:
-      each i: 0..10000000
+      each i in 0..10000000
       "useless"
 )
 
@@ -54,7 +54,7 @@
   import rhombus/measure
   measure.memory:
     for all:
-      each i: 0..10
+      each i in 0..10
       [1, 2]
 )
 

--- a/rhombus/rhombus/scribblings/reference/membership-testable.scrbl
+++ b/rhombus/rhombus/scribblings/reference/membership-testable.scrbl
@@ -1,0 +1,82 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@(def dots = @rhombus(..., ~bind))
+@(def dots_expr = @rhombus(...))
+
+@title{Membership Tests}
+
+A @deftech{membership test} uses the @rhombus(in) operator to check
+whether an element is included in the value. @tech{Maps}, @tech{lists},
+@tech{arrays}, and @tech{sets} all support membership tests, as do
+instances of classes that implement
+@rhombus(MembershipTestable, ~class).
+
+@doc(
+  ~nonterminal:
+    elem_expr: block expr
+  expr.macro '$elem_expr in $expr'
+  non_target:
+    expr.macro '$elem_expr !in $expr'
+  operator_order:
+    ~order: equivalence
+){
+
+ Checks whether the result of @rhombus(elem_expr) is a member of the
+ result of @rhombus(expr), where the latter is a value such as a set,
+ map, array, list, or @rhombus(MembershipTestable, ~class) object that
+ support @tech{membership tests}. The result is @rhombus(#true) for
+ @rhombus(in) if the element is present and @rhombus(#false) otherwise.
+ The operator combination @rhombus(!in) inverts the result relative to
+ @rhombus(in).
+
+ See also @rhombus(use_static).
+
+@examples(
+  "a" in {"a", "b"}
+  "c" !in {"a", "b"}
+  "a" in {"a": 1, "b": 2}
+  "a" in ["a", "b"]
+  1 in {"a": 1, "b": 2}
+)
+
+}
+
+
+@doc(
+  interface MembershipTestable
+){
+
+ An interface that a class can implement (publicly or privately) to make
+ instances of the class work with @rhombus(in). As an annotation,
+ @rhombus(MembershipTestable, ~annot) matches all objects that support
+ @tech{membership tests}, not just instances of classes that publicly
+ implement the @rhombus(MembershipTestable, ~class) interface.
+
+ The interface has a single abstract method:
+
+@itemlist(
+
+ @item{@rhombus(#,(@rhombus(contains, ~datum))(#,(@rhombus(val, ~var))))
+  --- checks for membership of @rhombus(val, ~var), which is normally
+  provided to the left of @rhombus(in). The result of the
+  @rhombus(contains) method must be a @rhombus(Boolean) value, and it
+  is the result of the @rhombus(in) form.}
+
+)
+
+@examples(
+  ~defn:
+    class Either(lst1, lst2):
+      private implements MembershipTestable
+      private override method contains(v):
+        v in lst1 || v in lst2
+  ~repl:
+    def lsts = Either([1, 2, 3], [-1, -2, -3])
+    2 in lsts
+    4 !in lsts
+)
+
+}

--- a/rhombus/rhombus/scribblings/reference/membership-testable.scrbl
+++ b/rhombus/rhombus/scribblings/reference/membership-testable.scrbl
@@ -32,6 +32,9 @@ instances of classes that implement
  The operator combination @rhombus(!in) inverts the result relative to
  @rhombus(in).
 
+ The @rhombus(in) operator is also recognized by @rhombus(for) and
+ @rhombus(each, ~for_clause) as part of the syntax of iteration.
+
  See also @rhombus(use_static).
 
 @examples(

--- a/rhombus/rhombus/scribblings/reference/mutable-list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/mutable-list.scrbl
@@ -359,8 +359,8 @@ and it is not managed by a lock.
 
 
 @doc(
-  method (mlst :: MutableList).has_element(v :: Any,
-                                           eqls :: Function.of_arity(2) = (_ == _))
+  method (mlst :: MutableList).contains(v :: Any,
+                                        eqls :: Function.of_arity(2) = (_ == _))
     :: Boolean
 ){
 
@@ -371,8 +371,8 @@ and it is not managed by a lock.
 
 @examples(
   def l = MutableList[1, 2, 3]
-  l.has_element(2)
-  l.has_element(200)
+  l.contains(2)
+  l.contains(200)
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/pair.scrbl
+++ b/rhombus/rhombus/scribblings/reference/pair.scrbl
@@ -423,8 +423,8 @@ list is a pair, a pair is a pair list only if its ``rest'' is a list.
 
 
 @doc(
-  method (lst :: PairList).has_element(v :: Any,
-                                       eqls :: Function.of_arity(2) = (_ == _))
+  method (lst :: PairList).contains(v :: Any,
+                                    eqls :: Function.of_arity(2) = (_ == _))
     :: Boolean
 ){
 
@@ -434,8 +434,8 @@ list is a pair, a pair is a pair list only if its ``rest'' is a list.
  cost of @rhombus(eqls)) to find an element as position @math{N}.
 
 @examples(
-  PairList[1, 2, 3].has_element(2)
-  PairList[1, 2, 3].has_element(200)
+  PairList[1, 2, 3].contains(2)
+  PairList[1, 2, 3].contains(200)
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/protocol.scrbl
+++ b/rhombus/rhombus/scribblings/reference/protocol.scrbl
@@ -12,6 +12,7 @@
 @include_section("sequence.scrbl")
 @include_section("appendable.scrbl")
 @include_section("comparable.scrbl")
+@include_section("membership-testable.scrbl")
 @include_section("printable.scrbl")
 @include_section("callable.scrbl")
 @include_section("closeable.scrbl")

--- a/rhombus/rhombus/scribblings/reference/range.scrbl
+++ b/rhombus/rhombus/scribblings/reference/range.scrbl
@@ -13,6 +13,9 @@ when the ending point is not @rhombus(#inf), the range is
 equal to the ending point, so that the lower bound is ``less than or
 equal to'' the upper bound by comparison on bounds.
 
+A range supports @tech{membership tests} using the @rhombus(in)
+operator, which is the same as @rhombus(Range.contains).
+
 @doc(
   annot.macro 'Range'
   annot.macro 'SequenceRange'
@@ -292,16 +295,17 @@ equal to'' the upper bound by comparison on bounds.
 
 
 @doc(
-  method (rge :: Range).has_element(int :: Int) :: Boolean
+  method (rge :: Range).contains(int :: Int) :: Boolean
 ){
 
  Checks whether @rhombus(rge) has @rhombus(int) in the range that it
- represents.
+ represents. See also @rhombus(in).
 
 @examples(
-  (3..=7).has_element(5)
-  (3..=7).has_element(7)
-  (3..=7).has_element(10)
+  (3..=7).contains(5)
+  (3..=7).contains(7)
+  (3..=7).contains(10)
+  5 in 3..=7
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/reducer-macro.scrbl
+++ b/rhombus/rhombus/scribblings/reference/reducer-macro.scrbl
@@ -39,7 +39,7 @@
     reducer.macro '(Array.len5)':
       'Array.of_length(5)'
   ~repl:
-    for Array.len5 (i: 0..3): i
+    for Array.len5 (i in 0..3): i
 )
 
  Here's an example that sums only the positive numbers that result
@@ -78,7 +78,7 @@
       '$new_accum'
   ~repl:
     for sum_pos_to_20 (a: [6, -4, 3]): a
-    for sum_pos_to_20 (a: 3..): a
+    for sum_pos_to_20 (a in 3..): a
 )
 
  @margin_note_block{It is recommended that a reducer macro only consume a
@@ -146,12 +146,12 @@
          def ($id, ...) = $finish $data
          values($count + 1, $id, ...)'
   ~repl:
-    for counted(List) (i: 0..3): i
+    for counted(List) (i in 0..3): i
   ~defn:
     :
       // static information is also chained
       def (map, count):
-        for counted(Map) (i: 0..10):
+        for counted(Map) (i in 0..10):
           keep_when i mod 2 == 0
           values(i, "val" +& i)
   ~repl:
@@ -162,7 +162,7 @@
   ~repl:
     :
       // cooperate with multiple-value reducers
-      for counted(values(i = 0, j = 10)) (k: 0..5):
+      for counted(values(i = 0, j = 10)) (k in 0..5):
         values(i+k, j-k)
 
 )

--- a/rhombus/rhombus/scribblings/reference/sequence.scrbl
+++ b/rhombus/rhombus/scribblings/reference/sequence.scrbl
@@ -124,7 +124,7 @@ internal state, and the state can even be specific to a particular
         ~position_to_next: fun (i): i + 2
       )
   ~repl:
-    for List (i: even_strings_up_to(5)): i
+    for List (i in even_strings_up_to(5)): i
 )
 
 }
@@ -152,7 +152,7 @@ internal state, and the state can even be specific to a particular
             ~position_to_next: fun (_): i := i + 2
           ))
   ~repl:
-    for List (i: even_strings_up_to(5)): i
+    for List (i in even_strings_up_to(5)): i
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/set.scrbl
+++ b/rhombus/rhombus/scribblings/reference/set.scrbl
@@ -14,15 +14,9 @@ which creates a set containing the values of the @rhombus(val_expr, ~var)s.
 More precisely, a use of curly braces with no preceding expression is
 parsed as an implicit use of the @rhombus(#%braces) form.
 
-A set is @tech{indexable}, and @brackets after a set
-expression with an expression for a value checks for membership: the result is a boolean
-indicating whether the value is in the set. Mutable sets can be updated
-with a combination of @brackets and the @rhombus(:=) operator, where
-a @rhombus(#false) result on the right-hand side of @rhombus(:=) removes an
-element from a set, and any other right-hand side result causes the value
-to be included in the set. (Use @rhombus(++) to functionally add to an
-immutable set.) These uses of @brackets are implemented by
-@rhombus(#%index). A set can be used as @tech{sequence}, in which case
+A set supports @tech{membership tests} with the @rhombus(in) operator.
+Use @rhombus(++) or @rhombus(Set.add) to functionally add to an
+immutable set. A set can be used as @tech{sequence}, in which case
 it supplies its elements in an unspecified order.
 
 @doc(
@@ -58,7 +52,7 @@ it supplies its elements in an unspecified order.
   annotation} given an annotations for elements; satisfaction of those
  annotations is confirmed only on demand, both for elements that are
  extracted from the set and for elements added or appended to the set.
- For @rhombus(Set.later_of), the key and value annotations must be
+ For @rhombus(Set.later_of, ~annot), the key and value annotations must be
  @tech(~doc: guide_doc){predicate annotations}. Since an element annotation is checked on
  every access, its static information is associated with access using
  @brackets.
@@ -110,9 +104,9 @@ it supplies its elements in an unspecified order.
 @examples(
   def s = Set{"x", 1, "y", 2}
   s
-  s["x"]
-  s[1]
-  s[42]
+  "x" in s
+  1 in s
+  42 in s
   Set("x", 1, "y", 2)
 )
 
@@ -207,10 +201,8 @@ it supplies its elements in an unspecified order.
 @examples(
   def m = MutableSet{"x", 1, "y", 2}
   m
-  m["x"]
-  m["x"] := #false
-  m
-  m["x"] := #true
+  "x" in m
+  m.remove("x")
   m
 )
 
@@ -285,18 +277,15 @@ it supplies its elements in an unspecified order.
 
 
 @doc(
-  method Set.get(st :: ReadableSet, val :: Any) :: Boolean
-  method Set.has_element(st :: ReadableSet, val :: Any) :: Boolean
+  method Set.contains(st :: ReadableSet, val :: Any) :: Boolean
 ){
 
- Equivalent to @rhombus(st[val]) (with the default implicit
- @rhombus(#%index) form). Returns @rhombus(#true) if @rhombus(val) is
+ Equivalent to @rhombus(val in st), returning @rhombus(#true) if @rhombus(val) is
  in @rhombus(st), @rhombus(#false) otherwise.
 
 @examples(
-  {"a", "b"}.get("a")
-  {"a", "b"}.has_element("a")
-  {"a", "b"}["a"]
+  {"a", "b"}.contains("a")
+  "a" in {"a", "b"}
 )
 
 }
@@ -355,6 +344,20 @@ it supplies its elements in an unspecified order.
 }
 
 @doc(
+  method (st :: Set).add(val :: Any) :: Set
+){
+
+ Returns a set like @rhombus(st) but with @rhombus(val) added if it is
+ not already present.
+
+@examples(
+  {1, 2, 3}.add(4)
+  {1, 2, 3}.add(2)
+)
+
+}
+
+@doc(
   method (st :: Set).remove(val :: Any) :: Set
 ){
 
@@ -370,20 +373,15 @@ it supplies its elements in an unspecified order.
 
 
 @doc(
-  method (st :: MutableSet).set(val :: Any, in :: Any)
+  method (st :: MutableSet).add(val :: Any)
     :: Void
 ){
 
- Equivalent to @rhombus(st[val] := in) (with the default implicit
- @rhombus(#%index) form). Changes @rhombus(st) to remove
- @rhombus(val) if @rhombus(in) is @rhombus(#false), otherwise add
- @rhombus(val).
+ Changes @rhombus(st) to add @rhombus(val) to the set.
 
 @examples(
   def s = MutableSet{1, 2, 3}
-  s.set(1, #false)
-  s
-  s[1] := #true
+  s.add(1)
   s
 )
 
@@ -391,7 +389,7 @@ it supplies its elements in an unspecified order.
 
 
 @doc(
-  method (st :: MutableSet).delete(val :: Any)
+  method (st :: MutableSet).remove(val :: Any)
     :: Void
 ){
 
@@ -399,7 +397,7 @@ it supplies its elements in an unspecified order.
 
 @examples(
   def s = MutableSet{1, 2, 3}
-  s.delete(2)
+  s.remove(2)
   s
 )
 

--- a/rhombus/rhombus/scribblings/reference/stxobj.scrbl
+++ b/rhombus/rhombus/scribblings/reference/stxobj.scrbl
@@ -709,8 +709,8 @@ class's name.
                     | '~max_args: $(max :: Int)')':
       'fun $(Syntax.make(
                [#'alts,
-                & for List (i: min.unwrap() ..= (max || min).unwrap()):
-                  let [var, ...] = for List (j: i): Syntax.make_temp_id()
+                & for List (i in min.unwrap() ..= (max || min).unwrap()):
+                  let [var, ...] = for List (j in i): Syntax.make_temp_id()
                   ': ($var, ...): [$var, ...]']
              ))'
   ~repl:

--- a/rhombus/rhombus/tests/annotation.rhm
+++ b/rhombus/rhombus/tests/annotation.rhm
@@ -1,5 +1,10 @@
 #lang rhombus
 
+check:
+  1 is_a Int ~is #true
+  1 !is_a Int ~is #false
+  1 !is_a Flonum ~is #true
+
 // check for sensible precedence of `is_a` mixed with expression
 check:
   "a" is_a String && #true ~is #true

--- a/rhombus/rhombus/tests/array.rhm
+++ b/rhombus/rhombus/tests/array.rhm
@@ -338,15 +338,15 @@ block:
   use_static
   def arr = Array("a", "b", "c")
   check:
-    for List (x: arr):
+    for List (x in arr):
       x
     ~is ["a", "b", "c"]
   check:
-    for List (x: Array.to_sequence(arr)):
+    for List (x in Array.to_sequence(arr)):
       x
     ~is ["a", "b", "c"]
   check:
-    for List (x: arr.to_sequence()):
+    for List (x in arr.to_sequence()):
       x
     ~is ["a", "b", "c"]
 
@@ -366,7 +366,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: "oops" :~ Array):
+    for List (x in "oops" :~ Array):
       x
     ~throws values(
       "Array.to_sequence: " ++ error.annot_msg(),
@@ -375,7 +375,7 @@ version_guard.at_least "8.13.0.1":
     )
 
   check:
-    for List (x: Array.to_sequence("oops")):
+    for List (x in Array.to_sequence("oops")):
       x
     ~throws values(
       "Array.to_sequence: " ++ error.annot_msg(),
@@ -383,7 +383,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: ("oops" :~ Array).to_sequence()):
+    for List (x in ("oops" :~ Array).to_sequence()):
       x
     ~throws values(
       "Array.to_sequence: " ++ error.annot_msg(),

--- a/rhombus/rhombus/tests/array.rhm
+++ b/rhombus/rhombus/tests/array.rhm
@@ -10,6 +10,7 @@ block:
     Array.length(arr) ~method
     Array.get(arr, n) ~method
     Array.set(arr, n, v) ~method
+    Array.contains(arr, v, [eql]) ~method
     Array.append(arr, ...) ~method
     Array.copy(arr, [start], [end]) ~method
     Array.copy_from(dest_arr, dest_start, src_arr, [src_start], [src_end]) ~method
@@ -216,6 +217,14 @@ check:
   Array.append(Array(1), Array(2)) ~is_now Array(1, 2)
   Array.append(Array(1), Array(2), Array(3)) ~is_now Array(1, 2, 3)
   Array.append(Array(1), Array(2), Array(3), Array(4)) ~is_now Array(1, 2, 3, 4)
+
+check:
+  Array(10, 20, 30).contains(20) ~is #true
+  Array(10, 20, 30).contains(2) ~is #false
+  20 in Array(10, 20, 30) ~is #true
+  2 in Array(10, 20, 30) ~is #false
+  20 !in Array(10, 20, 30) ~is #false
+  2 !in Array(10, 20, 30) ~is #true
 
 check:
   10 :: Array

--- a/rhombus/rhombus/tests/boolean.rhm
+++ b/rhombus/rhombus/tests/boolean.rhm
@@ -1,6 +1,12 @@
 #lang rhombus
 
 check:
+  [1] is_now [1] ~is #true
+  [1] !is_now [1] ~is #false
+  [1] is_now [2] ~is #false
+  [1] !is_now [2] ~is #true
+
+check:
   #false || !(#false || #false) ~is #true
   #false && !(#false || #false) ~is #false
   any(#false, 1) ~is 1
@@ -25,6 +31,7 @@ check:
 check:
   1 is_a Int && 2 is_a Int ~is #true
   1 is_a Int || 2 is_a Int ~is #true
+  1 !is_a Int || 2 !is_a Int ~is #false
   1 is_a String && 2 is_a Int ~is #false
   1 is_a Int && 2 is_a String ~is #false
   1 is_a String || 2 is_a Int ~is #true
@@ -62,3 +69,8 @@ block:
   check:
     Function.pass(x || println("reached: " +& y), ...)
     ~prints "reached: 3\n"
+
+check:
+  ~eval
+  1 ! = 2
+  ~throws "expected a negatable operator"

--- a/rhombus/rhombus/tests/bytes.rhm
+++ b/rhombus/rhombus/tests/bytes.rhm
@@ -124,15 +124,15 @@ block:
   use_static
   def bstr = #"123"
   check:
-    for List (x: bstr):
+    for List (x in bstr):
       x
     ~is [49, 50, 51]
   check:
-    for List (x: Bytes.to_sequence(bstr)):
+    for List (x in Bytes.to_sequence(bstr)):
       x
     ~is [49, 50, 51]
   check:
-    for List (x: bstr.to_sequence()):
+    for List (x in bstr.to_sequence()):
       x
     ~is [49, 50, 51]
 
@@ -152,7 +152,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: "oops" :~ Bytes):
+    for List (x in "oops" :~ Bytes):
       x
     ~throws values(
       "Bytes.to_sequence: " ++ error.annot_msg(),
@@ -160,7 +160,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: Bytes.to_sequence("oops")):
+    for List (x in Bytes.to_sequence("oops")):
       x
     ~throws values(
       "Bytes.to_sequence: " ++ error.annot_msg(),
@@ -168,7 +168,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: ("oops" :~ Bytes).to_sequence()):
+    for List (x in ("oops" :~ Bytes).to_sequence()):
       x
     ~throws values(
       "Bytes.to_sequence: " ++ error.annot_msg(),

--- a/rhombus/rhombus/tests/composite-statinfo.rhm
+++ b/rhombus/rhombus/tests/composite-statinfo.rhm
@@ -8,15 +8,15 @@ block:
         println(v)
     fun print_all_lst(lst):
       let [& rst] && all = lst
-      for (v: all):
+      for (v in all):
         println(v)
-      for (v: rst):
+      for (v in rst):
         println(v)
     fun print_all_set(set):
       let Set{& rst} && all = set
-      for (v: all):
+      for (v in all):
         println(v)
-      for (v: rst):
+      for (v in rst):
         println(v)
     fun print_all_map(map):
       let Map{& rst} && all = map
@@ -26,15 +26,15 @@ block:
         println(k +& ": " +& v)
     fun print_all_cons_lst(lst):
       let List.cons(_, rst) && all = lst
-      for (v: all):
+      for (v in all):
         println(v)
-      for (v: rst):
+      for (v in rst):
         println(v)
     ~completes
 
   check:
     def [& xs] = (["a", "b", "cd"] :: List.of(String))
-    for List (x: xs):
+    for List (x in xs):
       x.length()
     ~is [1, 1, 2]
 
@@ -45,13 +45,13 @@ block:
 
   check:
     def [& xs :: List.of(String)] = ["a", "b", "cd"]
-    for List (x: xs):
+    for List (x in xs):
       x.length()
     ~is [1, 1, 2]
 
   check:
     def [x :: String, ...] && xs = ["a", "b", "cd"]
-    [x.length(), ...] == (for List (x: xs):
+    [x.length(), ...] == (for List (x in xs):
                             x.length())
     ~is #true
 
@@ -89,7 +89,7 @@ block:
 
   check:
     def Set{& set} = ({"a", "b", "cd"} :: Set.of(String))
-    for Set (val: set):
+    for Set (val in set):
       val.length()
     ~is {1, 2}
 
@@ -106,6 +106,6 @@ block:
 
   check:
     def {val :: String, ...} && set = {"a", "b", "cd"}
-    {val.length(), ...} == (for Set (val: set):
+    {val.length(), ...} == (for Set (val in set):
                               val.length())
     ~is #true

--- a/rhombus/rhombus/tests/dot-macro.rhm
+++ b/rhombus/rhombus/tests/dot-macro.rhm
@@ -149,12 +149,12 @@ dot.macro 'myint2_dot_provider $left $dot $right':
                              $use_depth,
                              ())')
     match '$right $tail ...'
-    | 'is_zero $tail ...': values(make('for List (v: ($expr :~ List)): v .= 0'),
+    | 'is_zero $tail ...': values(make('for List (v in ($expr :~ List)): v .= 0'),
                                   '$tail ...')
     | 'add($(right :: repet_meta.Parsed)) $tail ...':
         // assumes a depth-1 `right`, too
         let '($_, $r_expr, $r_depth, $r_use_depth, $_)' = repet_meta.unpack_list(right)
-        values(make('for List (v: ($expr :~ List),
+        values(make('for List (v in ($expr :~ List),
                                r_v: ($r_expr :~ List)):
                        v + r_v'),
                '$tail ...')

--- a/rhombus/rhombus/tests/equality-map-set.rhm
+++ b/rhombus/rhombus/tests/equality-map-set.rhm
@@ -76,17 +76,17 @@ block:
     ~is "b"
 
 check:
-  {[1, 2]}[[1, 2]]
+  [1, 2] in {[1, 2]}
   ~is #true
 
 check:
-  {mcons(1, 2)}[mcons(1, 2)]
+  mcons(1, 2) in {mcons(1, 2)}
   ~is #false
 
 check:
   block:
     def v = mcons(1, 2)
-    {v}[v]
+    v in {v}
   ~is #true
 
 block:
@@ -95,13 +95,13 @@ block:
   def c = mcons(1, 2)
   def s = {a, b}
   check:
-    s[a]
+    a in s
     ~is #true
   check:
-    s[b]
+    b in s
     ~is #true
   check:
-    s[c]
+    c in s
     ~is #false
 
 // empty map, not empty set

--- a/rhombus/rhombus/tests/example-interp-ast.rhm
+++ b/rhombus/rhombus/tests/example-interp-ast.rhm
@@ -217,7 +217,7 @@ fun lookup(n, env):
 #//
 fun lookup(n, env):
   // using `for`
-  (for any (b: (env :~ List)):
+  (for any (b in (env :~ List)):
      (n == bind.name(b)) && bind.val(b))
     || error(#'lookup, "free variable: " +& n)
 

--- a/rhombus/rhombus/tests/filesystem.rhm
+++ b/rhombus/rhombus/tests/filesystem.rhm
@@ -187,7 +187,7 @@ block:
   | check filesystem.roots() ~is [Path("/")]
 
   check filesystem.rename(x, tmp.add("x_new")) ~is #void
-  check filesystem.files(tmp) ~is (for List (f: all_immediate_files):
+  check filesystem.files(tmp) ~is (for List (f in all_immediate_files):
                                      if f == Path("x")
                                      | Path("x_new")
                                      | f)
@@ -282,14 +282,14 @@ block:
     let inode = filesystem.identity(x)
     block:
       Closeable.let f = Port.Output.open_file(x, ~exists: #'truncate)
-      for (i: 0..4096):
+      for (i in 0..4096):
         println("hello world", ~out: f)
     check filesystem.identity(x) ~is inode
   check filesystem.size(x) ~is 12*4096
-  check filesystem.read_bytes(x) ~is_now Bytes.append(& for List (i: 0..4096): #"hello world\n")
-  check filesystem.read_string(x) ~is String.append(& for List (i: 0..4096): "hello world\n")
-  check filesystem.read_bytes_lines(x) ~is_now for List (i: 0..4096): #"hello world"
-  check filesystem.read_lines(x) ~is for List (i: 0..4096): "hello world"
+  check filesystem.read_bytes(x) ~is_now Bytes.append(& for List (i in 0..4096): #"hello world\n")
+  check filesystem.read_string(x) ~is String.append(& for List (i in 0..4096): "hello world\n")
+  check filesystem.read_bytes_lines(x) ~is_now for List (i in 0..4096): #"hello world"
+  check filesystem.read_lines(x) ~is for List (i in 0..4096): "hello world"
 
   check filesystem.write_bytes(x, #"hello world") ~throws "filesystem.write_bytes:"
   check filesystem.write_bytes(x, #"hello world", ~exists: #'truncate) ~is #void

--- a/rhombus/rhombus/tests/for.rhm
+++ b/rhombus/rhombus/tests/for.rhm
@@ -21,15 +21,32 @@ block:
   def mutable accum = []
   check:
     for:
-      each i: 0..2
+      each i in 0..2
       accum := List.cons(i, accum)
     accum
     ~is [1, 0]
   check:
+    for:
+      each i: 0..2
+      accum := List.cons(i, accum)
+    accum
+    ~is [1, 0, 1, 0]
+  check:
+    for (i in 0..2):
+      accum := List.cons(i + 10, accum)
+    accum
+    ~is [11, 10, 1, 0, 1, 0]
+  check:
     for (i: 0..2):
       accum := List.cons(i + 10, accum)
     accum
-    ~is [11, 10, 1, 0]
+    ~is [11, 10, 11, 10, 1, 0, 1, 0]
+
+check:
+  for List:
+    each i in 0..2
+    i
+  ~is [0, 1]
 
 check:
   for List:
@@ -39,14 +56,22 @@ check:
 
 check:
   for List:
-    each i: dynamic(0..2)
+    each i in dynamic(0..2)
     i
   ~is [0, 1]
 
 check:
-  for List (i: 0..2):
+  for List (i in 0..2):
     i
   ~is [0, 1]
+
+check:
+  for List:
+    each:
+      i in -2..
+      _ in 0..2
+    i
+  ~is [-2, -1]
 
 check:
   for List:
@@ -59,76 +84,76 @@ check:
 check:
   for List:
     each:
-      i: dynamic(-2..)
-      _: 0..2
+      i in dynamic(-2..)
+      _ in 0..2
     i
   ~is [-2, -1]
 
 check:
-  for List (i: -2..,
-            _: 0..2):
+  for List (i in -2..,
+            _ in 0..2):
     i
   ~is [-2, -1]
 
 check:
   for List:
-    each i: 0..=2
+    each i in 0..=2
     i
   ~is [0, 1, 2]
 
 check:
   for List:
-    each i: dynamic(0..=2)
+    each i in dynamic(0..=2)
     i
   ~is [0, 1, 2]
 
 check:
-  for List (i: 0..=2):
+  for List (i in 0..=2):
     i
   ~is [0, 1, 2]
 
 check:
   for Map:
-    each i: 0..2
+    each i in 0..2
     values(i, "" +& i)
   ~is {0: "0", 1: "1"}
 
 check:
-  for Map (i: 0..2):
+  for Map (i in 0..2):
     values(i, "" +& i)
   ~is {0: "0", 1: "1"}
 
 check:
   for:
-    each i: 0..2
+    each i in 0..2
     i
     ~into List
   ~is [0, 1]
 
 check:
-  for (i: 0..2):
+  for (i in 0..2):
     i
     ~into List
   ~is [0, 1]
 
 check:
   for List:
-    each i: 0..2
-    each j: 0..2
+    each i in 0..2
+    each j in 0..2
     [i, -j-1]
   ~is [[0, -1], [0, -2], [1, -1], [1, -2]]
 
 check:
   for List:
     each:
-      i: 0..2
-      j: 0..2
+      i in 0..2
+      j in 0..2
     [i, -j-1]
   ~is [[0, -1], [1, -2]]
 
 check:
-  for List (i: 0..2,
-            j: 0..2):
+  for List (i in 0..2,
+            j in 0..2):
     [i, -j-1]
   ~is [[0, -1], [1, -2]]
 
@@ -136,82 +161,82 @@ check:
   for List:
     def len = 2
     each:
-      i: 0..len
-      j: 0..len
+      i in 0..len
+      j in 0..len
     [i, -j-1]
   ~is [[0, -1], [1, -2]]
 
 check:
   for List:
-    each i: 0..2
+    each i in 0..2
     def i_plus = i+1
-    each j: 0..2
+    each j in 0..2
     [i_plus, -j-1]
   ~is [[1, -1], [1, -2], [2, -1], [2, -2]]
 
 check:
-  for List (i: 0..2):
+  for List (i in 0..2):
     def i_plus = i+1
-    each j: 0..2
+    each j in 0..2
     [i_plus, -j-1]
   ~is [[1, -1], [1, -2], [2, -1], [2, -2]]
 
 check:
   for List:
-    each i: 0..2
+    each i in 0..2
     def i_len = i+1
-    each j: 0..i_len
+    each j in 0..i_len
     [i, -j-1]
   ~is [[0, -1], [1, -1], [1, -2]]
 
 check:
   for values(sum = 0):
-    each i: 0..4
+    each i in 0..4
     sum + i
   ~is 6
 
 check:
-  for values(sum = 0) (i: 0..4):
+  for values(sum = 0) (i in 0..4):
     sum + i
   ~is 6
 
 check:
   for values(sum = 0, parity = #true):
-    each i: 0..4
+    each i in 0..4
     values(sum + i, !parity)
   ~is values(6, #true)
 
 check:
   for values(sum = 0):
-    each i: 0..4
+    each i in 0..4
     keep_when i != 1
     sum + i
   ~is 5
 
 check:
   for values(sum = 0):
-    each i: 0..4
+    each i in 0..4
     skip_when i == 1
     sum + i
   ~is 5
 
 check:
   for values(sum = 0):
-    each i: 0..8
+    each i in 0..8
     break_when i == 4
     sum + i
   ~is 6
 
 check:
   for values(sum = 0):
-    each i: 0..8
+    each i in 0..8
     final_when i == 4
     sum + i
   ~is 10
 
 check:
   for values(sum = 0):
-    each i: 0..8
+    each i in 0..8
     def new_sum = sum + i
     final_when i == 4
     def result = new_sum + 1
@@ -222,7 +247,7 @@ check:
   use_static
   def set:
     for values(set :~ Set = dynamic({1, 4, 9, 16, 25})):
-      each i: 0..8
+      each i in 0..8
       if i in set | set.remove(i) | set
   set ++ {36}
   ~is {9, 16, 25, 36}
@@ -231,7 +256,7 @@ check:
   use_static
   def set:
     for values(set :: Set = dynamic({1, 4, 9, 16, 25})):
-      each i: 0..8
+      each i in 0..8
       if i in set | set.remove(i) | set
   set ++ {36}
   ~is {9, 16, 25, 36}
@@ -240,7 +265,7 @@ version_guard.at_least "8.11.1.4":
   check:
     use_static
     for values(set :~ Set = dynamic({1, 4, 9, 16, 25})):
-      each i: 0..8
+      each i in 0..8
       keep_when i in set
       set.remove(i)
     ~is {9, 16, 25}
@@ -249,38 +274,38 @@ version_guard.at_least "8.11.1.4":
   check:
     use_static
     for values(set :: Set = dynamic({1, 4, 9, 16, 25})):
-      each i: 0..8
+      each i in 0..8
       keep_when i in set
       set.remove(i)
     ~is {9, 16, 25}
 
 check:
   for values(_ = 0, _ = 0+1):
-    each i: 0..8
+    each i in 0..8
     values(i, i+1)
   ~is values(7, 8)
 
 check:
   for values(_ :~ Int = 0, _ :~ Int = 0+1):
-    each i: 0..8
+    each i in 0..8
     values(i, i+1)
   ~is values(7, 8)
 
 check:
   for values(_ :: Int = 0, _ :: Int = 0+1):
-     each i: 0..8
+     each i in 0..8
      values(i, i+1)
   ~is values(7, 8)
 
 check:
   for values(_ :~ Int = 0, _ :~ Int = 0+1):
-    each _: 0..8
+    each _ in 0..8
     values("oops", "oh no")
   ~is values("oops", "oh no")
 
 check:
   for values(_ :~ Int = 0, _ :: Int = 0+1):
-    each _: 0..8
+    each _ in 0..8
     values("oops", "oh no")
   ~throws values(
     "value does not satisfy annotation",
@@ -290,7 +315,7 @@ check:
 
 check:
   for values(_ :: Int = 0, _ :: Int = 0+1):
-    each _: 0..8
+    each _ in 0..8
     values("oops", "oh no")
   ~throws values(
     "value does not satisfy annotation",
@@ -300,13 +325,13 @@ check:
 
 check:
   for values(_ :~ Int = "oops", _ :~ Int = "oh no"):
-    each i: 0..8
+    each i in 0..8
     values(i, i+1)
   ~is values(7, 8)
 
 check:
   for values(_ :~ Int = "oops", _ :: Int = "oh no"):
-    each i: 0..8
+    each i in 0..8
     values(i, i+1)
   ~throws values(
     "value does not satisfy annotation",
@@ -316,7 +341,7 @@ check:
 
 check:
   for values(_ :: Int = "oops", _ :: Int = "oh no"):
-    each i: 0..8
+    each i in 0..8
     values(i, i+1)
   ~throws values(
     "value does not satisfy annotation",
@@ -326,7 +351,7 @@ check:
 
 check:
   for values(_: println("first"); 0, _: println("second"); 0+1):
-    each i: 0..8
+    each i in 0..8
     println(i)
     values(i, i+1)
   ~prints "first\nsecond\n0\n1\n2\n3\n4\n5\n6\n7\n"
@@ -336,8 +361,8 @@ check:
   class Posn(x, y)
   fun point_xs(l :~ List.of(List.of(Posn))):
     for:
-      each ll: l
-      each p: ll
+      each ll in l
+      each p in ll
       p.x
       ~into List
   point_xs([[Posn(1, 2), Posn(0, 5)], [], [Posn(3, 3)]])
@@ -345,65 +370,65 @@ check:
 
 check:
   for Set:
-    each values(key, val): {1: "a", 2: "b"}
+    each values(key, val) in {1: "a", 2: "b"}
     key +& " -> " +& val
   ~is {"1 -> a", "2 -> b"}
 
 check:
   for Set:
-    each (key, val): {3: "c", 4: "d"}
+    each (key, val) in {3: "c", 4: "d"}
     key +& " -> " +& val
   ~is {"3 -> c", "4 -> d"}
 
 check:
-  for Set ((key, val): {3: "c", 4: "d"}):
+  for Set ((key, val) in {3: "c", 4: "d"}):
     key +& " -> " +& val
   ~is {"3 -> c", "4 -> d"}
 
 check:
   for Map:
-    each key: {3, 4}
+    each key in {3, 4}
     values(key, key+1)
   ~is {3: 4, 4: 5}
 
 check:
   for Array:
-    each i: 3..7
+    each i in 3..7
     i
   ~is_now Array(3, 4, 5, 6)
 
 check:
   for Array.of_length(6):
-    each i: 3..7
+    each i in 3..7
     i
   ~is_now Array(3, 4, 5, 6, 0, 0)
 
 check:
   for Array.of_length(1 + 5):
-    each i: 3..7
+    each i in 3..7
     i
   ~is_now Array(3, 4, 5, 6, 0, 0)
 
 check:
-  for Array.of_length(6) (i: 3..7):
+  for Array.of_length(6) (i in 3..7):
     i
   ~is_now Array(3, 4, 5, 6, 0, 0)
 
 check:
-  for Array.of_length(6, ~fill: 42) (i: 3..7):
+  for Array.of_length(6, ~fill: 42) (i in 3..7):
     i
   ~is_now Array(3, 4, 5, 6, 42, 42)
 
 check:
   for Array.of_length(2):
-    each i: 3..7
+    each i in 3..7
     i
   ~throws "index is out of range"
 
 check:
   def mutable accum = []
   [for all:
-     each i: 0..10
+     each i in 0..10
      accum := List.cons(i, accum)
      i > -1 && i,
    accum]
@@ -412,21 +437,21 @@ check:
 check:
   def mutable accum = []
   [for all:
-     each i: 0..10
+     each i in 0..10
      accum := List.cons(i, accum)
      i < 6,
    accum]
   ~is [#false, [6, 5, 4, 3, 2, 1, 0]]
 
 check:
-  for all (i: 0..10):
+  for all (i in 0..10):
     i < 10
   ~is #true
 
 check:
   def mutable accum = []
   [for any:
-     each i: 0..10
+     each i in 0..10
      accum := List.cons(i, accum)
      i > 9,
    accum]
@@ -435,14 +460,14 @@ check:
 check:
   def mutable accum = []
   [for any:
-     each i: 0..10
+     each i in 0..10
      accum := List.cons(i, accum)
      i > 5 && i,
    accum]
   ~is [6, [6, 5, 4, 3, 2, 1, 0]]
 
 check:
-  for any (i: 0..10):
+  for any (i in 0..10):
     i == 5
   ~is #true
 
@@ -450,27 +475,27 @@ check:
   ~eval
   use_static
   for:
-    each x: dynamic([1])
+    each x in dynamic([1])
     x
   ~throws "no specific iteration implementation available"
 
 check:
   for Set:
     each:
-      values(key, [x, ...]): { "x": [1, 2, 3],
-                               "y": [4, 5] }
+      values(key, [x, ...]) in { "x": [1, 2, 3],
+                                 "y": [4, 5] }
     [x, ...].reverse()
   ~is {[3, 2, 1], [5, 4]}
 
 check:
   for values() ():
-    each i: 1..2
+    each i in 1..2
     values()
   ~is values()
 
 check:
   for values():
-    each i: 1..2
+    each i in 1..2
     values()
   ~is values()
 
@@ -492,77 +517,77 @@ check:
 
 check:
   ~eval
-  for List (i: 0..2):
+  for List (i in 0..2):
     i
     ~into List
   ~throws "both `~into` and reducer"
 
 check:
   ~eval
-  for (i: 0..2):
+  for (i in 0..2):
     i
-    ~into List (i: 0..2)
+    ~into List (i in 0..2)
   ~throws "misplaced term"
 
 check:
-  for List (val: dynamic([1, 2, 3])):
+  for List (val in dynamic([1, 2, 3])):
     val
   ~is [1, 2, 3]
 
 check:
-  for Array (val: dynamic(Array(1, 2, 3))):
+  for Array (val in dynamic(Array(1, 2, 3))):
     val
   ~is_now Array(1, 2, 3)
 
 check:
-  for Map ((key, val): {1: 2, 2: 3, 3: 4}):
+  for Map ((key, val) in {1: 2, 2: 3, 3: 4}):
     values(key, val)
   ~is {1: 2, 2: 3, 3: 4}
 
 check:
-  for Set (val: dynamic({1, 2, 3})):
+  for Set (val in dynamic({1, 2, 3})):
     val
   ~is {1, 2, 3}
 
 check:
   ~eval
   use_static
-  for ((key, val): ([Box(1), Box(2), Box(3)] :: List.of(Box))):
+  for ((key, val) in ([Box(1), Box(2), Box(3)] :: List.of(Box))):
     key.value
   ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
-  for ((key, val): ([Box(1), Box(2), Box(3)] :: List.of(Box))):
+  for ((key, val) in ([Box(1), Box(2), Box(3)] :: List.of(Box))):
     val.value
   ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
-  for ((key, val): ({Box(1), Box(2), Box(3)} :: Set.of(Box))):
+  for ((key, val) in ({Box(1), Box(2), Box(3)} :: Set.of(Box))):
     key.value
   ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
-  for ((key, val): ({Box(1), Box(2), Box(3)} :: Set.of(Box))):
+  for ((key, val) in ({Box(1), Box(2), Box(3)} :: Set.of(Box))):
     val.value
   ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
-  for (val: ({Box(1): "1", Box(2): "2", Box(3): "3"} :: Map.of(Box, String))):
+  for (val in ({Box(1): "1", Box(2): "2", Box(3): "3"} :: Map.of(Box, String))):
     val.value
   ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
-  for (val: ({Box(1): "1", Box(2): "2", Box(3): "3"} :: Map.of(Box, String))):
+  for (val in ({Box(1): "1", Box(2): "2", Box(3): "3"} :: Map.of(Box, String))):
     val.length()
   ~throws "no such field or method (based on static information)"
 
@@ -583,7 +608,7 @@ block:
 // check `let` across clause boundary
 check:
   for List:
-    each num_str: ["1","2","3","4","5", "a"]
+    each num_str in ["1","2","3","4","5", "a"]
     let num = String.to_number(num_str)
     skip_when !num
     num
@@ -593,7 +618,7 @@ version_guard.at_least "8.11.1.4":
   // check `import` across clause boundary
   check:
     for List:
-      each num_str: ["1","2","3","4","5"]
+      each num_str in ["1","2","3","4","5"]
       import: rhombus.List as L
       skip_when !num_str
       L(num_str)
@@ -602,7 +627,7 @@ version_guard.at_least "8.11.1.4":
   // combine `import` and `let` across clause boundary
   check:
     for List:
-      each num_str: ["1","2","3","4","5", "a"]
+      each num_str in ["1","2","3","4","5", "a"]
       import: rhombus.List as L
       let num = String.to_number(num_str)
       skip_when !num
@@ -617,7 +642,7 @@ version_guard.at_least "8.11.1.4":
   // check syntax parameter within body
   check:
     for List:
-      each num_str: ["1","2","3"]
+      each num_str in ["1","2","3"]
       skip_when !num_str
       syntax_parameter.relet today_name:
         "Friday"
@@ -628,7 +653,7 @@ version_guard.at_least "8.11.1.4":
   check:
     def mutable accum = []
     [for List:
-       each num_str: ["1","2","3"]
+       each num_str in ["1","2","3"]
        syntax_parameter.relet today_name:
          "Friday"
        def now = today
@@ -645,7 +670,7 @@ version_guard.at_least "8.11.1.4":
     for List:
       syntax_parameter.relet today_name:
         "Friday"
-      each day_str: [today, today]
+      each day_str in [today, today]
       [day_str, today]
     ~is [["Friday", "Friday"], ["Friday", "Friday"]]
 
@@ -654,7 +679,7 @@ version_guard.at_least "8.11.1.4":
     for List:
       syntax_parameter.relet today_name:
         "Friday"
-      each day_str: [fun (): today, fun (): today]
+      each day_str in [fun (): today, fun (): today]
       [day_str(), today]
     ~is [["Friday", "Friday"], ["Friday", "Friday"]]
 
@@ -666,7 +691,7 @@ version_guard.at_least "8.11.1.4":
   // check syntax parameter used in guards
   check:
     for List:
-      each i: 0..2
+      each i in 0..2
       syntax_parameter.relet true_or_false_val:
         #true
       keep_when true_or_false
@@ -675,7 +700,7 @@ version_guard.at_least "8.11.1.4":
 
   check:
     for List:
-      each i: 0..2
+      each i in 0..2
       syntax_parameter.relet true_or_false_val:
         #true
       skip_when true_or_false
@@ -684,7 +709,7 @@ version_guard.at_least "8.11.1.4":
 
   check:
     for List:
-      each i: 0..2
+      each i in 0..2
       syntax_parameter.relet true_or_false_val:
         #true
       break_when true_or_false
@@ -693,7 +718,7 @@ version_guard.at_least "8.11.1.4":
 
   check:
     for List:
-      each i: 0..2
+      each i in 0..2
       syntax_parameter.relet true_or_false_val:
         #true
       final_when true_or_false
@@ -703,7 +728,7 @@ version_guard.at_least "8.11.1.4":
   syntax_parameter.bridge a_range_stx:
     #false
   for_clause.macro 'each_a_range $id':
-    'each $id: $(syntax_parameter_meta.lookup('a_range_stx'))'
+    'each $id in $(syntax_parameter_meta.lookup('a_range_stx'))'
 
   // check syntax parameter used in `for`-clause macros
   check:
@@ -727,6 +752,6 @@ version_guard.at_least "8.11.1.4":
 
 check:
   use_static
-  for List (i: 0..2):
+  for List (i in 0..2):
     i < 1
   ~is [#true, #false]

--- a/rhombus/rhombus/tests/for.rhm
+++ b/rhombus/rhombus/tests/for.rhm
@@ -223,7 +223,7 @@ check:
   def set:
     for values(set :~ Set = dynamic({1, 4, 9, 16, 25})):
       each i: 0..8
-      if set[i] | set.remove(i) | set
+      if i in set | set.remove(i) | set
   set ++ {36}
   ~is {9, 16, 25, 36}
 
@@ -232,7 +232,7 @@ check:
   def set:
     for values(set :: Set = dynamic({1, 4, 9, 16, 25})):
       each i: 0..8
-      if set[i] | set.remove(i) | set
+      if i in set | set.remove(i) | set
   set ++ {36}
   ~is {9, 16, 25, 36}
 
@@ -241,7 +241,7 @@ version_guard.at_least "8.11.1.4":
     use_static
     for values(set :~ Set = dynamic({1, 4, 9, 16, 25})):
       each i: 0..8
-      keep_when set[i]
+      keep_when i in set
       set.remove(i)
     ~is {9, 16, 25}
 
@@ -250,7 +250,7 @@ version_guard.at_least "8.11.1.4":
     use_static
     for values(set :: Set = dynamic({1, 4, 9, 16, 25})):
       each i: 0..8
-      keep_when set[i]
+      keep_when i in set
       set.remove(i)
     ~is {9, 16, 25}
 

--- a/rhombus/rhombus/tests/import.rhm
+++ b/rhombus/rhombus/tests/import.rhm
@@ -25,7 +25,7 @@ check:
   import: lib("rhombus/tests/example-a.rhm").ExList
   [ExList(1, 2), ExList.length([1, 2, 3]),
    for ExList:
-     each i: 10..12
+     each i in 10..12
      i]
   ~is [[1, 2], 3, [10, 11]]
 

--- a/rhombus/rhombus/tests/indexable.rhm
+++ b/rhombus/rhombus/tests/indexable.rhm
@@ -109,7 +109,7 @@ check:
   A4() is_a MutableIndexable ~is #false
 
   { 1: 2 } is_a Indexable ~is #true
-  { 1, 2 } is_a Indexable ~is #true
+  { 1, 2 } is_a Indexable ~is #false
   Array(1, 2) is_a Indexable ~is #true
   [1, 2] is_a Indexable ~is #true
   "apple" is_a Indexable ~is #true
@@ -125,7 +125,7 @@ check:
   #"apple" is_a MutableIndexable ~is #false
 
   { 1: 2 }.copy() is_a MutableIndexable ~is #true
-  { 1, 2 }.copy() is_a MutableIndexable ~is #true
+  { 1, 2 }.copy() is_a MutableIndexable ~is #false
   "apple".copy() is_a MutableIndexable ~is #false
   #"apple".copy() is_a MutableIndexable ~is #true
 

--- a/rhombus/rhombus/tests/list.rhm
+++ b/rhombus/rhombus/tests/list.rhm
@@ -18,7 +18,7 @@ block:
     List.for_each(lst, proc) ~method
     List.filter(lst) ~method
     List.partition(lst, proc) ~method
-    List.has_element(lst, val, [eql]) ~method
+    List.contains(lst, val, [eql]) ~method
     List.find(lst, pred) ~method
     List.index(lst, pred) ~method
     List.remove(lst, val) ~method
@@ -360,12 +360,12 @@ check:
   ~is "empty"
 
 check:
-  [1, 2, 3].has_element(2) ~is #true
-  [1, 2, 3].has_element(4) ~is #false
-  [1, 2, 3].has_element(-3, fun (x, y): x == -y) ~is #true
-  [1, 2, 3].has_element(-4, fun (x, y): x == -y) ~is #false
-  dynamic([1, 2, 3]).has_element(1) ~is #true
-  dynamic([1, 2, 3]).has_element(-1, fun (x, y): x == -y) ~is #true
+  [1, 2, 3].contains(2) ~is #true
+  [1, 2, 3].contains(4) ~is #false
+  [1, 2, 3].contains(-3, fun (x, y): x == -y) ~is #true
+  [1, 2, 3].contains(-4, fun (x, y): x == -y) ~is #false
+  dynamic([1, 2, 3]).contains(1) ~is #true
+  dynamic([1, 2, 3]).contains(-1, fun (x, y): x == -y) ~is #true
 
 check:
   [1, 2, 3].find(fun (x): x > 1) ~is 2
@@ -421,13 +421,13 @@ check:
 
 check:
   use_static
-  List.empty.has_element("no such thing")
+  List.empty.contains("no such thing")
   ~is #false
 
 check:
   use_static
   def List.empty && empty = dynamic([])
-  empty.has_element("no such thing")
+  empty.contains("no such thing")
   ~is #false
 
 block:

--- a/rhombus/rhombus/tests/list.rhm
+++ b/rhombus/rhombus/tests/list.rhm
@@ -315,7 +315,7 @@ check:
   ~is "other"
 
 check:
-  match (for List (i: []): i)
+  match (for List (i in []): i)
   | List.empty: "empty"
   | ~else: "other"
   ~is "empty"
@@ -440,15 +440,15 @@ block:
   use_static
   def lst = ["a", "b", "c"]
   check:
-    for List (x: lst):
+    for List (x in lst):
       x
     ~is ["a", "b", "c"]
   check:
-    for List (x: List.to_sequence(lst)):
+    for List (x in List.to_sequence(lst)):
       x
     ~is ["a", "b", "c"]
   check:
-    for List (x: lst.to_sequence()):
+    for List (x in lst.to_sequence()):
       x
     ~is ["a", "b", "c"]
 
@@ -468,7 +468,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: "oops" :~ List):
+    for List (x in "oops" :~ List):
       x
     ~throws values(
       "List.to_sequence: " ++ error.annot_msg(),
@@ -476,7 +476,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: List.to_sequence("oops")):
+    for List (x in List.to_sequence("oops")):
       x
     ~throws values(
       "List.to_sequence: " ++ error.annot_msg(),
@@ -484,7 +484,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: ("oops" :~ List).to_sequence()):
+    for List (x in ("oops" :~ List).to_sequence()):
       x
     ~throws values(
       "List.to_sequence: " ++ error.annot_msg(),

--- a/rhombus/rhombus/tests/map.rhm
+++ b/rhombus/rhombus/tests/map.rhm
@@ -1007,9 +1007,9 @@ block:
   check m2 is_a Map.by(is_same_number_or_object) ~is #true
   check m3 is_a Map.by(===) ~is #false
   check m3 is_a Map.by(is_now) ~is #true
-  check (for Map.by(===) (i: 0..1): values(i, i+1)) ~is Map.by(===){ 0: 1 }
-  check (for Map.by(is_now) (i: 0..1): values(i, i+1)) ~is Map.by(is_now){ 0: 1 }
-  check (for Map.by(is_same_number_or_object) (i: 0..1): values(i, i+1)) ~is Map.by(is_same_number_or_object){ 0: 1 }
+  check (for Map.by(===) (i in 0..1): values(i, i+1)) ~is Map.by(===){ 0: 1 }
+  check (for Map.by(is_now) (i in 0..1): values(i, i+1)) ~is Map.by(is_now){ 0: 1 }
+  check (for Map.by(is_same_number_or_object) (i in 0..1): values(i, i+1)) ~is Map.by(is_same_number_or_object){ 0: 1 }
   let [x, ...] = [1, 2, 3]
   check Map.by(===){ x: x, ...} ~is Map.by(===){ 1: 1, 2: 2, 3: 3 }
 
@@ -1039,7 +1039,7 @@ block:
        check [Map.by($key_comp){ x: x }, $('...')] ~is [Map.by($key_comp){ 1: 1 },
                                                         Map.by($key_comp){ 2: 2 },
                                                         Map.by($key_comp){ 3: 3 }]
-       check (for Map.by($key_comp) (i: 0..1): values(i, i+1)) ~is Map.by($key_comp){ 0: 1 }
+       check (for Map.by($key_comp) (i in 0..1): values(i, i+1)) ~is Map.by($key_comp){ 0: 1 }
        block:
          let Map.by($key_comp){ 1: v } = Map.by($key_comp){ 1: "x" }
          check v ~is "x"

--- a/rhombus/rhombus/tests/map.rhm
+++ b/rhombus/rhombus/tests/map.rhm
@@ -12,12 +12,14 @@ block:
     Map.values(mp) ~method ReadableMap
     Map.get(mp, k, [default])  ~method ReadableMap
     Map.has_key(mp, k) ~method ReadableMap
+    Map.contains(mp, k) ~method ReadableMap
+    Map.add(mp, k, v)  ~method
     Map.copy(mp) ~method ReadableMap
     Map.snapshot(mp) ~method ReadableMap
     Map.append(mp0, mp, ...) ~method
     Map.remove(mp, k) ~method
     MutableMap.set(mp, k, val) ~method
-    MutableMap.delete(mp, k) ~method
+    MutableMap.remove(mp, k) ~method
     Map.to_sequence(mp) ~method ReadableMap
     Map.by(==)(p, ...)
     Map.by(===)(p, ...)
@@ -54,6 +56,20 @@ block:
     {"a": 1, "b": 2}.get("a") ~is 1
     {"a": 1, "b": 2}.get("c", "other") ~is "other"
     {"a": 1, "b": 2}.get("c", fun (): "got other") ~is "got other"
+  check:
+    "a" in {"a": 1, "b": 2} ~is #true
+    "b" in {"a": 1, "b": 2} ~is #true
+    1 in {"a": 1, "b": 2} ~is #false
+    "a" !in {"a": 1, "b": 2} ~is #false
+    1 !in {"a": 1, "b": 2} ~is #true
+    {"a": 1, "b": 2}.contains("a") ~is #true
+    {"a": 1, "b": 2}.has_key("a") ~is #true
+    {"a": 1, "b": 2}.contains(1) ~is #false
+    {"a": 1, "b": 2}.has_key(1) ~is #false
+  check:
+    {"a": 1, "b": 2}.add("c", 3) ~is {"a": 1, "b": 2, "c": 3}
+    {"a": 1, "b": 2}.add("a", 3) ~is {"a": 3, "b": 2}
+    Map.add({"a": 1, "b": 2}, "c", 3) ~is {"a": 1, "b": 2, "c": 3}
   check:
     ({"a": 1, "b": 2} ++ {"a": 3})["a"] ~is 3
     ({"a": 1, "b": 2} ++ {"a": 3, "b": 4})["a"] ~is 3
@@ -203,6 +219,8 @@ block:
     dynamic({"a": 1, "b": 2})["a"] ~is 1
     dynamic({"a": 1, "b": 2}).get("a") ~is 1
     dynamic({"a": 1, "b": 2}).get("c", "other") ~is "other"
+  check:
+    dynamic({"a": 1, "b": 2}).add("c", 3) ~is {"a": 1, "b": 2, "c": 3}
   check:
     (dynamic({"a": 1, "b": 2}) ++ {"a": 3})["a"] ~is 3
     (dynamic({"a": 1, "b": 2}) ++ {"a": 3, "b": 4})["a"] ~is 3
@@ -716,38 +734,32 @@ block:
     use_dynamic
     check dynamic({1: "a", 2: "b"}).remove(1) ~is {2: "b"}
     check dynamic({1: "a", 2: "b"}).remove(3) ~is {1: "a", 2: "b"}
-    check MutableMap{1: "a", 2: "b"}.remove ~throws "no such field or method"
-    check MutableMap{1: "a", 2: "b"}.remove(1) ~throws "no such field or method"
 
 block:
   use_static
   let m = MutableMap{1: "a", 2: "b"}
-  m.delete(1)
+  m.remove(1)
   check m ~is_now MutableMap{2: "b"}
-  m.delete(3)
+  m.remove(3)
   check m ~is_now MutableMap{2: "b"}
   m[1] := "a"
   check m ~is_now MutableMap{1: "a", 2: "b"}
-  check MutableMap.delete(m, 1) ~is #void
+  check MutableMap.remove(m, 1) ~is #void
   check m ~is_now MutableMap{2: "b"}
-  check MutableMap.delete(m, 3) ~is #void
+  check MutableMap.remove(m, 3) ~is #void
   check m ~is_now MutableMap{2: "b"}
   m.set(1, "a")
   check m ~is_now MutableMap{1: "a", 2: "b"}
   block:
     use_dynamic
-    check dynamic(m).delete(1) ~is #void
+    check dynamic(m).remove(1) ~is #void
     check m ~is_now MutableMap{2: "b"}
     check dynamic(m)[1] := "a" ~is #void
     check m ~is_now MutableMap{1: "a", 2: "b"}
-    check dynamic(m).delete(1) ~is #void
+    check dynamic(m).remove(1) ~is #void
     check m ~is_now MutableMap{2: "b"}
     check dynamic(m).set(1, "a") ~is #void
     check m ~is_now MutableMap{1: "a", 2: "b"}
-
-check:
-  {1: "a", 2: "b"}.delete ~throws "no such field or method"
-  {1: "a", 2: "b"}.delete(1) ~throws "no such field or method"
 
 block:
   let m = MutableMap{1: "a", 2: "b"}
@@ -942,9 +954,9 @@ block:
   check orig[2] ~is 5
   check orig["x"] ~is 10
   check orig["y"] ~is 11
-  check m.delete(2) ~throws "key does not satisfy annotation"
-  check m.delete("y") ~is #void
-  check orig.delete(2) ~is #void
+  check m.remove(2) ~throws "key does not satisfy annotation"
+  check m.remove("y") ~is #void
+  check orig.remove(2) ~is #void
   check to_string(m) ~is "MutableMap{\"x\": 10}"
 
 check:

--- a/rhombus/rhombus/tests/membership-testable.rhm
+++ b/rhombus/rhombus/tests/membership-testable.rhm
@@ -1,0 +1,82 @@
+#lang rhombus
+
+use_static
+
+class A():
+  nonfinal
+  implements MembershipTestable
+  override method contains(index):
+    match index
+    | 1: #false
+    | 100: "yes"
+    | ~else: #true
+  method get_self(index):
+    index in this
+
+class C():
+  extends A
+
+interface I3:
+  extends MembershipTestable
+
+class A3():
+  implements I3
+  override method contains(index):
+    index != 3
+
+class A4():
+  private implements MembershipTestable
+  private override method contains(index):
+    index != 4
+
+class A5():
+  implements MembershipTestable
+  override method contains(index):
+    values("oops", "wow")
+
+check:
+  0 in A() ~is #true
+  0 !in A() ~is #false
+  1 in A() ~is #false
+  100 in A()  ~throws values(
+    "result does not satisfy annotation",
+    "Boolean"
+  )
+  A().get_self(7) ~is #true
+  4 in C() ~is #true
+  1 in A3() ~is #true
+  0 in (A3() :: I3) ~is #true
+  10 in A4() ~is #true
+  10 in A5() ~throws values(
+    "results do not satisfy annotation",
+    "Boolean",
+    "\"oops\"", "\"wow\"",
+  )
+  A5().contains("not good") ~throws values(
+    "results do not satisfy annotation",
+    "Boolean",
+    "\"oops\"", "\"wow\"",
+  )
+
+check:
+  A() is_a MembershipTestable ~is #true
+  C() is_a MembershipTestable ~is #true
+  A4() is_a MembershipTestable ~is #true
+  4 is_a MembershipTestable ~is #false
+
+  { 1: 2 } is_a MembershipTestable ~is #true
+  { 1, 2 } is_a MembershipTestable ~is #true
+  Array(1, 2) is_a MembershipTestable ~is #true
+  [1, 2] is_a MembershipTestable ~is #true
+
+  "apple" is_a MembershipTestable ~is #false
+  #"apple" is_a MembershipTestable ~is #false
+  #'apple is_a MembershipTestable ~is #false
+
+check:
+  0 in (#'apple :~ MembershipTestable) ~throws values(
+    "MembershipTestable.contains: " ++ error.annot_msg(),
+    error.annot("MembershipTestable").msg,
+    "#'apple",
+  )
+

--- a/rhombus/rhombus/tests/mutable-list.rhm
+++ b/rhombus/rhombus/tests/mutable-list.rhm
@@ -250,15 +250,15 @@ block:
   use_static
   def lst = MutableList[1, 2, 3]
   check:
-    for List (x: lst):
+    for List (x in lst):
       x
     ~is [1, 2, 3]
   check:
-    for List (x: MutableList.to_sequence(lst)):
+    for List (x in MutableList.to_sequence(lst)):
       x
     ~is [1, 2, 3]
   check:
-    for List (x: lst.to_sequence()):
+    for List (x in lst.to_sequence()):
       x
     ~is [1, 2, 3]
 
@@ -282,7 +282,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: "oops" :~ MutableList):
+    for List (x in "oops" :~ MutableList):
       x
     ~throws values(
       who ++ error.annot_msg(),
@@ -290,7 +290,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: MutableList.to_sequence("oops")):
+    for List (x in MutableList.to_sequence("oops")):
       x
     ~throws values(
       who ++ error.annot_msg(),
@@ -298,7 +298,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: ("oops" :~ MutableList).to_sequence()):
+    for List (x in ("oops" :~ MutableList).to_sequence()):
       x
     ~throws values(
       who ++ error.annot_msg(),

--- a/rhombus/rhombus/tests/mutable-list.rhm
+++ b/rhombus/rhombus/tests/mutable-list.rhm
@@ -13,7 +13,7 @@ block:
     MutableList.map(lst, proc) ~method
     MutableList.for_each(lst, proc) ~method
     MutableList.filter(lst) ~method
-    MutableList.has_element(lst, val, [eql]) ~method
+    MutableList.contains(lst, val, [eql]) ~method
     MutableList.find(lst, pred) ~method
     MutableList.index(lst, pred) ~method
     MutableList.remove(lst, val) ~method
@@ -196,12 +196,12 @@ block:
     check l ~is_now MutableList[3, 2]
 
 check:
-  MutableList[1, 2, 3].has_element(2) ~is #true
-  MutableList[1, 2, 3].has_element(4) ~is #false
-  MutableList[1, 2, 3].has_element(-3, fun (x, y): x == -y) ~is #true
-  MutableList[1, 2, 3].has_element(-4, fun (x, y): x == -y) ~is #false
-  dynamic(MutableList[1, 2, 3]).has_element(1) ~is #true
-  dynamic(MutableList[1, 2, 3]).has_element(-1, fun (x, y): x == -y) ~is #true
+  MutableList[1, 2, 3].contains(2) ~is #true
+  MutableList[1, 2, 3].contains(4) ~is #false
+  MutableList[1, 2, 3].contains(-3, fun (x, y): x == -y) ~is #true
+  MutableList[1, 2, 3].contains(-4, fun (x, y): x == -y) ~is #false
+  dynamic(MutableList[1, 2, 3]).contains(1) ~is #true
+  dynamic(MutableList[1, 2, 3]).contains(-1, fun (x, y): x == -y) ~is #true
 
 check:
   MutableList[1, 2, 3].find(fun (x): x > 1) ~is 2
@@ -243,7 +243,7 @@ check:
 
 check:
   use_static
-  MutableList().has_element("no such thing")
+  MutableList().contains("no such thing")
   ~is #false
 
 block:

--- a/rhombus/rhombus/tests/namespace.rhm
+++ b/rhombus/rhombus/tests/namespace.rhm
@@ -27,7 +27,7 @@ check:
   match home.XList(1, 2)
   | home.XList(x, y):
       for home.XList:
-        each i: x..3
+        each i in x..3
         i
   ~is [1, 2]
 
@@ -36,7 +36,7 @@ check:
   match XList(1, 2)
   | XList(x, y):
       for XList:
-        each i: x..3
+        each i in x..3
         i
   ~is [1, 2]
 

--- a/rhombus/rhombus/tests/pairlist.rhm
+++ b/rhombus/rhombus/tests/pairlist.rhm
@@ -16,7 +16,7 @@ block:
     PairList.for_each(lst, proc) ~method
     List.filter(lst) ~method
     List.partition(lst, proc) ~method
-    PairList.has_element(lst, val, [eql]) ~method
+    PairList.contains(lst, val, [eql]) ~method
     PairList.find(lst, pred) ~method
     PairList.index(lst, pred) ~method
     PairList.remove(lst, val) ~method
@@ -313,12 +313,12 @@ check:
   ~is "empty"
 
 check:
-  PairList[1, 2, 3].has_element(2) ~is #true
-  PairList[1, 2, 3].has_element(4) ~is #false
-  PairList[1, 2, 3].has_element(-3, fun (x, y): x == -y) ~is #true
-  PairList[1, 2, 3].has_element(-4, fun (x, y): x == -y) ~is #false
-  dynamic(PairList[1, 2, 3]).has_element(1) ~is #true
-  dynamic(PairList[1, 2, 3]).has_element(-1, fun (x, y): x == -y) ~is #true
+  PairList[1, 2, 3].contains(2) ~is #true
+  PairList[1, 2, 3].contains(4) ~is #false
+  PairList[1, 2, 3].contains(-3, fun (x, y): x == -y) ~is #true
+  PairList[1, 2, 3].contains(-4, fun (x, y): x == -y) ~is #false
+  dynamic(PairList[1, 2, 3]).contains(1) ~is #true
+  dynamic(PairList[1, 2, 3]).contains(-1, fun (x, y): x == -y) ~is #true
 
 check:
   PairList[1, 2, 3].find(fun (x): x > 1) ~is 2
@@ -381,13 +381,13 @@ check:
 
 check:
   use_static
-  PairList.empty.has_element("no such thing")
+  PairList.empty.contains("no such thing")
   ~is #false
 
 check:
   use_static
   def PairList.empty && empty = dynamic(PairList[])
-  empty.has_element("no such thing")
+  empty.contains("no such thing")
   ~is #false
 
 block:

--- a/rhombus/rhombus/tests/pairlist.rhm
+++ b/rhombus/rhombus/tests/pairlist.rhm
@@ -402,15 +402,15 @@ block:
   use_static
   def lst = PairList["a", "b", "c"]
   check:
-    for List (x: lst):
+    for List (x in lst):
       x
     ~is ["a", "b", "c"]
   check:
-    for List (x: PairList.to_sequence(lst)):
+    for List (x in PairList.to_sequence(lst)):
       x
     ~is ["a", "b", "c"]
   check:
-    for List (x: lst.to_sequence()):
+    for List (x in lst.to_sequence()):
       x
     ~is ["a", "b", "c"]
 
@@ -430,7 +430,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: "oops" :~ PairList):
+    for List (x in "oops" :~ PairList):
       x
     ~throws values(
       "PairList.to_sequence: " ++ error.annot_msg(),
@@ -438,7 +438,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: PairList.to_sequence("oops")):
+    for List (x in PairList.to_sequence("oops")):
       x
     ~throws values(
       "PairList.to_sequence: " ++ error.annot_msg(),
@@ -446,7 +446,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for List (x: ("oops" :~ PairList).to_sequence()):
+    for List (x in ("oops" :~ PairList).to_sequence()):
       x
     ~throws values(
       "PairList.to_sequence: " ++ error.annot_msg(),

--- a/rhombus/rhombus/tests/parsed-srcloc.rhm
+++ b/rhombus/rhombus/tests/parsed-srcloc.rhm
@@ -93,12 +93,12 @@ check_exp_loc: (box := 0) // `:=` claims weaker precedence than everything
 check_exp_loc: Posn(1, 2).p := 0
 
 check_exp_loc: for:
-                 each i: 0..1
+                 each i in 0..1
                  i
 check_exp_loc: for values(x = 1):
-                 each i: 0..1
+                 each i in 0..1
                  i
 check_exp_loc: for:
-                 each i: 0..1
+                 each i in 0..1
                  i
                  ~into values(x = 1)

--- a/rhombus/rhombus/tests/parsed-srcloc.rhm
+++ b/rhombus/rhombus/tests/parsed-srcloc.rhm
@@ -69,8 +69,8 @@ check_exp_loc: Posn(1, 2).m()
 check_exp_loc: Posn(1, 2).p
 check_exp_loc: [1, 2, 3].first
 check_exp_loc: [List.repet([1]), ...].first
-check_exp_loc: [1, 2, 3].has_element(1)
-check_exp_loc: [1, 2, 3].has_element
+check_exp_loc: [1, 2, 3].contains(1)
+check_exp_loc: [1, 2, 3].contains
 check_exp_loc: Array(1, 2, 3)[0]
 check_exp_loc: {1: 2}[0]
 check_exp_loc: Map{1: 2}[0]

--- a/rhombus/rhombus/tests/random.rhm
+++ b/rhombus/rhombus/tests/random.rhm
@@ -76,7 +76,7 @@ check:
   for (n: [2 ** 31, 2 ** 32, 2 ** 64, 10 ** 1000]):
     let M = 64
     let hits = Array.make(M)
-    for (i: 0..M*100):
+    for (i in 0..M*100):
       let x = math.random(n)
       when x .>= n | error("too big")
       let k = x div (n div M)
@@ -84,7 +84,7 @@ check:
     // We expect about 100 hits in each bin. Having less than 50 or
     // more than 150 should be so extremely unlikely that we can rely on
     // it not happening:
-    for (v: hits):
+    for (v in hits):
       when v < 50 || v > 150
       | error("bad sample")
   ~completes

--- a/rhombus/rhombus/tests/range.rhm
+++ b/rhombus/rhombus/tests/range.rhm
@@ -534,37 +534,37 @@ check:
 block:
   use_static
   check:
-    for List (x: 0..5):
+    for List (x in 0..5):
       x
     ~is [0, 1, 2, 3, 4]
   check:
-    for List (x: (0..5).step_by(2)):
+    for List (x in (0..5).step_by(2)):
       x
     ~is [0, 2, 4]
   block:
     def rge = 0..5
     check:
-      for List (x: rge):
+      for List (x in rge):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: dynamic(rge) :~ SequenceRange):
+      for List (x in dynamic(rge) :~ SequenceRange):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: dynamic(rge) :~ ListRange):
+      for List (x in dynamic(rge) :~ ListRange):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: rge.to_sequence()):
+      for List (x in rge.to_sequence()):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: Range.to_sequence(rge)):
+      for List (x in Range.to_sequence(rge)):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: rge.step_by(2)):
+      for List (x in rge.step_by(2)):
         x
       ~is [0, 2, 4]
     check:
@@ -574,29 +574,29 @@ block:
 
 block:
   check:
-    for List (x: dynamic(0..5)):
+    for List (x in dynamic(0..5)):
       x
     ~is [0, 1, 2, 3, 4]
   check:
-    for List (x: dynamic(0..5).step_by(2)):
+    for List (x in dynamic(0..5).step_by(2)):
       x
     ~is [0, 2, 4]
   block:
     def rge = dynamic(0..5)
     check:
-      for List (x: rge):
+      for List (x in rge):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: rge.to_sequence()):
+      for List (x in rge.to_sequence()):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: Range.to_sequence(rge)):
+      for List (x in Range.to_sequence(rge)):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: rge.step_by(2)):
+      for List (x in rge.step_by(2)):
         x
       ~is [0, 2, 4]
     check:
@@ -607,37 +607,37 @@ block:
 block:
   use_static
   check:
-    for List (x: 0..=5):
+    for List (x in 0..=5):
       x
     ~is [0, 1, 2, 3, 4, 5]
   check:
-    for List (x: (0..=5).step_by(2)):
+    for List (x in (0..=5).step_by(2)):
       x
     ~is [0, 2, 4]
   block:
     def rge = 0..=5
     check:
-      for List (x: rge):
+      for List (x in rge):
         x
       ~is [0, 1, 2, 3, 4, 5]
     check:
-      for List (x: dynamic(rge) :~ SequenceRange):
+      for List (x in dynamic(rge) :~ SequenceRange):
         x
       ~is [0, 1, 2, 3, 4, 5]
     check:
-      for List (x: dynamic(rge) :~ ListRange):
+      for List (x in dynamic(rge) :~ ListRange):
         x
       ~is [0, 1, 2, 3, 4, 5]
     check:
-      for List (x: rge.to_sequence()):
+      for List (x in rge.to_sequence()):
         x
       ~is [0, 1, 2, 3, 4, 5]
     check:
-      for List (x: Range.to_sequence(rge)):
+      for List (x in Range.to_sequence(rge)):
         x
       ~is [0, 1, 2, 3, 4, 5]
     check:
-      for List (x: rge.step_by(2)):
+      for List (x in rge.step_by(2)):
         x
       ~is [0, 2, 4]
     check:
@@ -647,29 +647,29 @@ block:
 
 block:
   check:
-    for List (x: dynamic(0..=5)):
+    for List (x in dynamic(0..=5)):
       x
     ~is [0, 1, 2, 3, 4, 5]
   check:
-    for List (x: dynamic(0..=5).step_by(2)):
+    for List (x in dynamic(0..=5).step_by(2)):
       x
     ~is [0, 2, 4]
   block:
     def rge = dynamic(0..=5)
     check:
-      for List (x: rge):
+      for List (x in rge):
         x
       ~is [0, 1, 2, 3, 4, 5]
     check:
-      for List (x: rge.to_sequence()):
+      for List (x in rge.to_sequence()):
         x
       ~is [0, 1, 2, 3, 4, 5]
     check:
-      for List (x: Range.to_sequence(rge)):
+      for List (x in Range.to_sequence(rge)):
         x
       ~is [0, 1, 2, 3, 4, 5]
     check:
-      for List (x: rge.step_by(2)):
+      for List (x in rge.step_by(2)):
         x
       ~is [0, 2, 4]
     check:
@@ -681,83 +681,83 @@ block:
   use_static
   check:
     for List (x: 0..,
-              _: 0..5):
+              _ in 0..5):
       x
     ~is [0, 1, 2, 3, 4]
   check:
-    for List (x: (0..).step_by(2),
-              _: 0..5):
+    for List (x in (0..).step_by(2),
+              _ in 0..5):
       x
     ~is [0, 2, 4, 6, 8]
   block:
     def rge = 0..
     check:
-      for List (x: dynamic(rge) :~ SequenceRange,
-                _: 0..5):
+      for List (x in dynamic(rge) :~ SequenceRange,
+                _ in 0..5):
         x
       ~is [0, 1, 2, 3, 4]
     check:
       for List (x: rge,
-                _: 0..5):
+                _ in 0..5):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: rge.to_sequence(),
-                _: 0..5):
+      for List (x in rge.to_sequence(),
+                _ in 0..5):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: Range.to_sequence(rge),
-                _: 0..5):
+      for List (x in Range.to_sequence(rge),
+                _ in 0..5):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: rge.step_by(2),
-                _: 0..5):
+      for List (x in rge.step_by(2),
+                _ in 0..5):
         x
       ~is [0, 2, 4, 6, 8]
     check:
       for List (x: Range.step_by(rge, 2),
-                _: 0..5):
+                _ in 0..5):
         x
       ~is [0, 2, 4, 6, 8]
 
 block:
   check:
-    for List (x: dynamic(0..),
-              _: 0..5):
+    for List (x in dynamic(0..),
+              _ in 0..5):
       x
     ~is [0, 1, 2, 3, 4]
   check:
-    for List (x: dynamic(0..).step_by(2),
-              _: 0..5):
+    for List (x in dynamic(0..).step_by(2),
+              _ in 0..5):
       x
     ~is [0, 2, 4, 6, 8]
   block:
     def rge = dynamic(0..)
     check:
       for List (x: rge,
-                _: 0..5):
+                _ in 0..5):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: rge.to_sequence(),
-                _: 0..5):
+      for List (x in rge.to_sequence(),
+                _ in 0..5):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: Range.to_sequence(rge),
-                _: 0..5):
+      for List (x in Range.to_sequence(rge),
+                _ in 0..5):
         x
       ~is [0, 1, 2, 3, 4]
     check:
-      for List (x: rge.step_by(2),
-                _: 0..5):
+      for List (x in rge.step_by(2),
+                _ in 0..5):
         x
       ~is [0, 2, 4, 6, 8]
     check:
       for List (x: Range.step_by(rge, 2),
-                _: 0..5):
+                _ in 0..5):
         x
       ~is [0, 2, 4, 6, 8]
 
@@ -803,7 +803,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (x: "oops" :~ SequenceRange):
+    for List (x in "oops" :~ SequenceRange):
       x
     ~throws values(
       "Range.to_sequence: " ++ error.annot_msg(),
@@ -811,7 +811,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (x: Range.to_sequence("oops")):
+    for List (x in Range.to_sequence("oops")):
       x
     ~throws values(
       "Range.to_sequence: " ++ error.annot_msg(),
@@ -819,7 +819,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (x: ("oops" :~ SequenceRange).to_sequence()):
+    for List (x in ("oops" :~ SequenceRange).to_sequence()):
       x
     ~throws values(
       "Range.to_sequence: " ++ error.annot_msg(),
@@ -835,7 +835,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (x: ("oops" :~ SequenceRange).step_by(2)):
+    for List (x in ("oops" :~ SequenceRange).step_by(2)):
       x
     ~throws values(
       "Range.step_by: " ++ error.annot_msg(),
@@ -862,7 +862,7 @@ block:
 // errors in optimized cases
 block:
   check:
-    for List (i: "oops"..5):
+    for List (i in "oops"..5):
       i
     ~throws values(
       "..: " ++ error.annot_msg(),
@@ -870,7 +870,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (i: 0.."oops"):
+    for List (i in 0.."oops"):
       i
     ~throws values(
       "..: " ++ error.annot_msg(),
@@ -878,7 +878,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (i: 5..0):
+    for List (i in 5..0):
       i
     ~throws values(
       "..: starting point must be less than or equal to ending point",
@@ -886,7 +886,7 @@ block:
       "ending point: 0",
     )
   check:
-    for List (i: "oops"..=5):
+    for List (i in "oops"..=5):
       i
     ~throws values(
       "..=: " ++ error.annot_msg(),
@@ -894,7 +894,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (i: 0..="oops"):
+    for List (i in 0..="oops"):
       i
     ~throws values(
       "..=: " ++ error.annot_msg(),
@@ -902,7 +902,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (i: 5..=0):
+    for List (i in 5..=0):
       i
     ~throws values(
       "..=: starting point must be less than or equal to ending point",
@@ -910,7 +910,7 @@ block:
       "ending point: 0",
     )
   check:
-    for List (i: "oops"..):
+    for List (i in "oops"..):
       i
     ~throws values(
       "..: " ++ error.annot_msg(),
@@ -920,7 +920,7 @@ block:
 
 block:
   check:
-    for List (i: ("oops"..5).step_by(2)):
+    for List (i in ("oops"..5).step_by(2)):
       i
     ~throws values(
       "..: " ++ error.annot_msg(),
@@ -928,7 +928,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (i: (0.."oops").step_by(2)):
+    for List (i in (0.."oops").step_by(2)):
       i
     ~throws values(
       "..: " ++ error.annot_msg(),
@@ -936,7 +936,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (i: (5..0).step_by(2)):
+    for List (i in (5..0).step_by(2)):
       i
     ~throws values(
       "..: starting point must be less than or equal to ending point",
@@ -944,7 +944,7 @@ block:
       "ending point: 0",
     )
   check:
-    for List (i: (0..5).step_by("oops")):
+    for List (i in (0..5).step_by("oops")):
       i
     ~throws values(
       "Range.step_by: " ++ error.annot_msg(),
@@ -952,7 +952,7 @@ block:
       error.val("oops").msg
     )
   check:
-    for List (i: ("oops"..=5).step_by(2)):
+    for List (i in ("oops"..=5).step_by(2)):
       i
     ~throws values(
       "..=: " ++ error.annot_msg(),
@@ -960,7 +960,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (i: (0..="oops").step_by(2)):
+    for List (i in (0..="oops").step_by(2)):
       i
     ~throws values(
       "..=: " ++ error.annot_msg(),
@@ -968,7 +968,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (i: (5..=0).step_by(2)):
+    for List (i in (5..=0).step_by(2)):
       i
     ~throws values(
       "..=: starting point must be less than or equal to ending point",
@@ -976,7 +976,7 @@ block:
       "ending point: 0",
     )
   check:
-    for List (i: (0..=5).step_by("oops")):
+    for List (i in (0..=5).step_by("oops")):
       i
     ~throws values(
       "Range.step_by: " ++ error.annot_msg(),
@@ -984,7 +984,7 @@ block:
       error.val("oops").msg
     )
   check:
-    for List (i: ("oops"..).step_by(2)):
+    for List (i in ("oops"..).step_by(2)):
       i
     ~throws values(
       "..: " ++ error.annot_msg(),
@@ -992,7 +992,7 @@ block:
       error.val("oops").msg,
     )
   check:
-    for List (i: (0..).step_by("oops")):
+    for List (i in (0..).step_by("oops")):
       i
     ~throws values(
       "Range.step_by: " ++ error.annot_msg(),
@@ -1013,75 +1013,75 @@ block:
     let most_negative_from = most_negative - 5
     'block:
        $check:
-         for List (i: (#%literal $most_positive) .. (#%literal $most_positive_to)):
+         for List (i in (#%literal $most_positive) .. (#%literal $most_positive_to)):
            i
          ~is $(block:
                  let [num, ...]:
-                   for List (i: most_positive .. most_positive_to):
+                   for List (i in most_positive .. most_positive_to):
                      i
                  '[#%literal $num, ...]')
        $check:
-         for List (i: (#%literal $most_negative_from) .. (#%literal $most_negative)):
+         for List (i in (#%literal $most_negative_from) .. (#%literal $most_negative)):
            i
          ~is $(block:
                  let [num, ...]:
-                   for List (i: most_negative_from .. most_negative):
+                   for List (i in most_negative_from .. most_negative):
                      i
                  '[#%literal $num, ...]')
        $check:
-         for List (i: ((#%literal $most_positive) .. (#%literal $most_positive_to)).step_by(2)):
+         for List (i in ((#%literal $most_positive) .. (#%literal $most_positive_to)).step_by(2)):
            i
          ~is $(block:
                  let [num, ...]:
-                   for List (i: (most_positive .. most_positive_to).step_by(2)):
+                   for List (i in (most_positive .. most_positive_to).step_by(2)):
                      i
                  '[#%literal $num, ...]')
        $check:
-         for List (i: ((#%literal $most_negative_from) .. (#%literal $most_negative)).step_by(2)):
+         for List (i in ((#%literal $most_negative_from) .. (#%literal $most_negative)).step_by(2)):
            i
          ~is $(block:
                  let [num, ...]:
-                   for List (i: (most_negative_from .. most_negative).step_by(2)):
+                   for List (i in (most_negative_from .. most_negative).step_by(2)):
                      i
                  '[#%literal $num, ...]')
        $check:
-         for List (i: (0..5).step_by(#%literal $(most_positive + 1))):
+         for List (i in (0..5).step_by(#%literal $(most_positive + 1))):
            i
          ~is [0]
        $check:
-         for List (i: (#%literal $most_positive) ..= (#%literal $most_positive_to)):
+         for List (i in (#%literal $most_positive) ..= (#%literal $most_positive_to)):
            i
          ~is $(block:
                  let [num, ...]:
-                   for List (i: most_positive ..= most_positive_to):
+                   for List (i in most_positive ..= most_positive_to):
                      i
                  '[#%literal $num, ...]')
        $check:
-         for List (i: (#%literal $most_negative_from) ..= (#%literal $most_negative)):
+         for List (i in (#%literal $most_negative_from) ..= (#%literal $most_negative)):
            i
          ~is $(block:
                  let [num, ...]:
-                   for List (i: most_negative_from ..= most_negative):
+                   for List (i in most_negative_from ..= most_negative):
                      i
                  '[#%literal $num, ...]')
        $check:
-         for List (i: ((#%literal $most_positive) ..= (#%literal $most_positive_to)).step_by(2)):
+         for List (i in ((#%literal $most_positive) ..= (#%literal $most_positive_to)).step_by(2)):
            i
          ~is $(block:
                  let [num, ...]:
-                   for List (i: (most_positive ..= most_positive_to).step_by(2)):
+                   for List (i in (most_positive ..= most_positive_to).step_by(2)):
                      i
                  '[#%literal $num, ...]')
        $check:
-         for List (i: ((#%literal $most_negative_from) ..= (#%literal $most_negative)).step_by(2)):
+         for List (i in ((#%literal $most_negative_from) ..= (#%literal $most_negative)).step_by(2)):
            i
          ~is $(block:
                  let [num, ...]:
-                   for List (i: (most_negative_from ..= most_negative).step_by(2)):
+                   for List (i in (most_negative_from ..= most_negative).step_by(2)):
                      i
                  '[#%literal $num, ...]')
        $check:
-         for List (i: (0..=5).step_by(#%literal $(most_positive + 1))):
+         for List (i in (0..=5).step_by(#%literal $(most_positive + 1))):
            i
          ~is [0]'
   generate_checks 29
@@ -1599,14 +1599,14 @@ block:
     [(x..y).to_list(), ...] ~is [[1], [2], [3], [4], [5]]
     [(x..=y).to_list(), ...] ~is [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]]
   fun sequence_to_list(xs :: Sequence):
-    for List (x: xs):
+    for List (x in xs):
       x
   check:
     [sequence_to_list((x..y).to_sequence()), ...] ~is [[1], [2], [3], [4], [5]]
     [sequence_to_list((x..=y).to_sequence()), ...] ~is [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]]
   fun sequence_take(xs :: Sequence, num :: NonnegInt):
     for List (x: xs,
-              _: 0..num):
+              _ in 0..num):
       x
   check:
     [sequence_take((x..).to_sequence(), 1), ...] ~is [[1], [2], [3], [4], [5]]

--- a/rhombus/rhombus/tests/range.rhm
+++ b/rhombus/rhombus/tests/range.rhm
@@ -16,7 +16,7 @@ block:
     Range.end(rge) ~method
     Range.includes_start(rge) ~method
     Range.includes_end(rge) ~method
-    Range.has_element(rge, v) ~method
+    Range.contains(rge, v) ~method
     Range.encloses(rge, ...) ~method
     Range.is_connected(rge, other) ~method
     Range.overlaps(rge, other) ~method
@@ -45,8 +45,8 @@ block:
       rge.end() ~is 5
       rge.includes_start() ~is #true
       rge.includes_end() ~is #false
-      rge.has_element(0) ~is #true
-      rge.has_element(5) ~is #false
+      rge.contains(0) ~is #true
+      rge.contains(5) ~is #false
       rge.encloses(0..5) ~is #true
       rge.is_connected(0..5) ~is #true
       rge.overlaps(0..5) ~is #true
@@ -58,8 +58,8 @@ block:
     dynamic(rge).end() ~is 5
     dynamic(rge).includes_start() ~is #true
     dynamic(rge).includes_end() ~is #false
-    dynamic(rge).has_element(0) ~is #true
-    dynamic(rge).has_element(5) ~is #false
+    dynamic(rge).contains(0) ~is #true
+    dynamic(rge).contains(5) ~is #false
     dynamic(rge).encloses(0..5) ~is #true
     dynamic(rge).is_connected(0..5) ~is #true
     dynamic(rge).overlaps(0..5) ~is #true
@@ -84,8 +84,8 @@ block:
       rge.end() ~is 5
       rge.includes_start() ~is #true
       rge.includes_end() ~is #true
-      rge.has_element(0) ~is #true
-      rge.has_element(5) ~is #true
+      rge.contains(0) ~is #true
+      rge.contains(5) ~is #true
       rge.encloses(0..=5) ~is #true
       rge.is_connected(0..=5) ~is #true
       rge.overlaps(0..=5) ~is #true
@@ -97,8 +97,8 @@ block:
     dynamic(rge).end() ~is 5
     dynamic(rge).includes_start() ~is #true
     dynamic(rge).includes_end() ~is #true
-    dynamic(rge).has_element(0) ~is #true
-    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).contains(0) ~is #true
+    dynamic(rge).contains(5) ~is #true
     dynamic(rge).encloses(0..=5) ~is #true
     dynamic(rge).is_connected(0..=5) ~is #true
     dynamic(rge).overlaps(0..=5) ~is #true
@@ -122,8 +122,8 @@ block:
       rge.end() ~is #inf
       rge.includes_start() ~is #true
       rge.includes_end() ~is #false
-      rge.has_element(0) ~is #true
-      rge.has_element(5) ~is #true
+      rge.contains(0) ~is #true
+      rge.contains(5) ~is #true
       rge.encloses(0..) ~is #true
       rge.is_connected(0..) ~is #true
       rge.overlaps(0..) ~is #true
@@ -135,8 +135,8 @@ block:
     dynamic(rge).end() ~is #inf
     dynamic(rge).includes_start() ~is #true
     dynamic(rge).includes_end() ~is #false
-    dynamic(rge).has_element(0) ~is #true
-    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).contains(0) ~is #true
+    dynamic(rge).contains(5) ~is #true
     dynamic(rge).encloses(0..) ~is #true
     dynamic(rge).is_connected(0..) ~is #true
     dynamic(rge).overlaps(0..) ~is #true
@@ -161,8 +161,8 @@ block:
       rge.end() ~is 5
       rge.includes_start() ~is #false
       rge.includes_end() ~is #false
-      rge.has_element(0) ~is #false
-      rge.has_element(5) ~is #false
+      rge.contains(0) ~is #false
+      rge.contains(5) ~is #false
       rge.encloses(0 <.. 5) ~is #true
       rge.is_connected(0 <.. 5) ~is #true
       rge.overlaps(0 <.. 5) ~is #true
@@ -174,8 +174,8 @@ block:
     dynamic(rge).end() ~is 5
     dynamic(rge).includes_start() ~is #false
     dynamic(rge).includes_end() ~is #false
-    dynamic(rge).has_element(0) ~is #false
-    dynamic(rge).has_element(5) ~is #false
+    dynamic(rge).contains(0) ~is #false
+    dynamic(rge).contains(5) ~is #false
     dynamic(rge).encloses(0 <.. 5) ~is #true
     dynamic(rge).is_connected(0 <.. 5) ~is #true
     dynamic(rge).overlaps(0 <.. 5) ~is #true
@@ -200,8 +200,8 @@ block:
       rge.end() ~is 5
       rge.includes_start() ~is #false
       rge.includes_end() ~is #true
-      rge.has_element(0) ~is #false
-      rge.has_element(5) ~is #true
+      rge.contains(0) ~is #false
+      rge.contains(5) ~is #true
       rge.encloses(0 <..= 5) ~is #true
       rge.is_connected(0 <..= 5) ~is #true
       rge.overlaps(0 <..= 5) ~is #true
@@ -213,8 +213,8 @@ block:
     dynamic(rge).end() ~is 5
     dynamic(rge).includes_start() ~is #false
     dynamic(rge).includes_end() ~is #true
-    dynamic(rge).has_element(0) ~is #false
-    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).contains(0) ~is #false
+    dynamic(rge).contains(5) ~is #true
     dynamic(rge).encloses(0 <..= 5) ~is #true
     dynamic(rge).is_connected(0 <..= 5) ~is #true
     dynamic(rge).overlaps(0 <..= 5) ~is #true
@@ -238,8 +238,8 @@ block:
       rge.end() ~is #inf
       rge.includes_start() ~is #false
       rge.includes_end() ~is #false
-      rge.has_element(0) ~is #false
-      rge.has_element(5) ~is #true
+      rge.contains(0) ~is #false
+      rge.contains(5) ~is #true
       rge.encloses(0 <..) ~is #true
       rge.is_connected(0 <..) ~is #true
       rge.overlaps(0 <..) ~is #true
@@ -251,8 +251,8 @@ block:
     dynamic(rge).end() ~is #inf
     dynamic(rge).includes_start() ~is #false
     dynamic(rge).includes_end() ~is #false
-    dynamic(rge).has_element(0) ~is #false
-    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).contains(0) ~is #false
+    dynamic(rge).contains(5) ~is #true
     dynamic(rge).encloses(0 <..) ~is #true
     dynamic(rge).is_connected(0 <..) ~is #true
     dynamic(rge).overlaps(0 <..) ~is #true
@@ -276,8 +276,8 @@ block:
       rge.end() ~is 5
       rge.includes_start() ~is #false
       rge.includes_end() ~is #false
-      rge.has_element(0) ~is #true
-      rge.has_element(5) ~is #false
+      rge.contains(0) ~is #true
+      rge.contains(5) ~is #false
       rge.encloses(..5) ~is #true
       rge.is_connected(..5) ~is #true
       rge.overlaps(..5) ~is #true
@@ -289,8 +289,8 @@ block:
     dynamic(rge).end() ~is 5
     dynamic(rge).includes_start() ~is #false
     dynamic(rge).includes_end() ~is #false
-    dynamic(rge).has_element(0) ~is #true
-    dynamic(rge).has_element(5) ~is #false
+    dynamic(rge).contains(0) ~is #true
+    dynamic(rge).contains(5) ~is #false
     dynamic(rge).encloses(..5) ~is #true
     dynamic(rge).is_connected(..5) ~is #true
     dynamic(rge).overlaps(..5) ~is #true
@@ -314,8 +314,8 @@ block:
       rge.end() ~is 5
       rge.includes_start() ~is #false
       rge.includes_end() ~is #true
-      rge.has_element(0) ~is #true
-      rge.has_element(5) ~is #true
+      rge.contains(0) ~is #true
+      rge.contains(5) ~is #true
       rge.encloses(..=5) ~is #true
       rge.is_connected(..=5) ~is #true
       rge.overlaps(..=5) ~is #true
@@ -327,8 +327,8 @@ block:
     dynamic(rge).end() ~is 5
     dynamic(rge).includes_start() ~is #false
     dynamic(rge).includes_end() ~is #true
-    dynamic(rge).has_element(0) ~is #true
-    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).contains(0) ~is #true
+    dynamic(rge).contains(5) ~is #true
     dynamic(rge).encloses(..=5) ~is #true
     dynamic(rge).is_connected(..=5) ~is #true
     dynamic(rge).overlaps(..=5) ~is #true
@@ -350,8 +350,8 @@ block:
       rge.end() ~is #inf
       rge.includes_start() ~is #false
       rge.includes_end() ~is #false
-      rge.has_element(0) ~is #true
-      rge.has_element(5) ~is #true
+      rge.contains(0) ~is #true
+      rge.contains(5) ~is #true
       rge.encloses(..) ~is #true
       rge.is_connected(..) ~is #true
       rge.overlaps(..) ~is #true
@@ -363,8 +363,8 @@ block:
     dynamic(rge).end() ~is #inf
     dynamic(rge).includes_start() ~is #false
     dynamic(rge).includes_end() ~is #false
-    dynamic(rge).has_element(0) ~is #true
-    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).contains(0) ~is #true
+    dynamic(rge).contains(5) ~is #true
     dynamic(rge).encloses(..) ~is #true
     dynamic(rge).is_connected(..) ~is #true
     dynamic(rge).overlaps(..) ~is #true
@@ -1093,85 +1093,85 @@ block:
   generate_checks 63
 
 // The following checks are borrowed from Rebellion
-// `Range.has_element`
+// `Range.contains`
 block:
   def rng = 2..4
   check:
-    rng.has_element(1) ~is #false
-    rng.has_element(2) ~is #true
-    rng.has_element(3) ~is #true
-    rng.has_element(4) ~is #false
-    rng.has_element(5) ~is #false
+    rng.contains(1) ~is #false
+    rng.contains(2) ~is #true
+    rng.contains(3) ~is #true
+    rng.contains(4) ~is #false
+    rng.contains(5) ~is #false
 
 check:
-  (3..3).has_element(3) ~is #false
+  (3..3).contains(3) ~is #false
 
 block:
   def rng = 2..=4
   check:
-    rng.has_element(1) ~is #false
-    rng.has_element(2) ~is #true
-    rng.has_element(3) ~is #true
-    rng.has_element(4) ~is #true
-    rng.has_element(5) ~is #false
+    rng.contains(1) ~is #false
+    rng.contains(2) ~is #true
+    rng.contains(3) ~is #true
+    rng.contains(4) ~is #true
+    rng.contains(5) ~is #false
 
 check:
-  (3..=3).has_element(3) ~is #true
+  (3..=3).contains(3) ~is #true
 
 block:
   def rng = 2..
   check:
-    rng.has_element(1) ~is #false
-    rng.has_element(2) ~is #true
-    rng.has_element(3) ~is #true
+    rng.contains(1) ~is #false
+    rng.contains(2) ~is #true
+    rng.contains(3) ~is #true
 
 block:
   def rng = 2 <.. 4
   check:
-    rng.has_element(1) ~is #false
-    rng.has_element(2) ~is #false
-    rng.has_element(3) ~is #true
-    rng.has_element(4) ~is #false
-    rng.has_element(5) ~is #false
+    rng.contains(1) ~is #false
+    rng.contains(2) ~is #false
+    rng.contains(3) ~is #true
+    rng.contains(4) ~is #false
+    rng.contains(5) ~is #false
 
 block:
   def rng = 2 <..= 4
   check:
-    rng.has_element(1) ~is #false
-    rng.has_element(2) ~is #false
-    rng.has_element(3) ~is #true
-    rng.has_element(4) ~is #true
-    rng.has_element(5) ~is #false
+    rng.contains(1) ~is #false
+    rng.contains(2) ~is #false
+    rng.contains(3) ~is #true
+    rng.contains(4) ~is #true
+    rng.contains(5) ~is #false
 
 block:
   def rng = 2 <..
   check:
-    rng.has_element(1) ~is #false
-    rng.has_element(2) ~is #false
-    rng.has_element(3) ~is #true
+    rng.contains(1) ~is #false
+    rng.contains(2) ~is #false
+    rng.contains(3) ~is #true
 
 block:
   def rng = ..4
   check:
-    rng.has_element(3) ~is #true
-    rng.has_element(4) ~is #false
-    rng.has_element(5) ~is #false
+    rng.contains(3) ~is #true
+    rng.contains(4) ~is #false
+    rng.contains(5) ~is #false
 
 block:
   def rng = ..=4
   check:
-    rng.has_element(3) ~is #true
-    rng.has_element(4) ~is #true
-    rng.has_element(5) ~is #false
+    rng.contains(3) ~is #true
+    rng.contains(4) ~is #true
+    rng.contains(5) ~is #false
 
 block:
   def rng = ..
   check:
-    rng.has_element(1) ~is #true
-    rng.has_element(2) ~is #true
-    rng.has_element(3) ~is #true
-    rng.has_element(4) ~is #true
-    rng.has_element(5) ~is #true
+    rng.contains(1) ~is #true
+    rng.contains(2) ~is #true
+    rng.contains(3) ~is #true
+    rng.contains(4) ~is #true
+    rng.contains(5) ~is #true
 
 // `Range.encloses`
 check:

--- a/rhombus/rhombus/tests/reducer-macro.rhm
+++ b/rhombus/rhombus/tests/reducer-macro.rhm
@@ -11,7 +11,7 @@ block:
 check:
   reducer.macro '(Array.len5)':
     'Array.of_length(5)'
-  for Array.len5 (i: 0..3): i
+  for Array.len5 (i in 0..3): i
   ~is_now Array(0, 1, 2, 0, 0)
 
 block:
@@ -35,7 +35,7 @@ block:
   expr.macro 'use_add [$_, $next_l]':
     next_l
   def lst:
-    for List.nested (i: 0..3):
+    for List.nested (i in 0..3):
       values(& List.iota(i))
   check:
     lst
@@ -96,11 +96,11 @@ block:
        def ($id, ...) = $finish $data
        values($count + 1, $id, ...)'
   check:
-    for counted(List) (i: 0..3): i
+    for counted(List) (i in 0..3): i
     ~is values([0, 1, 2], 3)
   block:
     def (map, count):
-      for counted(Map) (i: 0..10):
+      for counted(Map) (i in 0..10):
         keep_when i mod 2 == 0
         values(i, "val" +& i)
     check:
@@ -114,6 +114,6 @@ block:
       map.remove(2)
       ~is {0: "val0", 4: "val4", 6: "val6", 8: "val8"}
   check:
-    for counted(values(i = 0, j = 10)) (k: 0..5):
+    for counted(values(i = 0, j = 10)) (k in 0..5):
       values(i+k, j-k)
     ~is values(10, 0, 5)

--- a/rhombus/rhombus/tests/ref.rhm
+++ b/rhombus/rhombus/tests/ref.rhm
@@ -79,7 +79,7 @@ check:
 
 def a_set = {1, 3, 5, 7, 9}
 check:
-  if a_set[1] && !a_set[2]
+  if 1 in a_set && 2 !in a_set
   | "ok"
   | 1/0
   ~is "ok"

--- a/rhombus/rhombus/tests/repetition.rhm
+++ b/rhombus/rhombus/tests/repetition.rhm
@@ -147,7 +147,7 @@ block:
   check:
     use_static
     def m = [{x}, ...]
-    m[1][2]
+    2 in m[1]
     ~is #true
 
 // list-builiding `[]` as a repetition

--- a/rhombus/rhombus/tests/rest-args.rhm
+++ b/rhombus/rhombus/tests/rest-args.rhm
@@ -448,7 +448,7 @@ fun anyargs_rm(r, ..., ~& m): [[r, ...], m]
 fun anyargs_mr(~& m, r, ...): [[r, ...], m]
 
 for:
-  each anyargs: [anyargs_lm, anyargs_ml, anyargs_rm, anyargs_mr]
+  each anyargs in [anyargs_lm, anyargs_ml, anyargs_rm, anyargs_mr]
   check:
     anyargs("a", "b", ~c: "do", ~d: "re", ~e: "mi")
     ~is [["a", "b"], {#'~c: "do", #'~d: "re", #'~e: "mi"}]

--- a/rhombus/rhombus/tests/sequenceable.rhm
+++ b/rhombus/rhombus/tests/sequenceable.rhm
@@ -28,37 +28,37 @@ class Posn3D(z):
 
 check:
   for List:
-    each j: Posn(1, 2)
+    each j in Posn(1, 2)
     j
   ~is [2, 1]
 
 check:
   for List:
-    each j: Posn(1, 2) :: Sequence
+    each j in Posn(1, 2) :: Sequence
     j
   ~is [2, 1]
 
 check:
   for List:
-    each j: Posn(1, 2).to_sequence()
+    each j in Posn(1, 2).to_sequence()
     j
   ~is [2, 1]
 
 check:
   for List:
-    each j: Posn3D(1, 2, 3)
+    each j in Posn3D(1, 2, 3)
     j
   ~is [2, 1]
 
 check:
   for List:
-    each j: Posn3D(1, 2, 3) :: Sequence
+    each j in Posn3D(1, 2, 3) :: Sequence
     j
   ~is [2, 1]
 
 check:
   for List:
-    each j: Posn3D(1, 2, 3).to_sequence()
+    each j in Posn3D(1, 2, 3).to_sequence()
     j
   ~is [2, 1]
 
@@ -88,19 +88,19 @@ class Posn2(x, y):
 
 check:
   for List:
-    each j: Posn2(1, 2)
+    each j in Posn2(1, 2)
     j
   ~is [-2, -1]
 
 check:
   for List:
-    each j: Posn2(1, 2) :: Sequence
+    each j in Posn2(1, 2) :: Sequence
     j
   ~throws "don't use this"
 
 check:
   for List:
-    each j: Posn2(1, 2).to_sequence()
+    each j in Posn2(1, 2).to_sequence()
     j
   ~throws "don't use this"
 
@@ -114,19 +114,19 @@ class Posn3(x, y):
 
 check:
   for List:
-    each j: Posn3(1, 2) :: _Posn3
+    each j in Posn3(1, 2) :: _Posn3
     j
   ~is [-2, -1]
 
 check:
   for List:
-    each j: Posn3(1, 2) :: Sequence
+    each j in Posn3(1, 2) :: Sequence
     j
   ~throws "don't use this"
 
 check:
   for List:
-    each j: (Posn3(1, 2) :: _Posn3).to_sequence()
+    each j in (Posn3(1, 2) :: _Posn3).to_sequence()
     j
   ~throws "don't use this"
 
@@ -146,19 +146,19 @@ class Posn4(x, y):
 
 check:
   for List:
-    each j: Posn4(1, 2)
+    each j in Posn4(1, 2)
     j
   ~is [20, 10]
 
 check:
   for List:
-    each j: Posn4(1, 2) :: Sequence
+    each j in Posn4(1, 2) :: Sequence
     j
   ~is [20, 10]
 
 check:
   for List:
-    each j: Posn4(1, 2).to_sequence()
+    each j in Posn4(1, 2).to_sequence()
     j
   ~is [20, 10]
 
@@ -189,7 +189,7 @@ check:
         si
       '(($statinfo_meta.index_result_key, $(statinfo_meta.pack(list_info))))'
   for List:
-    each elem: Posn(1, 2)
+    each elem in Posn(1, 2)
     elem[0]
   ~is [1]
 
@@ -206,12 +206,12 @@ block:
       )
   check:
     for List:
-      each elem: TwoList([1, 2, 3, 4, 5]) :: Sequence
+      each elem in TwoList([1, 2, 3, 4, 5]) :: Sequence
       elem
     ~is [1, 3, 5]
   check:
     for List:
-      each elem: TwoList([1, 2, 3, 4, 5]).to_sequence()
+      each elem in TwoList([1, 2, 3, 4, 5]).to_sequence()
       elem
     ~is [1, 3, 5]
 
@@ -235,17 +235,17 @@ block:
           (pos + 1))'
   check:
     for List:
-      each elem: Posn(1, 2)
+      each elem in Posn(1, 2)
       elem
     ~is [2, 1]
   check:
     for List:
-      each elem: Posn(1, 2) :: Sequence
+      each elem in Posn(1, 2) :: Sequence
       elem
     ~is [Char"o", Char"o", Char"p", Char"s"]
   check:
     for List:
-      each elem: Posn(1, 2).to_sequence()
+      each elem in Posn(1, 2).to_sequence()
       elem
     ~is [Char"o", Char"o", Char"p", Char"s"]
   check:
@@ -259,7 +259,7 @@ block:
       Box("really not a sequence")
   check:
     for List:
-      each elem: Broken() :: Sequence
+      each elem in Broken() :: Sequence
       elem
     ~throws values(
       "result does not satisfy annotation",
@@ -268,7 +268,7 @@ block:
     )
   check:
     for List:
-      each elem: Broken().to_sequence()
+      each elem in Broken().to_sequence()
       elem
     ~throws values(
       "result does not satisfy annotation",

--- a/rhombus/rhombus/tests/set.rhm
+++ b/rhombus/rhombus/tests/set.rhm
@@ -8,16 +8,16 @@ block:
   static_arity.check:
     Set(k, ...)
     Set.length(st) ~method ReadableSet
-    Set.get(st, val) ~method ReadableSet
-    Set.has_element(st, val) ~method ReadableSet
+    Set.contains(st, val) ~method ReadableSet
     Set.copy(st) ~method ReadableSet
     Set.snapshot(st) ~method ReadableSet
     Set.append(st0, st, ...) ~method
     Set.union(st0, st, ...) ~method
     Set.intersect(st0, st, ...) ~method
+    Set.add(st, v) ~method
     Set.remove(st, v) ~method
-    MutableSet.set(st, v, in) ~method
-    MutableSet.delete(st, v) ~method
+    MutableSet.add(st, v) ~method
+    MutableSet.remove(st, v) ~method
     Set.to_list(st, [try_sort]) ~method ReadableSet
     Set.to_sequence(st) ~method ReadableSet
     Set.by(==)(p, ...)
@@ -43,13 +43,12 @@ block:
     {1, 2}.length()
     ~is 2
   check:
-    {"a", "b"}["a"]
-    ~is #true
+    "a" in {"a", "b"} ~is #true
+    "b" in {"a", "b"} ~is #true
+    "a" !in {"a", "b"} ~is #false
+    1 !in {"a", "b"} ~is #true
   check:
-    {"a", "b"}.get("a")
-    ~is #true
-  check:
-    {"a", "b"}.has_element("a")
+    {"a", "b"}.contains("a")
     ~is #true
   check:
     {1, 2, 3} ++ {4, 5} ~is {1, 2, 3, 4, 5}
@@ -106,14 +105,11 @@ block:
     dynamic({"a", "b"}).length()
     ~is 2
   check:
-    dynamic({"a", "b"})["a"]
-    ~is #true
+    "a" in dynamic({"a", "b"}) ~is #true
+    "c" in dynamic({"a", "b"}) ~is #false
+    dynamic({"a", "b"}).contains("a") ~is #true
   check:
-    dynamic({"a", "b"}).get("a")
-    ~is #true
-  check:
-    dynamic({"a", "b"}).has_element("a")
-    ~is #true
+    dynamic({"a", "b"}).add("c") ~is {"a", "b", "c"}
   check:
     dynamic({1, 2, 3}) ++ {4, 5} ~is {1, 2, 3, 4, 5}
     dynamic({1, 2, 3}).append({4, 5}) ~is {1, 2, 3, 4, 5}
@@ -292,7 +288,6 @@ check:
   {1, 2, 3}.to_list().length() ~is 3
   {1, 2, 3}.to_list(#true) ~is [1, 2, 3]
   Set.append({1}, {3, 5}, {2, 4, 6}) ~is {1, 2, 3, 4, 5, 6}
-  {1}.copy().remove(2) ~throws "no such field or method"
   {1, 3}.intersect() ~is {1, 3}
   {1, 3}.intersect({2, 3}) ~is {3}
   {1, 3}.intersect({2, 3}, {3, 4}) ~is {3}
@@ -327,54 +322,48 @@ block:
   use_static
   check {1, 2}.remove(1) ~is {2}
   check {1, 2}.remove(3) ~is {1, 2}
-  check {1, 2}.remove(1)[2] ~is #true
+  check 2 in {1, 2}.remove(1) ~is #true
   check Set.remove({1, 2}, 1) ~is {2}
   check Set.remove({1, 2}, 3) ~is {1, 2}
-  check Set.remove({1, 2}, 1)[2] ~is #true
+  check 2 in Set.remove({1, 2}, 1) ~is #true
   block:
     use_dynamic
     check dynamic({1, 2}).remove(1) ~is {2}
     check dynamic({1, 2}).remove(3) ~is {1, 2}
-    check MutableSet{1, 2}.remove ~throws "no such field or method"
-    check MutableSet{1, 2}.remove(1) ~throws "no such field or method"
 
 block:
   use_static
   let m = MutableSet{1, 2}
-  m.delete(1)
+  m.remove(1)
   check m ~is_now MutableSet{2}
-  m.delete(3)
+  m.remove(3)
   check m ~is_now MutableSet{2}
-  m[1] := "a"
+  m.add(1)
   check m ~is_now MutableSet{1, 2}
-  check MutableSet.delete(m, 1) ~is #void
+  check MutableSet.remove(m, 1) ~is #void
   check m ~is_now MutableSet{2}
-  check MutableSet.delete(m, 3) ~is #void
+  check MutableSet.remove(m, 3) ~is #void
   check m ~is_now MutableSet{2}
-  m.set(1, "a")
+  m.add(1)
   check m ~is_now MutableSet{1, 2}
   block:
     use_dynamic
-    check dynamic(m).delete(1) ~is #void
+    check dynamic(m).remove(1) ~is #void
     check m ~is_now MutableSet{2}
-    check dynamic(m)[1] := "a" ~is #void
+    check dynamic(m).add(1) ~is #void
     check m ~is_now MutableSet{1, 2}
-    check dynamic(m).delete(1) ~is #void
+    check dynamic(m).remove(1) ~is #void
     check m ~is_now MutableSet{2}
-    check dynamic(m).set(1, "a") ~is #void
+    check dynamic(m).add(1) ~is #void
     check m ~is_now MutableSet{1, 2}
-
-check:
-  {1, 2}.delete ~throws "no such field or method"
-  {1, 2}.delete(1) ~throws "no such field or method"
 
 block:
   let m = MutableSet{1, 2}
   let n = m.copy()
   check m is_now n ~is #true
   check m == n ~is #false
-  m[2] := #false
-  n[1] := #false
+  m.remove(2)
+  n.remove(1)
   check m ~is_now MutableSet{1}
   check n ~is_now MutableSet{2}
 
@@ -471,22 +460,14 @@ check:
   ~is {3, 7, 9}
 
 check:
-  ~eval
   use_static
-  // make sure sequence element static info isn't confused for index
-  def set :: Set.of(String) = {"foo", "1", "Box(2)"}
-  set["foo"].length()
-  ~throws "no such field or method (based on static information)"
-
-check:
-  use_static
-  Set.empty["no such thing"]
+  "no such thing" in Set.empty
   ~is #false
 
 check:
   use_static
   def Set.empty && empty = dynamic(Set{})
-  empty["no such thing"]
+  "no such thing" in empty
   ~is #false
 
 check:
@@ -502,13 +483,13 @@ check:
 
 check:
   use_static
-  ReadableSet.empty["no such thing"]
+  "no such thing" in ReadableSet.empty
   ~is #false
 
 check:
   use_static
   def ReadableSet.empty && empty = dynamic(Set{})
-  empty["no such thing"]
+  "no such thing" in empty
   ~is #false
 
 check:
@@ -534,7 +515,7 @@ check:
 
 check:
   def s = MutableSet{}
-  s[s] := #true
+  s.add(s)
   to_string(s)
   ~is "#0=MutableSet{#0#}"
 
@@ -542,31 +523,31 @@ block:
   def orig = MutableSet{"x", 2}
   check orig :: MutableSet.now_of(String) ~throws "value does not satisfy annotation"
   check orig :: MutableSet.now_of(Any) ~is orig
-  check (orig :: MutableSet.now_of(Any))["y"] := #true ~is #void
+  check (orig :: MutableSet.now_of(Any)).add("y") ~is #void
   check orig ~is_now MutableSet{"x", "y", 2}
 
 block:
   def orig = MutableSet{"x", 2}
   def m :: MutableSet.later_of(String) = orig
-  check m["x"] ~is #true
-  check m[2] ~throws "element does not satisfy annotation"
-  check m[2] := #true ~throws "element does not satisfy annotation"
+  check "x" in m ~is #true
+  check 2 in m ~throws "element does not satisfy annotation"
+  check m.set(2) ~throws "element does not satisfy annotation"
   check to_string(m) ~throws "element does not satisfy annotation"
-  check m["x"] := #true ~is #void
-  check m["y"] := #true ~is #void
-  check orig[2] ~is #true
-  check orig["x"] ~is #true
-  check orig["y"] ~is #true
-  check orig["z"] ~is #false
-  check m.delete(2) ~throws "element does not satisfy annotation"
-  check m.delete("y") ~is #void
-  check orig.delete(2) ~is #void
+  check m.add("x") ~is #void
+  check m.add("y") ~is #void
+  check 2 in orig ~is #true
+  check "x" in orig ~is #true
+  check "y" in orig ~is #true
+  check "z" in orig ~is #false
+  check m.remove(2) ~throws "element does not satisfy annotation"
+  check m.remove("y") ~is #void
+  check orig.remove(2) ~is #void
   check to_string(m) ~is "MutableSet{\"x\"}"
 
 block:
   def m :: Set.later_of(String) = Set{"x", 2}
-  check m["x"] ~is #true
-  check m[2] ~throws "element does not satisfy annotation"
+  check "x" in m ~is #true
+  check 2 in m ~throws "element does not satisfy annotation"
   check to_string(m) ~throws "element does not satisfy annotation"
   check m.remove(2) ~throws "element does not satisfy annotation"
   check m.remove("x") ~is_a Set
@@ -582,13 +563,13 @@ block:
   def s1 = Set.by(===){ a, b }
   def s2 = Set.by(is_same_number_or_object){ a, b, 1 / 2, 2 / 4 }
   def s3 = Set.by(is_now){ ab, bb }
-  check s1[a] ~is #true
-  check s1[b] ~is #true
-  check s2[a] ~is #true
-  check s2[b] ~is #true
-  check s2[1/2] ~is #true
+  check a in s1 ~is #true
+  check b in s1 ~is #true
+  check a in s2 ~is #true
+  check b in s2 ~is #true
+  check 1/2 in s2 ~is #true
   check s2.length() ~is 3
-  check s3[ab] ~is #true
+  check ab in s3 ~is #true
   check s3.length() ~is 1
   let str = to_string(s1)
   check str ~is "Set.by(===){Posn(1, 2), Posn(1, 2)}"
@@ -642,10 +623,10 @@ block:
        block:
          let Set.by($key_comp){ 1, & rest } = Set.by($key_comp){ 1, 2 }
          check rest ~is_a Set.by($key_comp)
-         check rest[2] ~is #true
+         check 2 in rest ~is #true
        let m4 = MutableSet.by($key_comp){}
-       m4[0] := #true
-       check m4[0] ~is #true
+       m4.add(0)
+       check 0 in m4 ~is #true
        check m4 ~is_now MutableSet.by($key_comp){ 0 }
        check m4 ~is_now MutableSet.by($key_comp)(0)
        check m4 ~is_a MutableSet.by($key_comp)
@@ -661,8 +642,8 @@ block:
        class Boson(v)
        let m5 = WeakMutableSet.by($key_comp){}
        let mutable boson = Boson("plus")
-       m5[boson] := #true
-       check m5[boson] ~is #true
+       m5.add(boson)
+       check boson in m5 ~is #true
        check m5 ~is_now WeakMutableSet.by($key_comp){ boson }
        check m5 ~is_now WeakMutableSet.by($key_comp)(boson)
        check m5 ~is_a WeakMutableSet.by($key_comp)
@@ -690,7 +671,7 @@ block:
       ~hash_code: fun (a, recur): 1
     let m = Set.by(is_anything){ 1, 3 }
     check m.length() ~is 1
-    check m["any value at all"] ~is #true
+    check "any value at all" in m ~is #true
     check m.to_list() ~is [3]
 
     key_comp.def 'both_42_or_both_other':
@@ -698,8 +679,8 @@ block:
       ~hash_code: fun (a, recur): if (a == 42) | 42 | 1
     let m2 = Set.by(both_42_or_both_other){ 1, 42, 3 }
     check m2.length() ~is 2
-    check m2["any non-42 value"] ~is #true
-    check m2[42] ~is #true
+    check "any non-42 value" in m2 ~is #true
+    check 42 in m2 ~is #true
     check m2.to_list().sort(math.less) ~is [3, 42]
 
     key_comp.def 'equals':
@@ -1159,17 +1140,17 @@ block:
       ) ~is Set.by(equals){}
 
 check:
-  ("oops" :~ Set)[0]
+  0 in ("oops" :~ Set)
   ~throws values(
-    "Set.get: " ++ error.annot_msg(),
+    "Set.contains: " ++ error.annot_msg(),
     error.annot("ReadableSet").msg,
     error.val("oops").msg,
   )
 
 check:
-  ("oops" :~ MutableSet)[0] := 0
+  ("oops" :~ MutableSet).add(0)
   ~throws values(
-    "MutableSet.set: " ++ error.annot_msg(),
+    "MutableSet.add: " ++ error.annot_msg(),
     error.annot("MutableSet").msg,
     error.val("oops").msg,
   )

--- a/rhombus/rhombus/tests/set.rhm
+++ b/rhombus/rhombus/tests/set.rhm
@@ -383,15 +383,15 @@ block:
   use_static
   def st = {"a", "b", "c"}
   check:
-    for Set (x: st):
+    for Set (x in st):
       x
     ~is {"a", "b", "c"}
   check:
-    for Set (x: Set.to_sequence(st)):
+    for Set (x in Set.to_sequence(st)):
       x
     ~is {"a", "b", "c"}
   check:
-    for Set (x: st.to_sequence()):
+    for Set (x in st.to_sequence()):
       x
     ~is {"a", "b", "c"}
 
@@ -399,15 +399,15 @@ block:
   use_static
   def st = MutableSet{"a", "b", "c"}
   check:
-    for Set (x: st):
+    for Set (x in st):
       x
     ~is {"a", "b", "c"}
   check:
-    for Set (x: Set.to_sequence(st)):
+    for Set (x in Set.to_sequence(st)):
       x
     ~is {"a", "b", "c"}
   check:
-    for Set (x: st.to_sequence()):
+    for Set (x in st.to_sequence()):
       x
     ~is {"a", "b", "c"}
 
@@ -427,7 +427,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for Set (x: "oops" :~ Set):
+    for Set (x in "oops" :~ Set):
       x
     ~throws values(
       "Set.to_sequence: " ++ error.annot_msg(),
@@ -435,7 +435,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for Set (x: Set.to_sequence("oops")):
+    for Set (x in Set.to_sequence("oops")):
       x
     ~throws values(
       "Set.to_sequence: " ++ error.annot_msg(),
@@ -443,7 +443,7 @@ version_guard.at_least "8.13.0.1":
       error.val("oops").msg,
     )
   check:
-    for Set (x: ("oops" :~ Set).to_sequence()):
+    for Set (x in ("oops" :~ Set).to_sequence()):
       x
     ~throws values(
       "Set.to_sequence: " ++ error.annot_msg(),
@@ -455,7 +455,7 @@ check:
   use_static
   class Posn(x, y)
   def set :: Set.of(Posn) = {Posn(1, 2), Posn(3, 4), Posn(4, 5)}
-  for Set (val: set):
+  for Set (val in set):
     val.x + val.y
   ~is {3, 7, 9}
 
@@ -583,9 +583,9 @@ block:
   check s2 is_a Set.by(is_same_number_or_object) ~is #true
   check s3 is_a Set.by(===) ~is #false
   check s3 is_a Set.by(is_now) ~is #true
-  check (for Set.by(===) (i: 0..1): i) ~is Set.by(===){ 0 }
-  check (for Set.by(is_now) (i: 0..1): i) ~is Set.by(is_now){ 0 }
-  check (for Set.by(is_same_number_or_object) (i: 0..1): i) ~is Set.by(is_same_number_or_object){ 0 }
+  check (for Set.by(===) (i in 0..1): i) ~is Set.by(===){ 0 }
+  check (for Set.by(is_now) (i in 0..1): i) ~is Set.by(is_now){ 0 }
+  check (for Set.by(is_same_number_or_object) (i in 0..1): i) ~is Set.by(is_same_number_or_object){ 0 }
   let [x, ...] = [1, 2, 3]
   check Set.by(===){ x, ... } ~is Set.by(===){ 1, 2, 3 }
 
@@ -616,7 +616,7 @@ block:
                                                      Set.by($key_comp){ 2 },
                                                      Set.by($key_comp){ 3 }]
 
-       check (for Set.by($key_comp) (i: 0..1): i) ~is Set.by($key_comp){ 0 }
+       check (for Set.by($key_comp) (i in 0..1): i) ~is Set.by($key_comp){ 0 }
        block:
          let Set.by($key_comp){ v, $('...') } = Set.by($key_comp){ "x" }
          check [v, $('...')] ~is ["x"]

--- a/rhombus/rhombus/tests/static_arity.rhm
+++ b/rhombus/rhombus/tests/static_arity.rhm
@@ -42,7 +42,7 @@ expr.macro 'static_arity_check $(pattern:
     | '($t, ...)':
         let ([arg, ...], [more, ...]):
           for values(args :~ List = [], mores :~ List = []):
-            each t: [t, ...]
+            each t in [t, ...]
             match t
             | '$(_ :: Identifier)': values(args.add(t), mores)
             | '[$(_ :: Identifier)]': values(args, mores.add(t))

--- a/rhombus/rhombus/tests/string.rhm
+++ b/rhombus/rhombus/tests/string.rhm
@@ -344,15 +344,15 @@ block:
   use_static
   def str = "abc"
   check:
-    for List (x: str):
+    for List (x in str):
       x
     ~is [Char"a", Char"b", Char"c"]
   check:
-    for List (x: String.to_sequence(str)):
+    for List (x in String.to_sequence(str)):
       x
     ~is [Char"a", Char"b", Char"c"]
   check:
-    for List (x: str.to_sequence()):
+    for List (x in str.to_sequence()):
       x
     ~is [Char"a", Char"b", Char"c"]
 
@@ -372,7 +372,7 @@ version_guard.at_least "8.13.0.1":
       error.val(#"oops").msg,
     )
   check:
-    for List (x: #"oops" :~ ReadableString):
+    for List (x in #"oops" :~ ReadableString):
       x
     ~throws values(
       "String.to_sequence: " ++ error.annot_msg(),
@@ -380,7 +380,7 @@ version_guard.at_least "8.13.0.1":
       error.val(#"oops").msg,
     )
   check:
-    for List (x: String.to_sequence(#"oops")):
+    for List (x in String.to_sequence(#"oops")):
       x
     ~throws values(
       "String.to_sequence: " ++ error.annot_msg(),
@@ -388,7 +388,7 @@ version_guard.at_least "8.13.0.1":
       error.val(#"oops").msg,
     )
   check:
-    for List (x: (#"oops" :~ ReadableString).to_sequence()):
+    for List (x in (#"oops" :~ ReadableString).to_sequence()):
       x
     ~throws values(
       "String.to_sequence: " ++ error.annot_msg(),

--- a/rhombus/rhombus/tests/veneer.rhm
+++ b/rhombus/rhombus/tests/veneer.rhm
@@ -30,7 +30,7 @@ block:
     r[2] ~is 1
     r[2] := "plate" ~prints "dropping plate\n"
     (r ++ [4, 5, 6])[0] ~is 6
-    (for List (i: r): i) ~is [3, 2, 1]
+    (for List (i in r): i) ~is [3, 2, 1]
 
 check:
   RevList([1, 2, 3]).m() ~is 3

--- a/shrubbery-render-lib/shrubbery/render/define.rhm
+++ b/shrubbery-render-lib/shrubbery/render/define.rhm
@@ -250,7 +250,7 @@ meta:
         | '$(kw_stx && ('~inset' || '~indent' || '~prompt' || '~indent_from_block'
                           || '~spacer_info_box' || '~escape' || '~space')) $_ ...':
             let kw = kw_stx.unwrap()
-            if kws[kw]
+            if kw in kws
             | syntax_meta.error("duplicate option", stx, kw_stx)
             | kws ++ { kw }
         | ~else: syntax_meta.error("invalid option", stx, opt)

--- a/shrubbery-render-lib/shrubbery/render/private/render.rkt
+++ b/shrubbery-render-lib/shrubbery/render/private/render.rkt
@@ -195,7 +195,8 @@
                                                                         (lambda (stx output)
                                                                           (cond
                                                                             [(element*? (syntax-e stx))
-                                                                             (display "ELEM" output)
+                                                                             ;; write as something self-delimiting:
+                                                                             (display "\"elem\"" output)
                                                                              #t]
                                                                             [else #f])))
                                               (syntax-column

--- a/shrubbery-render-lib/shrubbery/render/private/space_name.rhm
+++ b/shrubbery-render-lib/shrubbery/render/private/space_name.rhm
@@ -1,4 +1,4 @@
-#lang rhombus/and_meta
+#lang rhombus/static/and_meta
 
 export:
   SpaceName
@@ -44,9 +44,9 @@ def space_names:
     #'~doc }
 
 fun is_builtin_space_keyword(v):
-  space_names[v]
+  v in space_names
 
 fun normalize_space_name(v):
-  if space_names[v]
+  if v in space_names
   | Symbol.from_string("rhombus/" ++ to_string(v))
   | v

--- a/shrubbery-render-lib/shrubbery/render/private/spacer.rhm
+++ b/shrubbery-render-lib/shrubbery/render/private/spacer.rhm
@@ -32,7 +32,7 @@ meta:
       | context :: Keyword:
           Symbol.from_string(to_string(context))
       | context :: List:
-          for PairList (e: context): e
+          for PairList (e in context): e
       | ~else:
           context
     match stx
@@ -53,9 +53,9 @@ meta:
     let nows :~ PairList = #{full-space-names}(context)
     // `relevant_context` can be `#false` (the default space)
     for values(found = #false, relevant_context = #false):
-      each now: nows
-      each in: in_contexts
-      skip_when now != in
+      each now in nows
+      each in_ctx in in_contexts
+      skip_when now != in_ctx
       final_when #true
       values(#true, now)
 


### PR DESCRIPTION
Add an `in` operator that tests membership as in many other languages (e.g., Python, Kotlin, Rust). The operator combination `!in` works because `!` now has an infix mode as long as its followed by `in`, `is_now` or `is_a`.

A new class can support `in` by implementing the `MembershipTestable` interface, which has a single `contains` method. The method is required to return a `Boolean`.

Rename `List.has_element` and `Range.has_element` to `List.contains` and `Range.contains`. Add `Array.contains`, `Map.contains` (an alias for `Map.has_key`), and `Set.contains`.

Change sets to be non-indexable. The former indexing operation on a set is better expressed using `in`. Mutable sets no longer have an operator form for assignment; `MutableSet.add` or `MutableSet.remove` must be used, instead.

While we're at it, add `Set.add`, rename `MutableMap.delete` to `MutableMap.remove`, and rename `MutableSet.delete` to `MutableSet.remove`.