### PR TITLE
Add `guard` and `guard.let`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
@@ -18,4 +18,5 @@
         "str.rhm"
         "closeable.rhm"
         "filesystem.rhm"
-        "system.rhm")
+        "system.rhm"
+        "guard.rhm")

--- a/rhombus-lib/rhombus/private/amalgam/guard.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/guard.rhm
@@ -6,36 +6,92 @@ import:
 export:
   guard
 
+meta syntax_class GuardAndSuccess(stx):
+  kind: ~multi
+  fields: [condition, ...]
+          failure_body
+          success_body
+| '$condition ... | $failure_body
+   $(success_body :: Multi)':
+    when '$condition ...' matches ''
+    | syntax_meta.error("empty condition for guard",
+                        stx)
+    when failure_body matches ''
+    | syntax_meta.error("empty failure body for guard",
+                        stx)
+    when success_body matches ''
+    | syntax_meta.error("empty success sequence after guard",
+                        stx)
+| '$(seq :: Sequence)
+   $(_ :: Multi)':
+    match seq
+    | '$_ ... | $__body | ...':
+        syntax_meta.error("expected a single `|` alternative for failure body",
+                          stx,
+                          seq)
+    | ~else:
+        syntax_meta.error("missing `|` alternative for failure body",
+                          stx,
+                          seq)
+    field [condition, ...] = []
+    field failure_body = #false
+    field success_body = #false
 
-defn.sequence_macro 'guard $condition ... | $failure_body
-                     $success_body':
-  values(
-    'if $condition ...
-     | $success_body
-     | $failure_body',
-    '')
+defn.sequence_macro 'guard $seq ... ~nonempty
+                     $rest':
+  ~all_stx: stx
+  match '$seq ...; $rest':
+  | '$(g :: GuardAndSuccess(stx))':
+      values(
+        'if $g.condition ...
+         | $g.success_body
+         | $g.failure_body',
+        ''
+      )
 
-
-meta syntax_class GuardRightHandSide:
-  fields: as_expression
-  root_swap: as_expression raw_sequence
-| ': $e ...':
-    field as_expression = '$e ...'
-| ': $(b :: Block)':
-    field as_expression = 'block $b'
-| '$(bound_as expr_meta.space: '=') $e ...':
-    field as_expression = '$e ...'
-
+meta syntax_class GuardBindAndRightHandSide(who):
+  fields: [bind, ...]
+          rhs_expression
+| '$bind ... ~nonempty: $e ...':
+    field rhs_expression = '$e ...'
+    when rhs_expression matches ''
+    | syntax_meta.error(~who: who,
+                        "empty expression for binding",
+                        '$bind ...')
+| '$bind ... ~nonempty: $(b :: Block)':
+    field rhs_expression = 'block $b'
+| '$bind ... ~nonempty $(eql && bound_as expr_meta.space: '=') $e ...':
+    field rhs_expression = '$e ...'
+    when '$bind ... $e ...' matches '$_ ... $(bound_as expr_meta.space: '=') $_ ...':
+    | syntax_meta.error(~who: who,
+                        "multiple immediate equals not allowed in this group;\n"
+                          ++ " use parentheses to disambiguate",
+                        eql)
+    when '$e ...' matches ''
+    | syntax_meta.error(~who: who,
+                        "empty expression for binding",
+                        '$bind ...')
+| '$bind ...':
+    syntax_meta.error(~who: who,
+                      "expected binding followed by expression or block",
+                      '$bind ...')
+    field rhs_expression = #false
 
 namespace guard:
   export:
     rename guard_let as let
 
-  defn.sequence_macro 'guard_let $test_pattern ... $(rhs :: GuardRightHandSide)
-                       | $failure_body
-                       $success_body':
-    values(
-      'match $rhs
-       | $test_pattern ...: $success_body
-       | ~else: $failure_body',
-      '')
+  defn.sequence_macro 'guard_let $seq ... ~nonempty
+                       $rest':
+    ~op_stx: who
+    ~all_stx: stx
+    match '$seq ...; $rest':
+    | '$(g :: GuardAndSuccess(stx))':
+        match '$g.condition ...'
+        | '$(gb :: GuardBindAndRightHandSide(who))':
+            values(
+              'match $gb.rhs_expression
+               | $gb.bind ...: $g.success_body
+               | ~else: $g.failure_body',
+              ''
+            )

