### PR TITLE
more consistently name `maybe(....)` conversion functions

### DIFF
--- a/rhombus-lib/rhombus/cmdline.rhm
+++ b/rhombus-lib/rhombus/cmdline.rhm
@@ -51,7 +51,7 @@ fun convert_lib_module_path(x):
   | [base, submod, ...]:
       cond
       | all(submod.length() != 0, ...):
-          ModulePath.try('lib($base) $(List.append(['!', Symbol.from_string(submod)], ...))')
+          ModulePath.maybe('lib($base) $('! $(Symbol.from_string(submod))') ...')
       | ~else: #false
   | ~else: #false
 

--- a/rhombus-lib/rhombus/private/amalgam/module-path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/module-path-object.rkt
@@ -67,7 +67,7 @@
   #:just-annot
   #:fields ()
   #:namespace-fields
-  ([try ModulePath.try])
+  ([maybe ModulePath.maybe])
   #:properties
   ()
   #:methods
@@ -257,6 +257,6 @@
   #:static-infos ((#%call-result #,(get-module-path-static-infos)))
   (parse-ModulePath who stx #f))
 
-(define/arity (ModulePath.try stx)
+(define/arity (ModulePath.maybe stx)
   #:static-infos ((#%call-result ((#%maybe #,(get-module-path-static-infos)))))
   (parse-ModulePath who stx #t))

--- a/rhombus/rhombus/run.rhm
+++ b/rhombus/rhombus/run.rhm
@@ -12,7 +12,7 @@ fun file_to_mod_path(str :: String):
   match str.split("!")
   | [base, submod, ...]:
       all(submod.length() != 0, ...)
-        && ModulePath.try('file($base) $(List.append(['!', Symbol.from_string(submod)], ...))')
+        && ModulePath.maybe('file($base) $('! $(Symbol.from_string(submod))') ...')
   | ~else: #false
 
 // Keys for `args` map

--- a/rhombus/rhombus/scribblings/reference/import.scrbl
+++ b/rhombus/rhombus/scribblings/reference/import.scrbl
@@ -137,7 +137,7 @@
    by itself, with the additional constraint that @litchar{.} and
    @litchar{..} directory indicators are disallowed. More like a @rhombus(collection_module_path),
    if @rhombus(string) does not include @litchar{/}, then @filepath{/main.rhm}
-   is appended to @rhombus(string). When @rhombus(string) contains @litchar{/} but 
+   is appended to @rhombus(string). When @rhombus(string) contains @litchar{/} but
    does not end with a file suffix, @filepath{.rhm} is added.},
 
  @item{@rhombus(#,(@rhombus(file, ~impo))(string)): refers to a file through a
@@ -435,6 +435,7 @@
 
 }
 
+
 @doc(
   ~nonterminal:
     module_path: import ~defn
@@ -444,7 +445,7 @@
   expr.macro '«ModulePath '$module_path'»'
   repet.macro 'ModulePath'
 
-  fun ModulePath.try(mod_stx :: Group) :: maybe(ModulePath)
+  fun ModulePath.maybe(mod_stx :: Group) :: maybe(ModulePath)
 
   method (mp :: ModulePath).s_exp() :: Any
   method (mod :: ModulePath).add(rel_mod :: ModulePath) :: ModulePath
@@ -455,7 +456,7 @@
  expression form create such a value for a syntax-object
  @rhombus(mod_stx) or a quoted @rhombus(module_path). As a repetition,
  @rhombus(ModulePath, ~repet) is the same as referring to the
- @rhombus(ModulePath) function. The @rhombus(ModulePath.try) function
+ @rhombus(ModulePath) function. The @rhombus(ModulePath.maybe) function
  is like @rhombus(ModulePath), but it returns @rhombus(#false) instead
  of throwing an exception when @rhombus(mod_stx) does not represent
  a valid module path.

--- a/rhombus/rhombus/scribblings/reference/string.scrbl
+++ b/rhombus/rhombus/scribblings/reference/string.scrbl
@@ -361,26 +361,33 @@ Strings are @tech{comparable}, which means that generic operations like
 }
 
 
-
-
 @doc(
-  method String.to_int(str :: ReadableString) :: maybe(Int)
+  method String.to_int(str :: ReadableString) :: Int
   annot.macro 'String.to_int'
+  method String.maybe_to_int(str :: ReadableString) :: maybe(Int)
 ){
 
- The @rhombus(String.to_int) function parses @rhombus(str) as an integer, returning @rhombus(#false) if the
- string does not parse as an integer, otherwise returning the integer
- value.
+ The @rhombus(String.to_int) function parses @rhombus(str) as an
+ integer and returns the integer value. If @rhombus(str) does not
+ parse as an integer, the @rhombus(Exn.Fail.Contract, ~class)
+ exception is thrown. The @rhombus(String.maybe_to_int) function is
+ like @rhombus(String.to_int), but it returns @rhombus(#false) if
+ @rhombus(str) does not parse as an integer.
 
 @examples(
   String.to_int("-42")
-  String.to_int("42.0")
-  String.to_int("forty-two")
+  ~error:
+    String.to_int("42.0")
+  String.maybe_to_int("42.0")
+  ~error:
+    String.to_int("forty-two")
+  String.maybe_to_int("forty-two")
   "100".to_int()
+  "100".maybe_to_int()
 )
 
  The @rhombus(String.to_int, ~annot) @tech(~doc: guide_doc){converter annotation} is
- satisfied by a string that can be converted to an integer via
+ satisfied by an immutable string that can be converted to an integer via
  @rhombus(String.to_int), and it converts to that integer.
 
 @examples(
@@ -394,24 +401,31 @@ Strings are @tech{comparable}, which means that generic operations like
 
 
 @doc(
-  method String.to_number(str :: ReadableString) :: maybe(Number)
+  method String.to_number(str :: ReadableString) :: Number
   annot.macro 'String.to_number'
+  method String.maybe_to_number(str :: ReadableString) :: maybe(Number)
 ){
 
- The @rhombus(String.to_number) function @rhombus(str) as a number, returning @rhombus(#false) if the
- string does not parse as a number, otherwise returning the number
- value.
+ The @rhombus(String.to_number) function parses @rhombus(str) as a
+ number and returns the number value. If @rhombus(str) does not
+ parse as a number, the @rhombus(Exn.Fail.Contract, ~class)
+ exception is thrown. The @rhombus(String.maybe_to_number) function is
+ like @rhombus(String.to_number), but it returns @rhombus(#false) if
+ @rhombus(str) does not parse as a number.
 
 @examples(
   String.to_number("-42")
   String.to_number("42.0")
-  String.to_number("forty-two")
+  ~error:
+    String.to_number("forty-two")
+  String.maybe_to_number("forty-two")
   "3/4".to_number()
+  "3/4".maybe_to_number()
 )
 
  The @rhombus(String.to_number, ~annot) @tech(~doc: guide_doc){converter annotation} is
- satisfied by a string that can be converted to an integer via
- @rhombus(String.to_int), and it converts to that integer.
+ satisfied by an immutable string that can be converted to a number via
+ @rhombus(String.to_number), and it converts to that number.
 
 @examples(
   def n :: String.to_number = "42.0"

--- a/rhombus/rhombus/tests/for.rhm
+++ b/rhombus/rhombus/tests/for.rhm
@@ -601,8 +601,8 @@ check:
 // check `let` across clause boundary
 check:
   for List:
-    each num_str in ["1","2","3","4","5", "a"]
-    let num = String.to_number(num_str)
+    each num_str in ["1", "2", "3", "4", "5", "a"]
+    let num = String.maybe_to_number(num_str)
     skip_when !num
     num
   ~is [1, 2, 3, 4, 5]
@@ -620,9 +620,9 @@ version_guard.at_least "8.11.1.4":
   // combine `import` and `let` across clause boundary
   check:
     for List:
-      each num_str in ["1","2","3","4","5", "a"]
+      each num_str in ["1", "2", "3", "4", "5", "a"]
       import: rhombus.List as L
-      let num = String.to_number(num_str)
+      let num = String.maybe_to_number(num_str)
       skip_when !num
       L(num)
     ~is [[1], [2], [3], [4], [5]]

--- a/rhombus/rhombus/tests/module-path.rhm
+++ b/rhombus/rhombus/tests/module-path.rhm
@@ -4,6 +4,7 @@ block:
   import "static_arity.rhm"
   static_arity.check:
     ModulePath(s)
+    ModulePath.maybe(s)
     ModulePath.s_exp(mod) ~method
 
 // syntax form
@@ -49,8 +50,8 @@ check:
   ModulePath('parent') ~is ModulePath 'parent'
   ModulePath('parent!x') ~is ModulePath 'parent ! x'
   ModulePath('parent!x!y') ~is ModulePath 'parent ! x ! y'
-  ModulePath.try('lib("m")') ~is ModulePath 'lib("m/main.rhm")'
-  ModulePath.try('lib("m ?")') ~is #false
+  ModulePath.maybe('lib("m")') ~is ModulePath 'lib("m/main.rhm")'
+  ModulePath.maybe('lib("m ?")') ~is #false
 
 // method
 block:
@@ -75,7 +76,8 @@ block:
     (ModulePath 'parent!x').s_exp() ~is (ModulePath 'parent ! x').s_exp()
     (ModulePath 'parent!x!y').s_exp() ~is (ModulePath 'parent ! x ! y').s_exp()
     ModulePath('lib("m")').s_exp() ~is (ModulePath 'lib("m/main.rhm")').s_exp()
-    ModulePath.try('lib("m")')?.s_exp() ~is (ModulePath 'lib("m/main.rhm")').s_exp()
+    ModulePath.maybe('lib("m")')?.s_exp() ~is (ModulePath 'lib("m/main.rhm")').s_exp()
+    ModulePath.maybe('lib("m ?")')?.s_exp() ~is #false
 
 check:
   dynamic(ModulePath 'm').s_exp() ~is dynamic(ModulePath 'm').s_exp()

--- a/rhombus/rhombus/tests/string.rhm
+++ b/rhombus/rhombus/tests/string.rhm
@@ -15,6 +15,8 @@ block:
     String.ends_with(str, substr) ~method ReadableString
     String.to_string(str) ~method ReadableString
     ReadableString.to_string(str) ~method
+    String.maybe_to_int(str) ~method ReadableString
+    String.maybe_to_number(str) ~method ReadableString
     String.to_int(str) ~method ReadableString
     String.to_number(str) ~method ReadableString
     String.substring(str, start, [end]) ~method ReadableString
@@ -62,9 +64,19 @@ block:
     )
     "hello".append(" world") ~is "hello world"
     "hello".append(" world", " and bye") ~is "hello world and bye"
-    "hello".to_int() ~is #false
+    "hello".maybe_to_int() ~is #false
+    "17".maybe_to_int() ~is 17
+    "hello".maybe_to_number() ~is #false
+    "4.35".maybe_to_number() ~is 4.35
+    "hello".to_int() ~throws values(
+      "String.to_int: string does not parse as an integer",
+      error.val("hello", ~label: "string").msg,
+    )
     "17".to_int() ~is 17
-    "hello".to_number() ~is #false
+    "hello".to_number() ~throws values(
+      "String.to_number: string does not parse as a number",
+      error.val("hello", ~label: "string").msg,
+    )
     "4.35".to_number() ~is 4.35
     "hello".upcase() ~is "HELLO"
     "Hello".downcase() ~is "hello"
@@ -127,10 +139,19 @@ check:
   dynamic("hello" ++ " ") ++ #"world" ~throws "cannot append a string and other value"
   dynamic("hello").append(" world") ~is "hello world"
   dynamic("hello").append(" world", " and bye") ~is "hello world and bye"
-  dynamic("hello").to_int() ~is #false
+  dynamic("hello").maybe_to_int() ~is #false
+  dynamic("17").maybe_to_int() ~is 17
+  dynamic("hello").maybe_to_number() ~is #false
+  dynamic("4.35").maybe_to_number() ~is 4.35
+  dynamic("hello").to_int() ~throws values(
+    "String.to_int: string does not parse as an integer",
+    error.val("hello", ~label: "string").msg,
+  )
   dynamic("17").to_int() ~is 17
-  dynamic("hello").to_number() ~is #false
-  dynamic("4.35").to_number() ~is 4.35
+  dynamic("hello").to_number() ~throws values(
+    "String.to_number: string does not parse as a number",
+    error.val("hello", ~label: "string").msg,
+  )
   dynamic("hello").upcase() ~is "HELLO"
   dynamic("Hello").downcase() ~is "hello"
   dynamic("hello").locale_upcase() ~is_a String
@@ -170,6 +191,8 @@ check:
 
 check:
   String.length("hello") ~is 5
+  String.maybe_to_int("17") ~is 17
+  String.maybe_to_number("4.35") ~is 4.35
   String.to_int("17") ~is 17
   String.to_number("4.35") ~is 4.35
   String.upcase("hello") ~is "HELLO"
@@ -521,4 +544,22 @@ block:
   check f("10") ~is 10
   check f("1") ~is [1]
   check f("10.0") ~is { 10.0 }
+  check f("10".copy()) ~is #false
+  check f("1".copy()) ~is #false
+  check f("10.0".copy()) ~is #false
   check f(10.0) ~is #false
+
+// check result info for `(maybe_)to_{int,number}` methods
+block:
+  use_static
+  def int_str = "1"
+  check:
+    int_str.to_int() < dynamic(2) ~is #true
+    int_str.maybe_to_int()!! < dynamic(2) ~is #true
+
+block:
+  use_static
+  def num_str = "1.0"
+  check:
+    num_str.to_number() < dynamic(2.0) ~is #true
+    num_str.maybe_to_number()!! < dynamic(2.0) ~is #true


### PR DESCRIPTION
Change `ModulePath.try` to `ModulePath.maybe`; add `String.maybe_to_{int,number}` and change `String.to_{int,number}` to throw exceptions instead of returning `#false`.  In general, `maybe(....)` conversion functions should include `maybe` in their names, and variants without `maybe` should throw an exception instead of returning `#false`.

Also fix behavior of `String.to_{int,number}` annotations on mutable strings, that is, they should not match.