### PR TITLE
Change `List.index` and `List.find_index`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/list.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/list.rkt
@@ -3,6 +3,7 @@
                      syntax/parse/pre
                      "srcloc.rkt"
                      "tag.rkt")
+         "../version-case.rkt"
          "treelist.rkt"
          (submod "treelist.rkt" unsafe)
          "mutable-treelist.rkt"
@@ -129,8 +130,9 @@
    drop_last
    sublist
    contains
-   find
    index
+   find
+   find_index
    remove
    map
    for_each
@@ -182,8 +184,9 @@
    drop
    drop_last
    contains
-   find
    index
+   find
+   find_index
    remove
    map
    for_each
@@ -224,8 +227,9 @@
    drop_last
    sublist
    contains
-   find
    index
+   find
+   find_index
    remove
    map
    for_each
@@ -1175,6 +1179,33 @@
   #:primitive (mutable-treelist-member?)
   (mutable-treelist-member? l v eql))
 
+(define/method (List.index l v [eql equal-always?])
+  #:primitive (treelist-index-of)
+  #:static-infos ((#%call-result ((#%maybe #,(get-int-static-infos)))))
+  (meta-if-version-at-least
+   "8.15.0.6"
+   (treelist-index-of l v eql)
+   (begin
+     (check-treelist who l)
+     (check-function-of-arity 2 who eql)
+     (for/or ([vi (in-treelist l)]
+              [i (in-naturals)])
+       (and (eql v vi) i)))))
+
+(define/method (PairList.index l v [eql equal-always?])
+  (check-list who l)
+  (check-function-of-arity 2 who eql)
+  (for/or ([vi (in-list l)]
+           [i (in-naturals)])
+    (and (eql v vi) i)))
+
+(define/method (MutableList.index l v [eql equal-always?])
+  (check-mutable-treelist who l)
+  (check-function-of-arity 2 who eql)
+  (for/or ([vi (in-mutable-treelist l)]
+            [i (in-naturals)])
+    (and (eql v vi) i)))
+
 (define/method (List.find l pred)
   #:primitive (treelist-find)
   (treelist-find l pred))
@@ -1188,7 +1219,7 @@
   #:primitive (mutable-treelist-find)
   (mutable-treelist-find l pred))
 
-(define/method (List.index l pred)
+(define/method (List.find_index l pred)
   #:static-infos ((#%call-result ((#%maybe #,(get-int-static-infos)))))
   (check-treelist who l)
   (check-function-of-arity 1 who pred)
@@ -1196,7 +1227,7 @@
            [i (in-naturals)])
     (and (pred v) i)))
 
-(define/method (PairList.index l pred)
+(define/method (PairList.find_index l pred)
   #:static-infos ((#%call-result ((#%maybe #,(get-int-static-infos)))))
   (check-list who l)
   (check-function-of-arity 1 who pred)
@@ -1204,7 +1235,7 @@
            [i (in-naturals)])
     (and (pred v) i)))
 
