### PR TITLE
change regexp `#%comp` to recognize `min ..= max`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/rx.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx.rhm
@@ -93,6 +93,9 @@ export:
     names:
       #%literal #%comp #%parens #%juxtapose #%call #%brackets #%index
 
+    // recognized by `#%comp`
+    .. ..=
+
     // same as #%juxtapose, but supports continuing on the next line
     ++
 
@@ -344,15 +347,25 @@ rx.macro '.? $(g :: Greed) $()':
 
 rx.macro #%comp:
   ~order: rx_repetition
-| '$left #%comp $(self && '{$(min :: Int) ..}') $(g :: Greed) $()':
+| '$left #%comp $(self && '{$(min :: Int) $(bound_as rx_meta.space: '..')}') $(g :: Greed) $()':
     values(unary('repeat($min, #inf, $g.mode, $self)', left),
            '$g.tail ...')
-| '$left #%comp $(self && '{$(min :: Int) .. $(max :: Int)}') $(g :: Greed) $()':
+| '$left #%comp $(self && '{$(min :: Int) $(bound_as rx_meta.space: '..=') $(max :: Int)}') $(g :: Greed) $()':
     values(unary('repeat($min, $max, $g.mode, $self)', left),
            '$g.tail ...')
 | '$left #%comp $(self && '{$(count :: Int)}') $(g :: Greed) $()':
     values(unary('repeat($count, $count, $g.mode, $self)', left),
            '$g.tail ...')
+
+rx.macro '..':
+  ~stronger_than: ~other
+  ~op_stx: self
+  syntax_meta.error("misuse outside of a repetition pattern", self)
+
+rx.macro '..=':
+  ~stronger_than: ~other
+  ~op_stx: self
+  syntax_meta.error("misuse outside of a repetition pattern", self)
 
 rx.macro '.':
   ~same_as: $