--- a/rhombus-lib/rhombus/private/amalgam/guard.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/guard.rhm
@@ -16,17 +16,26 @@ defn.sequence_macro 'guard $condition ... | $failure_body
     '')
 
 
+meta syntax_class GuardRightHandSide:
+  fields: as_expression
+  root_swap: as_expression raw_sequence
+| ': $e ...':
+    field as_expression = '$e ...'
+| ': $(b :: Block)':
+    field as_expression = 'block $b'
+| '$(bound_as expr_meta.space: '=') $e ...':
+    field as_expression = '$e ...'
+
+
 namespace guard:
   export:
     rename guard_let as let
 
-  defn.sequence_macro 'guard_let $test_pattern ...
-                         $(bound_as expr_meta.space: '=')
-                         $target_expr ...
+  defn.sequence_macro 'guard_let $test_pattern ... $(rhs :: GuardRightHandSide)
                        | $failure_body
                        $success_body':
     values(
-      'match $target_expr ...
+      'match $rhs
        | $test_pattern ...: $success_body
        | ~else: $failure_body',
       '')

--- a/rhombus-lib/rhombus/private/amalgam/guard.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/guard.rhm
@@ -1,0 +1,32 @@
+#lang rhombus/private/amalgam/core
+
+import:
+  "core-meta.rkt" open
+
+export:
+  guard
+
+
+defn.sequence_macro 'guard $condition ... | $failure_body
+                     $success_body':
+  values(
+    'if $condition ...
+     | $success_body
+     | $failure_body',
+    '')
+
+
+namespace guard:
+  export:
+    rename guard_let as let
+
+  defn.sequence_macro 'guard_let $test_pattern ...
+                         $(bound_as expr_meta.space: '=')
+                         $target_expr ...
+                       | $failure_body
+                       $success_body':
+    values(
+      'match $target_expr ...
+       | $test_pattern ...: $success_body
+       | ~else: $failure_body',
+      '')

--- a/rhombus/rhombus/scribblings/guide/conditional.scrbl
+++ b/rhombus/rhombus/scribblings/guide/conditional.scrbl
@@ -116,3 +116,72 @@ multiple cases, use the function name after @rhombus(fun), then
     | fib(1): 1
     | fib(n :: NonnegInt): fib(n-1) + fib(n-2)
 )
+
+The @rhombus(if), @rhombus(cond), and @rhombus(match) forms are best for
+writing a single conditional expression where each branch has similar
+importance. However, it is often the case that some condition needs to be
+"gotten out of the way" before the "real logic" of an operation can
+happen. Consider this code:
+
+@examples(
+  ~hidden:
+    class User(name):
+      method get_documents(): [1, 2, 3]
+
+    fun get_user(_):
+      User("Alice")
+  ~defn:
+    fun show_user_stats(user_id):
+      cond
+      | user_id == "": #false
+      | ~else:
+          let user = get_user(user_id)
+          let document_count = user.get_documents().length
+          let message = @str{User @user.name has @document_count documents.}
+          println(message)
+  ~repl:
+    show_user_stats("bf4afcb")
+    show_user_stats("")
+)
+
+In these instances, the @rhombus(guard) form can be used. A @rhombus(guard)
+expression checks that a condition is true, and if it isn't, short-circuits
+the surrounding block with a given alternative. The above code can be
+rewritten using guard expressions like so:
+
+@examples(
+  ~hidden:
+    class User(name):
+      method get_documents(): [1, 2, 3]
+
+    fun get_user(_):
+      User("Alice")
+  ~defn:
+    fun show_user_stats(user_id):
+      guard user_id != "" | #false
+      let user = get_user(user_id)
+      let document_count = user.get_documents().length()
+      let message = @str{User @user.name has @document_count documents.}
+      println(message)
+  ~repl:
+    show_user_stats("bf4afcb")
+    show_user_stats("")
+)
+
+A pattern matching variant, @rhombus(guard.let), is also available. The
+@rhombus(guard.let) form checks that a value matches a pattern, otherwise
+it short-circuits with a given alternative just like @rhombus(guard). Here
+we can use it to check that two lists are equal:
+
+@examples(
+  ~defn:
+    fun lists_equal(xs, ys):
+      guard.let [x, & rest_xs] = xs | ys == []
+      guard.let [y, & rest_ys] = ys | #false
+      x == y && lists_equal(rest_xs, rest_ys)
+  ~repl:
+    lists_equal([1, 2, 3], [1, 2, 3])
+    lists_equal([1], [1, 2, 3])
+    lists_equal([1, 2, 3], [1])
+    lists_equal([1, 2, 3], [1, 2, 10000])
+)