-(define/method (MutableList.index l pred)
+(define/method (MutableList.find_index l pred)
   #:static-infos ((#%call-result ((#%maybe #,(get-int-static-infos)))))
   (check-mutable-treelist who l)
   (check-function-of-arity 1 who pred)

--- a/rhombus/rhombus/scribblings/reference/list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/list.scrbl
@@ -530,7 +530,26 @@ it supplies its elements in order.
 @examples(
   [1, 2, 3].contains(2)
   [1, 2, 3].contains(200)
+  [10, 20, 30].contains(20.0, (_ .= _))
   2 in [1, 2, 3]
+)
+
+}
+
+
+@doc(
+  method (lst :: List).index(v :: Any,
+                             eqls :: Function.of_arity(2) = (_ == _))
+    :: maybe(Int)
+){
+
+ Like @rhombus(List.contains), but instead of returning @rhombus(#true),
+ returns the index of a found element.
+
+@examples(
+  ["a", "b", "c"].index("b")
+  ["a", "b", "c"].index("d")
+  [10, 20, 30].index(20.0, (_ .= _))
 )
 
 }
@@ -539,14 +558,14 @@ it supplies its elements in order.
 @doc(
   method (lst :: List).find(pred :: Function.of_arity(1))
     :: Any
-  method (lst :: List).index(pred :: Function.of_arity(1))
+  method (lst :: List).find_index(pred :: Function.of_arity(1))
     :: maybe(NonnegInt)
 ){
 
  The @rhombus(List.find) function finds the first element of
  @rhombus(lst) for which @rhombus(pred) returns a true value, or it
  returns @rhombus(#false) if no such element is found. The
- @rhombus(List.index) function is similar, but it returns the index of the
+ @rhombus(List.find_index) function is similar, but it returns the index of the
  found element instead of the element. Searching the list takes
  @math{O(N)} time (multiplied by the cost of @rhombus(pred)) to find an
  element at position @math{N}.
@@ -554,8 +573,8 @@ it supplies its elements in order.
 @examples(
   [1, 2, 3].find((_ mod 2 .= 0))
   [1, 2, 3].find((_ mod 10 .= 9))
-  [1, 2, 3].index((_ mod 2 .= 0))
-  [1, 2, 3].index((_ mod 10 .= 9))
+  [1, 2, 3].find_index((_ mod 2 .= 0))
+  [1, 2, 3].find_index((_ mod 10 .= 9))
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/mutable-list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/mutable-list.scrbl
@@ -375,7 +375,27 @@ and it is not managed by a lock.
   def l = MutableList[1, 2, 3]
   l.contains(2)
   l.contains(200)
+  l.contains(-2, (fun (a, b): math.abs(a) == math.abs(b)))
   2 in l
+)
+
+}
+
+
+@doc(
+  method (lst :: MutableList).index(v :: Any,
+                                    eqls :: Function.of_arity(2) = (_ == _))
+    :: maybe(Int)
+){
+
+ Like @rhombus(MutableList.contains), but instead of returning @rhombus(#true),
+ returns the index of a found element.
+
+@examples(
+  def l = MutableList["a", "b", "c"]
+  l.index("b")
+  l.index("d")
+  l.index("B", fun (a, b): Char.downcase(a[0]) == Char.downcase(b[0]))
 )
 
 }
@@ -384,7 +404,7 @@ and it is not managed by a lock.
 @doc(
   method (lst :: MutableList).find(pred :: Function.of_arity(1))
     :: Any
-  method (lst :: MutableList).index(pred :: Function.of_arity(1))
+  method (lst :: MutableList).find_index(pred :: Function.of_arity(1))
     :: maybe(NonnegInt)
 ){
 
@@ -397,8 +417,8 @@ and it is not managed by a lock.
   def l = MutableList[1, 2, 3]
   l.find((_ mod 2 .= 0))
   l.find((_ mod 10 .= 9))
-  l.index((_ mod 2 .= 0))
-  l.index((_ mod 10 .= 9))
+  l.find_index((_ mod 2 .= 0))
+  l.find_index((_ mod 10 .= 9))
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/pair.scrbl
+++ b/rhombus/rhombus/scribblings/reference/pair.scrbl
@@ -444,7 +444,26 @@ which case it supplies its elements in order.
 @examples(
   PairList[1, 2, 3].contains(2)
   PairList[1, 2, 3].contains(200)
+  PairList[10, 20, 30].contains(20.0, (_ .= _))
   2 in PairList[1, 2, 3]
+)
+
+}
+
+
+@doc(
+  method (lst :: PairList).index(v :: Any,
+                                 eqls :: Function.of_arity(2) = (_ == _))
+    :: maybe(Int)
+){
+
+ Like @rhombus(PairList.contains), but instead of returning
+ @rhombus(#true), returns the index of a found element.
+
+@examples(
+  PairList["a", "b", "c"].index("b")
+  PairList["a", "b", "c"].index("d")
+  PairList[10, 20, 30].index(20.0, (_ .= _))
 )
 
 }
@@ -453,7 +472,7 @@ which case it supplies its elements in order.
 @doc(
   method (lst :: PairList).find(pred :: Function.of_arity(1))
     :: Any
-  method (lst :: PairList).index(pred :: Function.of_arity(1))
+  method (lst :: PairList).find_index(pred :: Function.of_arity(1))
     :: maybe(NonnegInt)
 ){
 
@@ -464,8 +483,8 @@ which case it supplies its elements in order.
 @examples(
   PairList[1, 2, 3].find((_ mod 2 .= 0))
   PairList[1, 2, 3].find((_ mod 10 .= 9))
-  PairList[1, 2, 3].index((_ mod 2 .= 0))
-  PairList[1, 2, 3].index((_ mod 10 .= 9))
+  PairList[1, 2, 3].find_index((_ mod 2 .= 0))
+  PairList[1, 2, 3].find_index((_ mod 10 .= 9))
 )
 
 }

--- a/rhombus/rhombus/tests/list.rhm
+++ b/rhombus/rhombus/tests/list.rhm
@@ -19,8 +19,9 @@ block:
     List.filter(lst) ~method
     List.partition(lst, proc) ~method
     List.contains(lst, val, [eql]) ~method
+    List.index(lst, v, [eql]) ~method
     List.find(lst, pred) ~method
-    List.index(lst, pred) ~method
+    List.find_index(lst, pred) ~method
     List.remove(lst, val) ~method
     List.delete(lst, i) ~method
     List.insert(lst, i, val) ~method
@@ -375,6 +376,18 @@ check:
   dynamic([1, 2, 3]).contains(-1, fun (x, y): x == -y) ~is #true
 
 block:
+  use_static
+  check:
+    [1, 2, 3].index(2) ~is 1
+    [1, 2, 3].index(4) ~is #false
+    [1, 2, 3].index(-3, fun (x, y): x == -y) ~is 2
+    [1, 2, 3].index(-4, fun (x, y): x == -y) ~is #false
+
+check:
+  dynamic([1, 2, 3]).index(1) ~is 0
+  dynamic([1, 2, 3]).index(-1, fun (x, y): x == -y) ~is 0
+
+block:
   let bx = Box(1)
   let bx_copy = bx.copy()
   block:
@@ -392,9 +405,9 @@ check:
   [1, 2, 3].find(fun (x): x > 1) ~is 2
   [1, 2, 3].find(fun (x): x > 10) ~is #false
   dynamic([1, 2, 3]).find(fun (x): x > 1) ~is 2
-  [1, 2, 3].index(fun (x): x > 1) ~is 1
-  [1, 2, 3].index(fun (x): x > 10) ~is #false
-  dynamic([1, 2, 3]).index(fun (x): x > 1) ~is 1
+  [1, 2, 3].find_index(fun (x): x > 1) ~is 1
+  [1, 2, 3].find_index(fun (x): x > 10) ~is #false
+  dynamic([1, 2, 3]).find_index(fun (x): x > 1) ~is 1
 
 check:
   [1, 2, 3].remove(2) ~is [1, 3]

--- a/rhombus/rhombus/tests/mutable-list.rhm
+++ b/rhombus/rhombus/tests/mutable-list.rhm
@@ -14,8 +14,9 @@ block:
     MutableList.for_each(lst, proc) ~method
     MutableList.filter(lst) ~method
     MutableList.contains(lst, val, [eql]) ~method
+    MutableList.index(lst, val, [eql]) ~method
     MutableList.find(lst, pred) ~method
-    MutableList.index(lst, pred) ~method
+    MutableList.find_index(lst, pred) ~method
     MutableList.remove(lst, val) ~method
     MutableList.delete(lst, i) ~method
     MutableList.insert(lst, i, val) ~method
@@ -211,6 +212,18 @@ check:
   dynamic(MutableList[1, 2, 3]).contains(-1, fun (x, y): x == -y) ~is #true
 
 block:
+  use_static
+  check:
+    MutableList[1, 2, 3].index(2) ~is 1
+    MutableList[1, 2, 3].index(4) ~is #false
+    MutableList[1, 2, 3].index(-3, fun (x, y): x == -y) ~is 2
+    MutableList[1, 2, 3].index(-4, fun (x, y): x == -y) ~is #false
+
+check:
+  dynamic(MutableList[1, 2, 3]).index(1) ~is 0
+  dynamic(MutableList[1, 2, 3]).index(-1, fun (x, y): x == -y) ~is 0
+
+block:
   let bx = Box(1)
   let bx_copy = bx.copy()
   block:
@@ -228,9 +241,9 @@ check:
   MutableList[1, 2, 3].find(fun (x): x > 1) ~is 2
   MutableList[1, 2, 3].find(fun (x): x > 10) ~is #false
   dynamic(MutableList[1, 2, 3]).find(fun (x): x > 1) ~is 2
-  MutableList[1, 2, 3].index(fun (x): x > 1) ~is 1
-  MutableList[1, 2, 3].index(fun (x): x > 10) ~is #false
-  dynamic(MutableList[1, 2, 3]).index(fun (x): x > 1) ~is 1
+  MutableList[1, 2, 3].find_index(fun (x): x > 1) ~is 1
+  MutableList[1, 2, 3].find_index(fun (x): x > 10) ~is #false
+  dynamic(MutableList[1, 2, 3]).find_index(fun (x): x > 1) ~is 1
 
 check:
   (block: let l = MutableList[1, 2, 3]; l.remove(2); l) ~is_now MutableList[1, 3]

--- a/rhombus/rhombus/tests/pairlist.rhm
+++ b/rhombus/rhombus/tests/pairlist.rhm
@@ -17,8 +17,9 @@ block:
     List.filter(lst) ~method
     List.partition(lst, proc) ~method
     PairList.contains(lst, val, [eql]) ~method
+    PairList.index(lst, val, [eql]) ~method
     PairList.find(lst, pred) ~method
-    PairList.index(lst, pred) ~method
+    PairList.find_index(lst, pred) ~method
     PairList.remove(lst, val) ~method
     PairList.reverse(lst) ~method
     PairList.append(lst, ...) ~method
@@ -328,6 +329,18 @@ check:
   dynamic(PairList[1, 2, 3]).contains(-1, fun (x, y): x == -y) ~is #true
 
 block:
+  use_static
+  check:
+    PairList[1, 2, 3].index(2) ~is 1
+    PairList[1, 2, 3].index(4) ~is #false
+    PairList[1, 2, 3].index(-3, fun (x, y): x == -y) ~is 2
+    PairList[1, 2, 3].index(-4, fun (x, y): x == -y) ~is #false
+
+check:
+  dynamic(PairList[1, 2, 3]).index(1) ~is 0
+  dynamic(PairList[1, 2, 3]).index(-1, fun (x, y): x == -y) ~is 0
+
+block:
   let bx = Box(1)
   let bx_copy = bx.copy()
   block:
@@ -345,9 +358,9 @@ check:
   PairList[1, 2, 3].find(fun (x): x > 1) ~is 2
   PairList[1, 2, 3].find(fun (x): x > 10) ~is #false
   dynamic(PairList[1, 2, 3]).find(fun (x): x > 1) ~is 2
-  PairList[1, 2, 3].index(fun (x): x > 1) ~is 1
-  PairList[1, 2, 3].index(fun (x): x > 10) ~is #false
-  dynamic(PairList[1, 2, 3]).index(fun (x): x > 1) ~is 1
+  PairList[1, 2, 3].find_index(fun (x): x > 1) ~is 1
+  PairList[1, 2, 3].find_index(fun (x): x > 10) ~is #false
+  dynamic(PairList[1, 2, 3]).find_index(fun (x): x > 1) ~is 1
 
 check:
   PairList[1, 2, 3].remove(2) ~is PairList[1, 3]


### PR DESCRIPTION
The old `List.index` was like `List.find`, taking a predicate as an argument. The new `List.index` that takes a value to locate (like `List.contains`), which makes it more like `treelist-index-of` and Python's `index` method on list.

The old `List.index` is renamed here to `List.find_index`. I'm not sure whether it should be kept.

Ditto for methods in `PairList` and `MutableList`.