--- a/rhombus/rhombus/scribblings/reference/rx-pattern.scrbl
+++ b/rhombus/rhombus/scribblings/reference/rx-pattern.scrbl
@@ -233,8 +233,8 @@ multiplying like the expression @rhombus(*) operator.
 
 @doc(
   rx.macro '$pat #%comp {$count}'
-  rx.macro '$pat #%comp {$min ..}'
-  rx.macro '$pat #%comp {$min .. $max}'
+  rx.macro '$pat #%comp {$min #,(@rhombus(.., ~at rhombus/rx))}'
+  rx.macro '$pat #%comp {$min #,(@rhombus(..=, ~at rhombus/rx)) $max}'
   operator_order:
     ~order: rx_repetition
 ){
@@ -246,9 +246,9 @@ multiplying like the expression @rhombus(*) operator.
  exact number of repetitions. If just @rhombus(min) is provided, then it
  specifies a minimum number of repetitions, and there is no maximum.
  Finally, @rhombus(min) and @rhombus(max) both can be specified.
- @margin_note{Write @rhombus(0 .. max) to provide only an upper bound.
-  Note that the expression form @rhombus(.. max) creates a range that
-  starts a @rhombus(#neginf), and the intent of requiring a @rhombus(min) for
+ @margin_note{Write @rhombus(0 #,(@rhombus(..=, ~at rhombus/rx)) max) to provide only an upper bound.
+  Note that the expression form @rhombus(..= max) creates a range that
+  starts at @rhombus(#neginf), and the intent of requiring a @rhombus(min) for
   a regexp repetition is to avoid suggesting that negative counts are
   possible.} A @rhombus(count), @rhombus(min), or @rhombus(max) must be a
  literal nonnegative integer.
@@ -262,10 +262,19 @@ multiplying like the expression @rhombus(*) operator.
     rx'any{2..}'.match("aa")
     rx'any{2..}'.match("aaa")
   ~repl:
-    rx'any{2..3}'.match("aa")
-    rx'any{2..3}'.match("aaa")
-    rx'any{2..3}'.match("aaaa")
+    rx'any{2..=3}'.match("aa")
+    rx'any{2..=3}'.match("aaa")
+    rx'any{2..=3}'.match("aaaa")
 )
+
+}
+
+@doc(
+  rx.macro '..'
+  rx.macro '..='
+){
+
+ Only allowed within a @braces repetition form.
 
 }
 

--- a/rhombus/rhombus/tests/rx.rhm
+++ b/rhombus/rhombus/tests/rx.rhm
@@ -146,22 +146,22 @@ check:
   M rx'()?' "" ~is [""]
 
 check:
-  M rx'"x"{1..3}' "xy" ~is #false
-  P rx'"x"{1..3}' "xy" ~is ["x"]
-  P rx'"x"{1..3}' "ax" ~is ["x"]
-  M rx'"x"{1..3}' "" ~is #false
-  M rx'"x"{1..3}' "xx" ~is ["xx"]
-  M rx'"x"{1..3}' "xxx" ~is ["xxx"]
-  M rx'"x"{1..3}' "xxxx" ~is #false
-  M rx'"x"{1..3} "y"' "y" ~is #false
-  M rx'"x"{1..3} "y"' "xxxy" ~is ["xxxy"]
-  M rx'"x"{1..3} "xy"' "xxxy" ~is ["xxxy"]
-  M rx'"x"{1..3} ~possessive "y"' "xxxy" ~is ["xxxy"]
-  M rx'"x"{1..3} ~possessive "xy"' "xxxy" ~is #false
-  M rx'"x"{1..3} ~greedy $end: "x"*' "xxx" ~is ["xxx", ""]
-  M rx'"x"{1..3} ~nongreedy $end: "x"*' "xxx" ~is ["xxx", "xx"]
-  M rx'"x"{1..3} ~possessive $end: "x"*' "xxx" ~is ["xxx", ""]
-  M rx'"x"{0..3}' "" ~is [""]
+  M rx'"x"{1..=3}' "xy" ~is #false
+  P rx'"x"{1..=3}' "xy" ~is ["x"]
+  P rx'"x"{1..=3}' "ax" ~is ["x"]
+  M rx'"x"{1..=3}' "" ~is #false
+  M rx'"x"{1..=3}' "xx" ~is ["xx"]
+  M rx'"x"{1..=3}' "xxx" ~is ["xxx"]
+  M rx'"x"{1..=3}' "xxxx" ~is #false
+  M rx'"x"{1..=3} "y"' "y" ~is #false
+  M rx'"x"{1..=3} "y"' "xxxy" ~is ["xxxy"]
+  M rx'"x"{1..=3} "xy"' "xxxy" ~is ["xxxy"]
+  M rx'"x"{1..=3} ~possessive "y"' "xxxy" ~is ["xxxy"]
+  M rx'"x"{1..=3} ~possessive "xy"' "xxxy" ~is #false
+  M rx'"x"{1..=3} ~greedy $end: "x"*' "xxx" ~is ["xxx", ""]
+  M rx'"x"{1..=3} ~nongreedy $end: "x"*' "xxx" ~is ["xxx", "xx"]
+  M rx'"x"{1..=3} ~possessive $end: "x"*' "xxx" ~is ["xxx", ""]
+  M rx'"x"{0..=3}' "" ~is [""]
   M rx'"x"{2..}' "x" ~is #false
   M rx'"x"{2..}' "xx" ~is ["xx"]
   M rx'"x"{2..}' "xxxxx" ~is ["xxxxx"]
@@ -441,7 +441,7 @@ check_throws rx'(string: byte)' "byte string mode used in a context that require
 check_throws rx'[alpha-"q"]' "expected a single-character set for a range start"
 check_throws rx'()*' "repetition operand could match an empty string"
 check_throws rx'()+' "repetition operand could match an empty string"
-check_throws rx'(){1..2}' "repetition operand could match an empty string"
+check_throws rx'(){1..=2}' "repetition operand could match an empty string"
 check_throws rx'()* ~nongreedy' "repetition operand could match an empty string"
 check_throws rx'lookbehind(.*)' "pattern must match a bounded sequence"
 check_throws rx'($x: .*) $x *' "repetition operand could match an empty string"


### PR DESCRIPTION
In `pat {min .. max}`, `pat` would be matched from `min` (inclusive) to `max` (inclusive) times, but expression `min .. max` doesn't include `max`.  Instead, the new `pat {min ..= max}` form corresponds to expression `min ..= max`, which includes `max`.  The `pat {min ..}` form is still kept as-is, corresponding to expression `min ..`.

Also add `..`/`..=` to regexp pattern space, and change `#%comp` to recognize them by bindings.