--- a/rhombus/rhombus/scribblings/guide/conditional.scrbl
+++ b/rhombus/rhombus/scribblings/guide/conditional.scrbl
@@ -120,7 +120,7 @@ multiple cases, use the function name after @rhombus(fun), then
 The @rhombus(if), @rhombus(cond), and @rhombus(match) forms are best for
 writing a single conditional expression where each branch has similar
 importance. However, it is often the case that some condition needs to be
-"gotten out of the way" before the "real logic" of an operation can
+gotten out of the way before the ``real logic'' of an operation can
 happen. Consider this code:
 
 @examples(
@@ -136,7 +136,7 @@ happen. Consider this code:
       | user_id == "": #false
       | ~else:
           let user = get_user(user_id)
-          let document_count = user.get_documents().length
+          let document_count = user.get_documents().length()
           let message = @str{User @user.name has @document_count documents.}
           println(message)
   ~repl:

--- a/rhombus/rhombus/scribblings/reference/branch.scrbl
+++ b/rhombus/rhombus/scribblings/reference/branch.scrbl
@@ -8,6 +8,7 @@
 
 @include_section("cond.scrbl")
 @include_section("match.scrbl")
+@include_section("guard.scrbl")
 @include_section("annotation.scrbl")
 @include_section("equal.scrbl")
 @include_section("check.scrbl")

--- a/rhombus/rhombus/scribblings/reference/guard.scrbl
+++ b/rhombus/rhombus/scribblings/reference/guard.scrbl
@@ -20,7 +20,7 @@
  Checks that @rhombus(test_expr) produces a true value, evaluating the
 @rhombus(body) sequence if so. If @rhombus(test_expr) produces
 @rhombus(#false), then @rhombus(body) is skipped and @rhombus(failure_body)
-is evaluated instead. This is equivalent to
+is evaluated, instead. This is equivalent to
 @rhombus(if $test_expr | $body ... | $failure_body ...), and is primarily
 useful when @rhombus(body) is much more complex than @rhombus(failure_body)
 or contains a mixture of definitions and additional @rhombus(guard) forms
@@ -68,7 +68,7 @@ Static information works the same way as it would in an equivalent
 available in the subsequent @rhombus(body) sequence. If
 @rhombus(target_expr) does not match @rhombus(test_bind), then the
 @rhombus(body) sequence is skipped and @rhombus(failure_body) is
-evaluated instead. This is the pattern matching variant of
+evaluated, instead. This is the pattern matching variant of
 @rhombus(guard), see its documentation for general advice on using
 guards.
 

--- a/rhombus/rhombus/scribblings/reference/guard.scrbl
+++ b/rhombus/rhombus/scribblings/reference/guard.scrbl
@@ -1,0 +1,102 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@title{Guards}
+
+@doc(
+  ~nonterminal:
+    test_expr: block expr
+    failure_body: block body
+    body: block body
+  defn.sequence_macro 'guard $test_expr
+                       | $failure_body
+                         ...
+                       $body
+                       ...'
+){
+
+ Checks that @rhombus(test_expr) produces a true value, evaluating the
+@rhombus(body) sequence if so. If @rhombus(test_expr) produces
+@rhombus(#false), then @rhombus(body) is skipped and @rhombus(failure_body)
+is evaluated instead. This is equivalent to
+@rhombus(if $test_expr | $body ... | $failure_body ...), and is primarily
+useful when @rhombus(body) is much more complex than @rhombus(failure_body)
+or contains a mixture of definitions and additional @rhombus(guard) forms
+interleaved with each other.
+
+Static information works the same way as it would in an equivalent
+@rhombus(if) expression.
+
+@examples(
+  block:
+    guard #true | println("KABOOM!!!")
+    println("everything working normally")
+
+  block:
+    guard #false | println("KABOOM!!!")
+    println("everything working normally")
+)
+
+}
+
+
+@doc(
+  ~nonterminal:
+    test_bind: block expr
+    target_expr: block expr
+    target_body: block body
+    failure_body: block body
+    body: block body
+  defn.sequence_macro 'guard.let $test_bind = $target_expr
+                       | $failure_body
+                         ...
+                       $body
+                       ...'
+  defn.sequence_macro 'guard.let $test_bind:
+                         $target_body
+                         ...
+                       | $failure_body
+                         ...
+                       $body
+                       ...'
+){
+
+ Checks that @rhombus(target_expr) produces a value that matches
+@rhombus(test_bind) and makes the bindings of @rhombus(test_bind)
+available in the subsequent @rhombus(body) sequence. If
+@rhombus(target_expr) does not match @rhombus(test_bind), then the
+@rhombus(body) sequence is skipped and @rhombus(failure_body) is
+evaluated instead. This is the pattern matching variant of
+@rhombus(guard), see its documentation for general advice on using
+guards.
+
+@examples(
+  ~defn:
+    fun print_third(xs):
+      guard.let [_, _, third, & _] = xs
+      | println("list doesn't have three or more elements")
+      println(third)
+  ~repl:
+    print_third(["hi", "hello", "goodbye", "farewell"])
+    print_third(["hi", "hello"])
+)
+
+The block form with @rhombus(target_body) is
+equivalent to using @rhombus(block: target_body ...) as the
+@rhombus(target_expr).
+
+@examples(
+  ~defn:
+    fun print_third(xs):
+      guard.let [_, _, third, & _]:
+        xs
+      | println("list doesn't have three or more elements")
+      println(third)
+  ~repl:
+    print_third(["hi", "hello", "goodbye", "farewell"])
+    print_third(["hi", "hello"])
+)
+
+}

--- a/rhombus/rhombus/tests/guard.rhm
+++ b/rhombus/rhombus/tests/guard.rhm
@@ -85,3 +85,89 @@ check:
     | 100
     x + y
   ~is 3
+
+check:
+  ~eval
+  guard
+  ~throws "expected more terms"
+
+check:
+  ~eval
+  guard
+  0
+  ~throws "expected more terms"
+
+check:
+  ~eval
+  guard 1
+  ~throws "missing `|` alternative for failure body"
+
+check:
+  ~eval
+  guard 1 | #false
+  ~throws "empty success sequence after guard"
+
+check:
+  ~eval
+  guard 1 | #false | #true
+  ~throws "expected a single `|` alternative for failure body"
+
+check:
+  ~eval
+  guard 1 |«»
+  ~throws "empty failure body for guard"
+
+check:
+  ~eval
+  guard.let
+  ~throws "expected more terms"
+
+check:
+  ~eval
+  guard.let
+  0
+  ~throws "expected more terms"
+
+check:
+  ~eval
+  guard.let 1
+  ~throws "missing `|` alternative for failure body"
+
+check:
+  ~eval
+  guard.let 1 | #false
+  ~throws "empty success sequence after guard"
+
+check:
+  ~eval
+  guard.let 1 | #false | #true
+  ~throws "expected a single `|` alternative for failure body"
+
+check:
+  ~eval
+  guard.let 1 |«»
+  ~throws "empty failure body for guard"
+
+check:
+  ~eval
+  guard.let 1 | #false
+  0
+  ~throws "expected binding followed by expression or block"
+
+check:
+  ~eval
+  guard.let 1 = 1 = 1 | #false
+  0
+  ~throws "multiple immediate equals not allowed"
+
+check:
+  ~eval
+  guard.let 1 = | #false
+  0
+  ~throws "empty expression for binding"
+
+check:
+  ~eval
+  guard.let 1:«» | #false
+  0
+  ~throws "empty expression for binding"

--- a/rhombus/rhombus/tests/guard.rhm
+++ b/rhombus/rhombus/tests/guard.rhm
@@ -1,0 +1,87 @@
+#lang rhombus
+
+check:
+  block:
+    guard #false | 1
+    2
+  ~is 1
+
+check:
+  block:
+    guard #true | 1
+    2
+  ~is 2
+
+check:
+  block:
+    let x = 1
+    guard x > 0
+    | let y = x - 1
+      -100
+    let y = x + 1
+    100
+  ~is 100
+
+check:
+  block:
+    let x = 1
+    guard x < 0
+    | let y = x - 1
+      -100
+    let y = x + 1
+    100
+  ~is -100
+
+class Point(x, y)
+
+check:
+  block:
+    guard.let Point(x, y) = #false | 100
+    x + y
+  ~is 100
+
+check:
+  block:
+    guard.let Point(x, y) = Point(1, 2) | 100
+    x + y
+  ~is 3
+
+
+check:
+  block:
+    guard.let Point(x, y) = #false
+    | let x = 42
+      let y = 43
+      100
+    let z = x + y
+    z
+  ~is 100
+
+check:
+  block:
+    guard.let Point(x, y) = Point(1, 2)
+    | let x = 42
+      let y = 43
+      100
+    let z = x + y
+    z
+  ~is 3
+
+
+check:
+  block:
+    guard.let Point(x, y):
+      let foo = 42
+      #false
+    | 100
+    x + y
+  ~is 100
+
+check:
+  block:
+    guard.let Point(x, y):
+      let foo = 42
+      Point(1, 2)
+    | 100
+    x + y
+  ~is 3


### PR DESCRIPTION
This pull request adds _guard statements_ (as seen in Swift and Rust) in the form of two new control flow utility macros, `guard` and `guard.let`. They're definition sequence macros that give straight-line code the ability to escape early if a condition isn't met. Their semantics are the same as in my [`guard`](https://docs.racket-lang.org/guard/) package for Racket, with the exception that `define/guard` and `guarded-block` aren't needed. As an example, here are two versions of a `list_equals(xs, ys)` function, one with guard statements and one without:

```haskell
fun list_equals(xs :: List, ys :: List):
  cond
  | xs == []: ys == []
  | ys == []: #false
  | ~else:
      let [x, & rest_xs] = xs
      let [y, & rest_ys] = ys
      x == y && list_equals(rest_xs, rest_ys)
```

```haskell
fun list_equals(xs :: List, ys :: List):
  guard.let [x, & rest_xs] = xs | ys == []
  guard.let [y, & rest_ys] = ys | #false
  x == y && list_equals(rest_xs, rest_ys)
```

The `guard` form checks that an expression is true; otherwise, it short-circuits the enclosing block and evaluates the given alternative. The `guard.let` form checks that a pattern matches an expression or else short-circuits. They're equivalent to putting the remainder of the block in an enclosing `if` or a `match` expression. Here is a longer piece of example code that uses a mix of `guard` and `guard.let`statements:

```haskell
fun foo(x, y):
  guard.let x :: Int = x | #false
  guard.let y :: Int = y | #false

  println("looks like the types are right")
  println("so far so good")

  guard x > 0 | #false
  guard y > 0 | #false

  println("both values positive")

  guard x > y
  | println("x must be greater than y")
    #false

  guard.let delta :: Int = x - y
  | println("this is supposed to be impossible")
    println("compiler bug?")
    #false

  delta
```

Tests and documentation are not yet included, as I wanted to get feedback on the proposal first.