### PR TITLE
Improve repetition syntax error message

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/repetition.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/repetition.rkt
@@ -286,15 +286,19 @@
 
 (define-for-syntax (raise-wrong-depth expr used-depth-stx want-depth actual-depth
                                       #:at-least? [at-least? #f])
-  (raise-syntax-error #f
-                      "used with wrong repetition depth"
-                      expr
-                      #f
-                      null
-                      (format "\n  expected: ~a\n  actual: ~a~a"
-                              (+ want-depth (syntax-e used-depth-stx))
-                              (if at-least? "at least " "")
-                              (+ actual-depth (syntax-e used-depth-stx)))))
+  (define expected-depth (+ want-depth (syntax-e used-depth-stx)))
+  (define adjusted-actual-depth (+ actual-depth (syntax-e used-depth-stx)))
+  (cond
+    [(and (zero? expected-depth) (positive? adjusted-actual-depth))
+     (define details (format "\n  used repetition depth: ~a" adjusted-actual-depth))
+     (raise-syntax-error #f "not a repetition" expr #f null details)]
+    [else
+     (define details
+       (format "\n  expected: ~a\n  actual: ~a~a"
+               expected-depth
+               (if at-least? "at least " "")
+               adjusted-actual-depth))
+     (raise-syntax-error #f "used with wrong repetition depth" expr #f null details)]))
 
 (define-syntax (define-repetition-syntax stx)
   (syntax-parse stx

--- a/rhombus/rhombus/tests/repetition.rhm
+++ b/rhombus/rhombus/tests/repetition.rhm
@@ -351,3 +351,14 @@ check:
   def [x, ...] = [1, 2, 3]
   [[if 1 | 2 | 3, x,] ...]
   ~throws "cannot use expression binding as a repetition"
+
+check:
+  ~eval
+  [x, ...]
+  ~throws "not a repetition"
+
+check:
+  ~eval
+  def [x, ...] = [1, 2, 3]
+  [x, ..., ...]
+  ~throws "used with wrong repetition depth"


### PR DESCRIPTION
The [Repetitions](https://docs.racket-lang.org/rhombus/repetition.html) documentation includes this example code:

```
> def five = 5
> [five, ...]
five: used with wrong repetition depth
  expected: 0
  actual: 1
```

In cases where the bound variable isn't a repetition at all, like above, I find the error message confusing. So this pull request adds a special case for that which changes the message to this:

```
> [five, ...]
five: not a repetition binding
  used repetition depth: 1
```

This new message is only shown when the variable isn't a repetition and is used in any repetition position. In all other cases, the original error message is used.