### PR TITLE
add `net/url` and `net/http`

### DIFF
--- a/rhombus-http-lib/info.rkt
+++ b/rhombus-http-lib/info.rkt
@@ -1,0 +1,15 @@
+#lang info
+
+(define collection 'multi)
+
+(define deps
+  '("base"
+    "rhombus-lib"
+    "http-easy-lib"))
+
+(define pkg-desc "implementation (no documentation) part of \"rhombus-http\"")
+
+(define license '(Apache-2.0 OR MIT))
+
+(define version "0.1")
+

--- a/rhombus-http-lib/net/http.rhm
+++ b/rhombus-http-lib/net/http.rhm
@@ -1,0 +1,5 @@
+#lang rhombus
+import:
+  rhombus/net/http
+export:
+  all_from(.http)

--- a/rhombus-http-lib/rhombus/net/http.rhm
+++ b/rhombus-http-lib/rhombus/net/http.rhm
@@ -1,0 +1,449 @@
+#lang rhombus/static/and_meta
+import:
+  rhombus/rx open
+  lib("net/http-easy.rkt") as easy:
+    expose:
+      response
+  lib("racket/match.rkt"):
+    expose:
+      match as rkt_match
+  lib("racket/base.rkt"):
+    expose:
+      quote
+  net/url
+
+// todo:
+annot.macro 'JSON': 'Any'
+annot.macro 'HTTPConn': 'Any'
+annot.macro 'SSLContext': 'Any'
+annot.macro 'CookieJar': 'Any'
+
+export:
+  get
+  post
+  delete
+  head
+  options
+  patch
+  put
+ 
+  Response
+  Session
+  Timeouts
+  PoolConfig
+  Proxy
+  LiteralURL
+
+  Method
+  Headers
+  StatusCode
+
+  current_user_agent
+
+  auth
+  payload
+
+  Exn
+
+enum Method:
+  get
+  post
+  delete
+  head
+  options
+  patch
+  put
+
+annot.macro 'Headers':
+  'Map.of(String, Bytes || String)'
+
+annot.macro 'StatusCode':
+  'Int.in(100, 999)'
+
+namespace hdr:
+  export:
+    to_symbols
+    to_strings
+  fun to_symbols({k: v, ...}): { Symbol.from_string(k): v, ... }
+  fun to_strings({k: v, ...}): { to_string(k): maybe_to_string(v), ... }
+  fun maybe_to_string(v): if v is_a MutableString | to_string(v) | v
+
+namespace au:
+  export:
+    wrap
+    unwrap
+  fun wrap(f):
+    fun (u, headers, [url.KeyValue(k, v), ...]):
+      let (headers, PairList(Pair(k, v), ...)) = f(url.URL.to_handle(u),
+                                                   hdr.to_symbols(headers),
+                                                   PairList(Pair(k, v), ...))
+      values(hdr.to_strings(headers), [url.KeyValue(k, v), ...])
+  fun unwrap(f):
+    fun (u, headers, PairList[Pair(k, v), ...]):
+      let (headers, [url.KeyValue(k, v), ...]) = f(url.URL.from_handle(u),
+                                                   hdr.to_strings(headers),
+                                                   [url.KeyValue(k, v), ...])
+      values(hdr.to_symbols(headers), PairList[Pair(k, v), ...])
+
+namespace auth:
+  export:
+    Function
+    basic
+    bearer
+  annot.macro 'Function':
+    '(url.URL, Headers, List.of(url.KeyValue)) -> values(Headers, List.of(url.KeyValue))'
+  fun basic(~username: username :: String || Bytes,
+            ~password: password :: String || Bytes) :: Function:
+    au.wrap(easy.#{basic-auth}(username, password))
+  fun bearer(~token: token :: String || Bytes) :: Function:
+    au.wrap(easy.#{bearer-auth}(token))
+
+namespace pl:
+  export:
+    wrap
+    unwrap
+  fun wrap(f):
+    fun (headers):
+      let (headers, r) = f(hdr.to_symbols(headers))
+      values(hdr.to_strings(headers), r)
+  fun unwrap(f):
+    fun (headers):
+      let (headers, r) = f(hdr.to_strings(headers))
+      values(hdr.to_symbols(headers), r)
+
+namespace payload:
+  export:
+    Function
+    buffered
+    form
+    json
+    gzip
+    pure
+    multipart
+  annot.macro 'Function':
+    '(Headers) -> values(Headers, Bytes || String || Port.Input)'
+  fun buffered(f :: Function described_as payload.Function) :: Function:
+    pl.wrap(easy.#{buffered-payload}(pl.unwrap(f)))
+  fun form(f :: List.of(url.KeyValue)) :: Function:
+    let [url.KeyValue(k, v), ...] = f
+    pl.wrap(easy.#{form-payload}(PairList[Pair(Symbol.from_string(k), v), ...]))
+  fun json(j :: JSON) :: Function:
+    pl.wrap(easy.#{json-payload}(j))
+  fun gzip(f :: Function described_as payload.Function) :: Function:
+    pl.wrap(easy.#{gzip-payload}(pl.unwrap(f)))
+  fun pure(inp :: Bytes || String || Port.Input) :: Function:
+    pl.wrap(easy.#{pure-payload}(inp))
+  namespace multipart:
+    export:
+      Part
+    class Part(_handle):
+      opaque
+      internal _Part
+      export:
+        field
+        file
+      property handle: _handle
+      constructor ~none
+    fun field(~name: name :: Bytes || String,
+              ~value: value :: Bytes || String,
+              ~content_type: content_type :: Bytes || String = #"text/plain") :: Part:
+      ~name: multipart.Part.field
+      _Part(easy.#{field-part}(name, value, content_type))
+    fun file(~name: name :: Bytes || String,
+             ~in: inp :: Port.Input,
+             ~filename: filename :: Bytes || String = to_string(Port.name(inp)),
+             ~content_type: content_type :: Bytes || String = #"application/octet-stream") :: Part:
+      ~name: multipart.Part.field
+      _Part(name, inp, filename, content_type)
+  fun multipart(~boundary: boundary :: maybe(Bytes || String),
+                f :: multipart.Part, ...) :: Function:
+    if boundary
+    | easy.#{multipart-payload}(f.handle, ..., ~boundary: boundary)
+    | easy.#{multipart-payload}(f.handle, ...)
+    
+
+class PoolConfig(_handle):
+  opaque
+  internal _PoolConfig
+  property handle: _handle
+  constructor (~max_size: max_size :: PosInt || matching(#inf) = 128,
+               ~idle_timeout_seconds: idle_timeout :: maybe(PosReal) = 600):
+    super(easy.#{make-pool-config}(#{#:max-size}: max_size,
+                                   #{#:idle-timeout}: idle_timeout))
+
+class Timeouts(_handle):
+  opaque
+  internal _Timeouts
+  property handle: _handle
+  constructor (~lease: lease :: maybe(PosReal) = 5,
+               ~connect: connect :: maybe(PosReal) = 5,
+               ~request: request :: maybe(PosReal) = 30):
+    super(easy.#{make-timeout-config}(~lease: lease,
+                                      ~connect: connect,
+                                      ~request: request))
+
+class LiteralURL(_handle):
+  opaque
+  internal _LiteralURL
+  private implements Printable
+  property handle: _handle
+  constructor (s :: String):
+    super(easy.#{string->url/literal})
+  method to_string() :~ String:
+    String.to_string(easy.#{url/literal->string}(_handle))
+  private override describe(mode, recur):
+    if mode == #'text
+    | to_string()
+    | recur(this, ~mode: mode)
+
+Parameter.def current_user_agent :: Bytes || String = easy.#{current-user-agent}()
+
+let header_rx = rx'case_insensitive:
+                     ($name:
+                        [! ":"]*)
+                       ++ ":" blank*
+                       ++ ($val:
+                              any *)'
+
+class Response(_handle):
+  opaque
+  implements Closeable
+  internal _Response
+  constructor ~none
+
+  property handle: _handle
+
+  property status_line :~ Bytes: easy.#{response-status-line}(_handle)
+  property status_code :~ StatusCode: easy.#{response-status-code}(_handle)
+  property status_message :~ Bytes: easy.#{response-status-message}(_handle)
+  property http_version :~ Bytes: easy.#{response-http-version}(_handle)
+  property raw_headers :~ List.of(Bytes): List(& easy.#{response-headers}(_handle))
+
+  method output() :~ Port.Input:
+    easy.#{response-output}(_handle)
+  method body() :~ Bytes:
+    easy.#{response-body}(_handle)
+  method headers() :~ Map.of(String, Bytes):
+    let hs = raw_headers
+    for Map (bstr in hs):
+      let m = header_rx.match(bstr)
+      skip_when !m
+      values(String.foldcase(Bytes.utf8_string(m!![#'name], Char"\uFFFD")),
+             m!![#'val])
+
+  method history() :~ List.of(Response):
+    let PairList[r, ...] = easy.#{response-history}(_handle)
+    [_Response(r), ...]
+
+  binding:
+    fun (stx):
+      match stx
+      | '$self($(group_option_sequence
+                 | '~status_line: $status_line_bind'
+                 | '~status_code: $status_code_bind'
+                 | '~status_message: $status_message_bind'
+                 | '~http_version: $http_version_bind'
+                 | '~history: $history_bind'
+                 | '~headers: { $(header_key :: Sequence): $header_val,
+                                ...,
+                                & $header_bind, ... ~once }'
+                 | '~body: $body_bind'))':
+          let binds = ''
+          let binds: if status_line_bind
+                     | '$binds
+                        $status_line_bind = r.status_line'
+                     | binds
+          let binds: if status_code_bind
+                     | '$binds
+                        $status_code_bind = r.status_code'
+                     | binds
+          let binds: if status_message_bind
+                     | '$binds
+                        $status_message_bind = r.status_message'
+                     | binds
+          let binds: if http_version_bind
+                     | '$binds
+                        $http_version_bind = r.http_version'
+                     | binds
+          let binds: if history_bind
+                     | '$binds
+                        $history_bind = r.history()'
+                     | binds
+          let binds: if [header_key, ...] != [] || [header_bind, ...] != []
+                     | let header_bind:
+                         match [header_bind, ...]
+                         | []: '_'
+                         | [bind]: bind
+                       '$binds
+                        [($header_val) :~ Bytes, ..., ($header_bind) :~ List.of(Bytes)]:
+                          header_extract($self,
+                                         r.handle,
+                                         $header_key, ...)'
+                     | binds
+          let binds: if body_bind
+                     | '$binds
+                        $body_bind = r.body()'
+                     | binds
+          'r :: _Response where:
+             $binds'
+
+  override method close():
+    easy.#{response-close!}(_handle)
+  method drain():
+    easy.#{response-drain!}(_handle)
+
+expr.macro 'header_extract($who, $hand, $key, ...)':
+  let [key_sym, ...]:
+    for List (key in [key, ...]):
+      match key
+      | '$(key :: String)': '$(Symbol.from_string(key.unwrap()))'
+      | ~else:
+          syntax_meta.error(~who: who,
+                            "expected an immediate string",
+                            key)
+  let [key_id, ...] = [Syntax.make_temp_id(key_sym), ...]
+  expr_meta.pack_s_exp(['rkt_match',
+                        expr_meta.pack_expr(hand),
+                        [['response', '#{#:headers}',
+                          [[key_sym, key_id],
+                           ...],
+                          'rest'],
+                         expr_meta.pack_expr('[$key_id, ..., PairList.to_list(rest)]')],
+                        [['quote', '#true'],
+                         expr_meta.pack_expr('#false')]])
+
+class Proxy(_handle):
+  opaque
+  internal _Proxy
+  property handle: _handle
+  export:
+    http
+    https
+
+  constructor (~matches: matches :: url.URL -> Boolean,
+               ~connect: connect :: (HTTPConn, url.URL, maybe(SSLContext)) -> Void) :~ Proxy:
+    super(easy.#{make-proxy}(fun (url_handle):
+                               matches(url.URL.from_handle(url_handle)),
+                             fun (conn_handle, url_handle, ssl_context_handle):
+                               connect(conn_handle, url.URL.from_handle(url_handle), ssl_context_handle)))
+
+fun http(~proxy_url: proxy_url :: String || Bytes || url.URL,
+         ~matches: matches :: url.URL -> Boolean = (fun (u :~ url.URL):
+                                                      u.scheme == "http")) :~ Proxy:
+  ~name: Proxy.http
+  _Proxy(easy.#{make-http-proxy}(proxy_url,
+                                 fun (url_handle):
+                                   matches(url.URL.from_handle(url_handle))))
+
+fun https(~proxy_url: proxy_url :: String || Bytes || url.URL,
+          ~matches: matches :: url.URL -> Boolean = (fun (u :~ url.URL):
+                                                       u.scheme == "https")) :~ Proxy:
+  ~name: Proxy.https
+  _Proxy(easy.#{make-http-proxy}(proxy_url,
+                                 fun (url_handle):
+                                   matches(url.URL.from_handle(url_handle))))
+
+class Session(_handle):
+  opaque
+  implements Closeable
+  internal _Session
+  property handle: _handle
+  constructor (~pool_config: pool_config :: PoolConfig = PoolConfig(),
+               ~ssl_context: ssl_context :: maybe(SSLContext) = #false, // FIXME: don't default to `#false`
+               ~cookie_jar: cookie_jar :: maybe(CookieJar) = #false,
+               ~proxies: proxies :: List.of(Proxy) = []):
+    let [p, ...] = proxies
+    super(easy.#{make-session}(#{#:pool-config}: pool_config.handle,
+                               #{#:ssl-context}: ssl_context,
+                               #{#:cookie-jar}: cookie_jar,
+                               ~proxies: PairList(p.handle, ...)))
+  override method close():
+    easy.#{session-close!}(_handle)
+  export:
+    rename:
+      current_session as current
+
+  method request(uri :: Bytes || String || url.URL || LiteralURL,
+                 ~method: method :: Method = #'get,
+                 ~close: close :: Any.to_boolean = #false,
+                 ~stream: stream :: Any.to_boolean = #false,
+                 ~headers: headers :: Headers = {},
+                 ~params: params :: List.of(url.KeyValue) = [],
+                 ~auth: auth :: maybe(auth.Function) = #false,         
+                 ~data: data :: maybe(Bytes || String || Port.Input || payload.Function) = #false,
+                 ~timeouts: timeouts :: Timeouts = Timeouts(),
+                 ~max_attempts: max_attempts :: PosInt = 3,
+                 ~max_redirects: max_redirects :: PosInt = 16,
+                 ~user_agent: user_agent :: Bytes || String = current_user_agent()) :~ Response:
+    let [url.KeyValue(k, v), ...] = params
+    _Response(easy.#{session-request}(handle,
+                                      match uri
+                                      | u :: url.URL: u.to_handle()
+                                      | ~else: uri,
+                                      ~method: method,
+                                      #{#:close?}: close,
+                                      #{#:stream?}: stream,
+                                      ~headers: hdr.to_symbols(headers),
+                                      ~params: PairList[Pair(Symbol.from_string(k), v), ...],
+                                      ~auth: auth && au.unwrap(auth),
+                                      ~data: if data is_a Function | pl.unwrap(data) | data,
+                                      ~timeouts: timeouts.handle,
+                                      #{#:max-attempts}: max_attempts,
+                                      #{#:max-redirects}: max_redirects,
+                                      #{#:user-agent}: user_agent))
+
+
+Parameter.def current_session :: Session:
+  ~name: Session.current
+  _Session(easy.#{current-session}())
+
+defn.macro 'def_method $name':
+  'fun $name(uri :: Bytes || String || url.URL || LiteralURL,
+             ~session: session :: Session = Session.current(),
+             ~method: method :: Method = #'get,
+             ~close: close :: Any.to_boolean = #false,
+             ~stream: stream :: Any.to_boolean = #false,
+             ~headers: headers :: Headers = {},
+             ~params: params :: List.of(url.KeyValue) = [],
+             ~auth: auth :: maybe(auth.Function) = #false,         
+             ~data: data :: maybe(Bytes || String || Port.Input || payload.Function) = #false,
+             ~timeouts: timeouts :: Timeouts = Timeouts(),
+             ~max_attempts: max_attempts :: PosInt = 3,
+             ~max_redirects: max_redirects :: PosInt = 16,
+             ~user_agent: user_agent :: Bytes || String = current_user_agent()) :~ Response:
+     session.request(uri,
+                     ~method: #' $name,
+                     ~close: close,
+                     ~stream: stream,
+                     ~headers: headers,
+                     ~params: params,
+                     ~auth: auth,
+                     ~data: data,
+                     ~timeouts: timeouts,
+                     ~max_attempts: max_attempts,
+                     ~max_redirects: max_redirects,
+                     ~user_agent: user_agent)'
+
+def_method get
+def_method post
+def_method delete
+def_method head
+def_method options
+def_method patch
+def_method put
+
+veneer Exn.Fail.HTTP(this :: satisfying(easy.#{exn:fail:http-easy?})):
+  export:
+    Timeout
+  veneer Timeout(this :: satisfying(easy.#{exn:fail:http-easy:timeout?})):
+    property kind :~ Symbol: easy.#{exn:fail:http-easy:timeout-kind}(this)
+
+#//
+module main:
+  match get("http://www.cs.utah.edu")
+  | Response(~status_line: stat,
+             ~http_version: vers,
+             ~headers: { #'date: d,
+                         & remain },
+             ~body: body):
+      [stat, vers, d]

--- a/rhombus-http/info.rkt
+++ b/rhombus-http/info.rkt
@@ -1,0 +1,17 @@
+#lang info
+
+(define collection 'multi)
+
+(define deps '("base"
+               "rhombus-http-lib"))
+(define implies '("rhombus-http-lib"))
+
+(define build-deps
+  '("http-easy"
+    "rhombus"
+    "rhombus-scribble-lib"
+    "rhombus-url"))
+
+(define pkg-desc "Rhombus HTTP library")
+
+(define license '(Apache-2.0 OR MIT))

--- a/rhombus-http/rhombus/net/info.rkt
+++ b/rhombus-http/rhombus/net/info.rkt
@@ -1,0 +1,3 @@
+#lang info
+
+(define scribblings '(("scribblings/rhombus-http.scrbl" (multi-page))))

--- a/rhombus-http/rhombus/net/scribblings/http/auth.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/auth.scrbl
@@ -1,0 +1,46 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~tag: "auth"){Authentication}
+
+@doc(
+  annot.macro 'auth.Function'
+){
+
+ Equivalent to
+
+@rhombusblock(
+  (url.URL, Headers, List.of(url.KeyValue))
+    -> values(Headers, List.of(url.KeyValue))
+)
+
+ representing an authorization function to be supplied to @rhombus(Session.request).
+
+}
+
+@doc(
+  fun auth.basic(
+    ~username: username :: String || Bytes,
+    ~password: password :: String || Bytes
+  ) :: auth.Function
+){
+
+ Generates a function that authenticates requests using HTTP basic
+ authentication.
+
+}
+
+@doc(
+  fun auth.bearer(
+    ~token: token :: String || Bytes
+  ) :: Function
+){
+
+ Generates a function that authenticates requests using the given bearer
+ token.
+
+}

--- a/rhombus-http/rhombus/net/scribblings/http/exn.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/exn.scrbl
@@ -1,0 +1,20 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~tag: "exn"){Exceptions}
+
+@doc(
+  veneer Exn.Fail.HTTP
+  veneer Exn.Fail.HTTP.Timeout
+  property (exn :: Exn.Fail.HTTP.Timeout).kind
+    :: Any.of(#'lease, #'connect, #'request)
+){
+
+ Veneers to recognize exceptions raised by @rhombus(Session.request) and
+ related functions.
+
+}

--- a/rhombus-http/rhombus/net/scribblings/http/get.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/get.scrbl
@@ -1,0 +1,43 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~tag: "get"){Sending Requests}
+
+@doc( 
+  fun get(
+    uri :: Bytes || String || url.URL || LiteralURL,
+    ~session: session :: Session = Session.current(),
+    ~method: method :: Method = #'get,
+    ~close: close :: Any.to_boolean = #false,
+    ~stream: stream :: Any.to_boolean = #false,
+    ~headers: headers :: Headers = {},
+    ~params: params :: List.of(url.KeyValue) = [],
+    ~auth: auth :: maybe(auth.Function) = #false,         
+    ~data: data :: maybe(Bytes || String || Port.Input || payload.Function) = #false,
+    ~timeouts: timeouts :: Timeouts = Timeouts(),
+    ~max_attempts: max_attempts :: PosInt = 3,
+    ~max_redirects: max_redirects :: PosInt = 16,
+    ~user_agent: user_agent :: Bytes || String = current_user_agent()
+  ) :: Response
+  fun post(....) :: Response
+  fun delete(....) :: Response
+  fun head(....) :: Response
+  fun options(....) :: Response
+  fun patch(....) :: Response
+  fun put(....) :: Response
+){
+
+ Sends a request using the @rhombus(session) argument's
+ @rhombus(Session.request) method. All of these functions accept the same
+ arguments as @rhombus(get), and each corresponds to calling
+ @rhombus(Session.request) with a corresponding @rhombus(~method)
+ argument and passing along all the other arguments as given.
+
+ See @rhombus(Session.request) for descriptions of the arguments other
+ than @rhombus(session).
+
+}

--- a/rhombus-http/rhombus/net/scribblings/http/literal_url.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/literal_url.scrbl
@@ -1,0 +1,30 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~tag: "literal_url"){Literal URLs}
+
+@doc(
+  class LiteralURL():
+    constructor (s :: String):
+      super(easy.#{string->url/literal})
+
+  method LiteralURL.to_string() :: String
+){
+
+ A @rhombus(LiteralURL, ~class) object represents Literal URL string
+ that may not conform to the parsing implemented by @rhombus(url.URL).
+ for user, path, query and fragment components. When converting to a
+ string, only the components of those components that are not already
+ percent encoded are encoded. A component is considered to be percent
+ encoded if all of its percent characters are followed by two hexadecimal
+ characters.
+
+ Literal URLs are used automatically when handling redirects to avoid
+ issues that may pop up when decoding an re-encoding URLs from
+ standards-non-compliant servers.
+
+}

--- a/rhombus-http/rhombus/net/scribblings/http/payload.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/payload.scrbl
@@ -1,0 +1,67 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~tag: "payload"){Payload Data}
+
+@doc(
+  annot.macro 'payload.Function'
+){
+
+ Equivalent to
+
+@rhombusblock(
+  (Headers)
+    -> values(Headers, Bytes || String || Port.Input)
+)
+
+ representing a function to generate a payload for @rhombus(Session.request).
+
+}
+
+@doc(
+  fun payload.buffered(f :: payload.Function) :: payload.Function
+){
+
+ Produces a payload function that buffers the result of @rhombus(f) in
+ memory to determine its length before sending it to the server.
+
+}
+
+@doc(
+  fun payload.form(v :: List.of(url.KeyValue)) :: payload.Function
+){
+
+ Produces a payload function that encodes @rhombus(v) as form data using the
+ @rhombus(application/x-www-form-urlencoded) content type.
+
+}
+
+@doc(
+  fun payload.json(v :: JSON) :: payload.Function
+){
+
+ Produces a payload function that encodes @rhombus(v) as JSON data.
+
+}
+
+
+@doc(
+  fun payload.gzip(f :: payload.Function) :: payload.Function
+){
+
+ Produces a payload function that gzips the output of @rhombus(f).
+
+}
+
+@doc(
+  fun payload.pure(inp :: Bytes || String || Port.Input)
+    :: payload.Function
+){
+
+ Produces a payload function that uses @rhombus(inp) as the request body.
+
+}

--- a/rhombus-http/rhombus/net/scribblings/http/pool.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/pool.scrbl
@@ -1,0 +1,22 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~tag: "pool"){Connection Pool Configuration}
+
+
+@doc( 
+  class PoolConfig():
+    constructor (
+      ~max_size: max_size :: PosInt || matching(#inf) = 128,
+      ~idle_timeout_seconds: idle_timeout :: maybe(PosReal) = 600
+    )
+){
+
+ Represents a connection pool configuration for use in creating
+ a @rhombus(Session).
+
+}

--- a/rhombus-http/rhombus/net/scribblings/http/proxy.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/proxy.scrbl
@@ -1,0 +1,44 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~tag: "proxy"){Proxy Configuration}
+
+
+@doc( 
+  class Proxy():
+    constructor (
+      ~matches: matches :: url.URL -> Boolean,
+      ~connect: connect :: (HTTPConn, url.URL, maybe(SSLContext)) -> Void
+    )
+    
+  fun Proxy.http(
+    ~proxy_url: proxy_url :: String || Bytes || url.URL,
+    ~matches: matches :: url.URL -> Boolean:
+                fun (u :: url.URL): u.scheme == "http"
+  ) :: Proxy
+  
+  fun Proxy.https(
+    ~proxy_url: proxy_url :: String || Bytes || url.URL,
+    ~matches: matches :: url.URL -> Boolean:
+                = fun (u :: url.URL): u.scheme == "https"
+  ) :: Proxy
+){
+
+ A @rhombus(Proxy, ~class) represents a configuration for constructing a
+ @rhombus(Session) that causes some connections to be created through the
+ proxy. In general, a @rhombus(Proxy, ~class) has a @rhombus(matches)
+ function to determine whether a request address should use the proxy,
+ and a @rhombus(connect) function that creates the proxied connection.
+
+ The @rhombus(Proxy.http) configuration specifies an HTTP @tt{CONNECT}
+ proxy at the given @rhombus(proxy_url) and optionally with a
+ @rhombus(matches) function.
+
+ The @rhombus(Proxy.https) configuration is similar to
+ @rhombus(Proxy.http), but using HTTPS.
+
+}

--- a/rhombus-http/rhombus/net/scribblings/http/response.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/response.scrbl
@@ -1,0 +1,168 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~tag: "response"){Responses}
+
+@doc(
+  ~nonterminal:
+    val_bind: def bind ~defn
+    status_code_bind: def bind ~defn
+    bstr_bind: def bind ~defn
+    bstr_list_bind: def bind ~defn
+    response_list_bind: def bind ~defn
+  
+  class Response():
+    expression ~none
+    binding 'Response($field, ...)'
+  
+  grammar field:
+    ~status_line: $bstr_bind
+    ~status_code: $status_code_bind
+    ~status_message: $bstr_bind
+    ~http_version: $bstr_bind
+    ~history: $response_list_bind
+    ~headers: { $key_str: $bstr_bind, ... }
+    ~headers: { $key_str: $bstr_bind, ..., & $bstr_list_bind }
+    ~body: $bstr_bind
+
+){
+
+ A @rhombus(Response, ~class) represents a request sent via
+ @rhombus(Session.request) or through one of the shorthand functions like
+ @rhombus(get).
+
+ A @rhombus(Response, ~class) may still be in the process of receiving
+ its data when it is returned, so methods like @rhombus(Response.body)
+ may block while data is read. A @rhombus(Response, ~class) is
+ @rhombus(Closeable, ~class) via @rhombus(Response.close).
+
+ As a binding form, @rhombus(Response, ~bind) extracts and sometimes
+ converts response information, blocking as needed until the information
+ is available. The extracted information is matched against a given
+ binding.
+
+@itemlist(
+
+ @item{@rhombus(~status_line): Matches the same byte string result as
+  produced by @rhombus(Response.status_line).}
+
+ @item{@rhombus(~status_code): Matches the same integer result as
+  produced by @rhombus(Response.status_code).}
+
+ @item{@rhombus(~status_message): Matches the same byte string result as
+  produced by @rhombus(Response.status_message).}
+
+ @item{@rhombus(~http_version): Matches the same byte string result as
+  produced by @rhombus(Response.http_version).}
+
+ @item{@rhombus(~history): Matches the list result as
+  produced by @rhombus(Response.history).}
+
+ @item{@rhombus(~headers): Matches against indivdual fields in a
+  response header. These fields are located in the byte strings returned
+  by @rhombus(Response.raw_headers), where @rhombus(key_str)s are matched
+  case-insensitively to field name, and each @rhombus(bstr_bind) after a
+  @rhombus(key_str) is matched against the byte-string value of that
+  field. If @rhombus(& bstr_list_bind) is present, it is matched against
+  the list of byte strings from @rhombus(Response.raw_headers), but with
+  lines matched to @rhombus(key_str)s removed.}
+
+ @item{@rhombus(~body): Matches the byte string result as
+  produced by @rhombus(Response.body).}
+
+)
+
+}
+
+@doc(
+  property (resp :: Response).status_line :: Bytes
+  property (resp :: Response).status_code :: StatusCode
+  property (resp :: Response).status_message :: Bytes
+  property (resp :: Response).http_version :: Bytes
+  property (resp :: Response).raw_headers :: List.of(Bytes)
+){
+
+ Accesses the raw immediate data for a request response.
+
+}
+
+@doc(
+  method (resp :: Response).headers() :: Map.of(String, Bytes)
+){
+
+ Returns the same result as @rhombus(Response.raw_headers), but parsed
+ into a map from field names to values.
+
+}
+
+@doc(
+  method (resp :: Response).output() :: Port.Input
+  method (resp :: Response).body() :: Bytes
+){
+
+ The @rhombus(Response.output) method returns an output port that
+ provides the response's body content. The @rhombus(Response.body) method
+ reads and records all data from that output port; calling
+ @rhombus(Response.body) a second time returns the same recorded data.
+
+ If @rhombus(Response.output) is called after @rhombus(Response.body),
+ then the returned output port will be closed. If
+ @rhombus(~stream: #false) or @rhombus(~close: #true) were provided to
+ @rhombus(Session.request) to obtain the @rhombus(Response, ~class)
+ object, then @rhombus(Response.body) is effectively called already.
+
+}
+
+@doc(
+  method (resp :: Response).history() :: List.of(Response)
+){
+
+ Reports redirections taken to arrive at the final response. The
+ redirection responses are in reverse order in the result list (i.e.,
+ most recent first).
+
+}
+
+@doc(
+  method (resp :: Response).close() :: Void
+  method (resp :: Response).drain() :: Void
+){
+
+ The @rhombus(Response.close) method terminates any communication still
+ in process to reeceive the result.
+
+ The @rhombus(Response.drain) method reads all data for the response
+ body and records it. A @rhombus(Response.drain) call has no effect if
+ the content is already read.
+
+}
+
+@doc(
+  annot.macro 'StatusCode'
+){
+
+ Equivalent to @rhombus(Int.in(100, 999)).
+
+}
+
+@doc(
+  Parameter.def current_user_agent :: String
+){
+
+ Supplies a default value for the @rhombus(~user_agent) argument of
+ @rhombus(Session.request), which determines the @tt{User-Agent} field of
+ the request.
+
+}
+
+@doc(
+  property (resp :: Response).handle
+){
+
+ Returns a Racket representation of the response.
+
+}

--- a/rhombus-http/rhombus/net/scribblings/http/session.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/session.scrbl
@@ -1,0 +1,91 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~tag: "session"){Sessions}
+
+@doc( 
+  class Session():
+    constructor (
+      ~pool_config: pool_config :: PoolConfig = PoolConfig(),
+      ~ssl_context: maybe(SSLContext) = #false,
+      ~cookie_jar: maybe(CookieJar) = #false,
+      ~proxies: proxies :: List.of(Proxy) = []
+    )
+  method (session :: Session).close() :: Void
+){
+
+ Creates a new session, which can house multiple requests with a common
+ configuration.
+
+ A session has a pool of connections, and the pool is configured through
+ the @rhombus(pool_config) structor argument, which is a
+ @rhombus(PoolConfig, ~class).
+
+ A session is @rhombus(Closeable, ~class), where closing a session via
+ the @rhombus(Session.close) method closes all of its associated connections and
+ responses.
+
+}
+
+@doc( 
+  method (session :: Session).request(
+    uri :: Bytes || String || url.URL || LiteralURL,
+    ~method: method :: Method = #'get,
+    ~close: close :: Any.to_boolean = #false,
+    ~stream: stream :: Any.to_boolean = #false,
+    ~headers: headers :: Headers = {},
+    ~params: params :: List.of(url.KeyValue) = [],
+    ~auth: auth :: maybe(auth.Function) = #false,         
+    ~data: data :: maybe(Bytes || String || Port.Input || payload.Function) = #false,
+    ~timeouts: timeouts :: Timeouts = Timeouts(),
+    ~max_attempts: max_attempts :: PosInt = 3,
+    ~max_redirects: max_redirects :: PosInt = 16,
+    ~user_agent: user_agent :: Bytes || String = current_user_agent()
+  ) :: Response
+){
+
+ Sends an HTTP request. By default, a @tt{GET} request is sent, but the
+ @rhombus(method) argument selects the type of request. The functions
+ @rhombus(get), @rhombus(post), @rhombus(delete), @rhombus(head),
+ @rhombus(options), @rhombus(patch), and @rhombus(put) are the same as
+ calling @rhombus(Session.request) with the corresponding request type (on a
+ @rhombus(Session, ~class) object that is given as a @rhombus(~session)
+ argument, defaulting to a fresh session).
+
+}
+
+@doc(
+  Parameter.def Session.current :: Session
+){
+
+ The default session used by @rhombus(get), @rhombus(post), etc.
+
+}
+
+@doc(
+  enum Method:
+    get
+    post
+    delete
+    head
+    options
+    patch
+    put
+){
+
+ Methods recognized by @rhombus(Session.request).
+
+}
+
+
+@doc(
+  annot.macro 'Headers'
+){
+
+ A shorthand for @rhombus(Map.of(String, Bytes || String)).
+
+}

--- a/rhombus-http/rhombus/net/scribblings/http/timeout.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/timeout.scrbl
@@ -1,0 +1,21 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~tag: "timeout"){Timeout Configuration}
+
+@doc(
+  class Timeouts(_handle):
+    constructor (
+      ~lease: lease :: maybe(PosReal) = 5,
+      ~connect: connect :: maybe(PosReal) = 5,
+      ~request: request :: maybe(PosReal) = 30
+    )
+){
+
+ Configures timeouts for @rhombus(Session.request).
+
+}

--- a/rhombus-http/rhombus/net/scribblings/rhombus-http.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/rhombus-http.scrbl
@@ -1,0 +1,26 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/http open
+      net/url)
+
+@title(~style: #'toc){Rhombus HTTP Client}
+
+@docmodule(net/http)
+
+The @rhombusmodname(net/http) library provides functions for sending
+HTTP requests as a client.
+
+@table_of_contents()
+
+@include_section("http/get.scrbl")
+@include_section("http/session.scrbl")
+@include_section("http/response.scrbl")
+@include_section("http/auth.scrbl")
+@include_section("http/payload.scrbl")
+@include_section("http/timeout.scrbl")
+@include_section("http/pool.scrbl")
+@include_section("http/proxy.scrbl")
+@include_section("http/literal_url.scrbl")
+@include_section("http/exn.scrbl")

--- a/rhombus-http/rhombus/net/tests/http.rhm
+++ b/rhombus-http/rhombus/net/tests/http.rhm
@@ -1,0 +1,189 @@
+#lang rhombus/static
+import:
+  net/url
+  net/http open
+  rhombus/network
+
+def lnr = network.TCP.listen()
+def (_, portno) = lnr.addresses()
+
+def here = url.URL(~scheme: "http",
+                   ~host: "localhost",
+                   ~port: portno,
+                   ~path: [url.PathWithParams("index.html", [])])
+
+def mutable recent_method = #false
+def mutable recent_path = #false
+def mutable recent_user_agent = #false
+def mutable recent_data = #false
+
+// minimal server to test against:
+block:
+  import:
+    rhombus/thread open
+    rhombus/rx open
+  thread:
+    recur serve():
+      let (in, out) = lnr.accept()
+      thread:
+        // Discard the request header (up to blank line):
+        let headers_o = Port.Output.open_bytes()
+        let req_line = in.read_line()
+        rx'("\r\n" || bof) "\r\n"'.match_in(in, ~unmatched_out: headers_o)        
+        let headers = headers_o.get_string()
+        recent_method := rx'bof ["A"-"Z"]*'.match_in(req_line)!![0]
+        recent_path := rx'" " ~~([! " "]*) " "'.match_in(req_line)!![1]
+        recent_user_agent := rx'case_insensitive: "user-agent: " ($ua: [! "\r"]*)'.match_in(headers)!![#'ua]
+        let pause = rx'"pause: " ($v: [! "\r"]*)'.match_in(headers)
+        when pause
+        | Thread.sleep(String.to_int(pause!![#'v]))
+        let content = rx'case_insensitive: "Content-Length: " ($v: [! "\r"]*)'.match_in(headers)
+        when content
+        | recent_data := in.read_bytes(String.to_int(content!![#'v]))
+        when rx'case_insensitive: "Transfer-Encoding: chunked"'.is_match_in(headers)
+        | recent_data := #""
+          recur loop():
+            let spec = in.read_line()
+            let len = String.to_int(String.split(spec, " ")[0], ~radix: 16)            
+            recent_data := Bytes.append(recent_data, in.read_bytes(len))
+            in.read_line() // terminator
+            unless len == 0
+            | loop()
+        // Send reply:
+        out.write_string("HTTP/1.0 200 Okay\r\n")
+        out.write_string("Server: k\r\nContent-Type: text/html\r\n\r\n")
+        cond
+        | rx'"authorization: Basic"'.match_in(headers):
+            out.write_string("<html><body>make a wish</body></html>")
+        | ~else:
+            out.write_string("<html><body>Hello, world!</body></html>")
+        in.close()
+        out.close()
+      serve()
+  #void
+
+check get(here) ~matches Response(~status_code: 200)
+check get(here) ~matches Response(~status_message: is_now #"Okay")
+check get(here) ~matches Response(~http_version: is_now #"1.0")
+check get(here) ~matches Response(~body: is_now #"<html><body>Hello, world!</body></html>")
+check get(here) ~matches Response(~headers: { "Server": is_now #"k" })
+check get(here) ~matches Response(~headers: { "Server": is_now #"k", & [is_now #"Content-Type: text/html"] })
+check get(here) ~matches Response(~history: [])
+
+check get(here).status_code ~is 200
+check get(here).status_message ~is_now #"Okay"
+check get(here).status_message.length() ~is 4
+check get(here).http_version ~is_now #"1.0"
+check get(here).http_version.length() ~is 3
+check get(here).body() ~is_now #"<html><body>Hello, world!</body></html>"
+check get(here).body().length() ~is 39
+check get(here).headers() ~is_now { "server": #"k", "content-type": #"text/html" }
+check get(here).headers()["server"] ~is_now #"k"
+check get(here).headers()["server"].length() ~is 1
+check get(here).history() ~is []
+check get(here).history().length() ~is 0
+
+block:
+  let resp = get(here)
+  let o = resp.output()
+  check o.read_bytes(2) ~throws "closed"
+
+block:
+  let resp = get(here, ~stream: #true)
+  let o = resp.output()
+  check o.read_bytes(10) ~is_now #"<html><bod"
+  check o.read_bytes(2) ~is_now #"y>"
+  resp.close()
+  check o.read_bytes(2) ~throws "closed"
+
+block:
+  let resp = get(here, ~stream: #true)
+  resp.drain()
+  let o = resp.output()
+  check o.read_bytes(2) ~throws "closed"
+  check resp.body() ~is_now #"<html><body>Hello, world!</body></html>"
+
+block:
+  let resp = get(here, ~stream: #true)
+  check resp.body() ~is_now #"<html><body>Hello, world!</body></html>"
+  let o = resp.output()
+  check o.read_bytes(2) ~throws "closed"
+
+check String.substring(recent_user_agent, 0..13) ~is_now "net/http-easy"
+
+parameterize { current_user_agent: "Tester" }:
+  check get(here).status_code ~is 200
+  check recent_user_agent ~is "Tester"
+
+check get(here, ~user_agent: "test2").status_code ~is 200
+check recent_user_agent ~is "test2"
+check recent_method ~is "GET"
+
+check put(here).status_code ~is 200
+check recent_method ~is "PUT"
+
+check post(here).status_code ~is 200
+check recent_method ~is "POST"
+
+check delete(here).status_code ~is 200
+check recent_method ~is "DELETE"
+
+check head(here).status_code ~is 200
+check recent_method ~is "HEAD"
+
+check options(here).status_code ~is 200
+check recent_method ~is "OPTIONS"
+
+check patch(here).status_code ~is 200
+check recent_method ~is "PATCH"
+
+check Session().request(here, ~method: #'post).status_code ~is 200
+check recent_method ~is "POST"
+
+check get(here, ~session: Session()).status_code ~is 200
+check recent_method ~is "GET"
+
+check 100 ~is_a StatusCode
+check 1 is_a StatusCode ~is #false
+
+check Timeouts() ~is_a Timeouts
+check: try:
+         get(here,
+             ~timeouts: Timeouts(~request: 0.25),
+             ~headers: { "pause": "10"})
+         ~catch e :: Exn.Fail.HTTP.Timeout:
+           e.kind
+       ~is #'request
+
+check recent_path ~is "/index.html"
+
+check get(here, ~params: [url.KeyValue("piano", "C")]).status_code ~is 200
+check recent_path ~is "/index.html?piano=C"
+
+check get(here with (query = [url.KeyValue("skeleton", "attic")]), ~params: [url.KeyValue("piano", "C")]).status_code ~is 200
+check recent_path ~is "/index.html?skeleton=attic&piano=C"
+
+check get(here with (query = [url.KeyValue("skeleton", #false)]), ~params: [url.KeyValue("piano", "C")]).status_code ~is 200
+check recent_path ~is "/index.html?skeleton&piano=C"
+
+check get(here with (query = [url.KeyValue("skeleton", "attic")]), ~params: [url.KeyValue("piano", #false)]).status_code ~is 200
+check recent_path ~is "/index.html?skeleton=attic&piano"
+
+check:
+  get(here, ~auth: auth.basic(~username: "Alladin", ~password: "OpenSesame")).body()
+  ~is_now #"<html><body>make a wish</body></html>"
+check get(here, ~auth: auth.bearer(~token: "token")).status_code ~is 200
+
+check recent_data ~is_now #""
+
+check put(here, ~data: #"howdy").status_code ~is 200
+check recent_data ~is_now #"howdy"
+
+check put(here, ~data: payload.pure(#"hello")).status_code ~is 200
+check recent_data ~is_now #"hello"
+
+check put(here, ~data: payload.pure(Port.Input.open_bytes(#"helloooo"))).status_code ~is 200
+check recent_data ~is_now #"helloooo"
+
+check put(here, ~data: payload.buffered(payload.pure(Port.Input.open_bytes(#"oooo")))).status_code ~is 200
+check recent_data ~is_now #"oooo"

--- a/rhombus-url-lib/info.rkt
+++ b/rhombus-url-lib/info.rkt
@@ -1,0 +1,14 @@
+#lang info
+
+(define collection 'multi)
+
+(define deps
+  '("base"
+    "rhombus-lib"))
+
+(define pkg-desc "implementation (no documentation) part of \"rhombus-url\"")
+
+(define license '(Apache-2.0 OR MIT))
+
+(define version "0.1")
+

--- a/rhombus-url-lib/net/url.rhm
+++ b/rhombus-url-lib/net/url.rhm
@@ -1,0 +1,5 @@
+#lang rhombus
+import:
+  rhombus/net/url
+export:
+  all_from(.url)

--- a/rhombus-url-lib/rhombus/net/url.rhm
+++ b/rhombus-url-lib/rhombus/net/url.rhm
@@ -1,0 +1,163 @@
+#lang rhombus/static/and_meta
+import:
+  lib("net/url-structs.rkt") open
+  lib("net/url-string.rkt") open
+  lib("net/uri-codec.rkt") open
+
+export:
+  URL
+  PathWithParams
+  KeyValue
+
+  relative_path_to_relative_url_string
+
+  EncodeMode
+  current_encode_mode
+
+  uri
+  form
+
+enum EncodeMode:
+  recommended
+  unreserved
+
+class PathWithParams(path :: String || Path.Dot,
+                     params :: List.of(String))
+
+class KeyValue(key :: String,
+               value :: maybe(String))
+
+class URL(~scheme: scheme :: maybe(String) = #false,
+          ~user: user :: maybe(String) = #false,
+          ~host: host :: maybe(String) = #false,
+          ~port: port :: maybe(NonnegInt) = #false,
+          ~is_path_absolute: is_path_absolute :: Boolean = #true,
+          ~path: path :: List.of(PathWithParams) = [],
+          ~query: query :: List.of(KeyValue) = [],
+          ~fragment: fragment :: maybe(String) = #false):
+  private implements Printable
+  export:
+    from_string
+    from_path
+    from_handle
+
+  method to_string() :~ String:
+    parameterize { #{current-url-encode-mode}: current_encode_mode(),
+                   #{current-alist-separator-mode}: current_separator_mode_as_rkt() }:
+      String.to_string(#{url->string}(to_url()))
+
+  private override method describe(mode, recur):
+    if mode == #'text
+    | to_string()
+    | recur(this, ~mode: mode, ~as: #'super)
+
+  method to_path(conv :: CrossPath.Convention = CrossPath.Convention.current()) :~ CrossPath:
+    #{url->path}(to_url(), conv)      
+
+  method add(rel :: String) :~ URL:
+    from_url(#{combine-url/relative}(to_url(), rel))
+
+  method to_handle():
+    to_url()
+    
+  private method to_url() :~ URL:
+    let [pp, ...] = path
+    let [KeyValue(k, v), ...] = query
+    url(scheme,
+        user,
+        host,
+        port,
+        is_path_absolute,
+        PairList[#{path/param}(pp.path, PairList(& pp.params)), ...],
+        PairList[Pair(Symbol.from_string(k), v), ...],
+        fragment)
+
+fun from_handle(handle) :~ URL:
+  unless #{url?}(handle)
+  | error("not a valid URL handle",
+          error.val(handle))
+  from_url(handle)
+
+fun from_string(s :: String) :~ URL:
+  ~name: URL.from_string
+  from_url(#{string->url}(s))
+
+fun from_path(p :: PathString || CrossPath) :~ URL:
+  ~name: URL.from_path
+  from_url(#{path->url}(p))
+
+fun from_url(u) :~ URL:
+  fun maybe_to_string(s): s && to_string(s)
+  URL(~scheme: maybe_to_string(#{url-scheme}(u)),
+      ~user: maybe_to_string(#{url-user}(u)),
+      ~host: maybe_to_string(#{url-host}(u)),
+      ~port: #{url-port}(u),
+      ~is_path_absolute: #{url-path-absolute?}(u),
+      ~path: let PairList[pp, ...] = #{url-path}(u)
+             [PathWithParams(to_string(#{path/param-path}(pp)),
+                             PairList.to_list(#{path/param-param}(pp)).map(to_string)),
+              ...],
+      ~query: let PairList[Pair(k, v), ...] = #{url-query}(u)
+              [KeyValue(to_string(k), maybe_to_string(v)), ...],
+      ~fragment: maybe_to_string(#{url-fragment}(u)))
+
+fun relative_path_to_relative_url_string(p :: (PathString.to_path || CrossPath) && CrossPath.Relative) :~ String:
+  to_string(#{relative-path->relative-url-string}(p))
+  
+Parameter.def current_encode_mode :: EncodeMode = #{current-url-encode-mode}()
+
+fun current_separator_mode_as_rkt():
+  match form.current_separator_mode()
+  | #'amp_or_semi: #'#{amp-or-semi}
+  | #'semi_or_amp: #'#{semi-or-amp}
+  | s: s
+
+decl.nestable_macro 'converter_def $id $rkt_id':
+  'export $id
+   fun $id(s :: String) :~ String:
+     to_string($rkt_id(s))'
+
+namespace uri:
+  converter_def encode #{uri-encode}
+  converter_def decode #{uri-decode}
+  converter_def path_segment_encode #{uri-path-segment-encode}
+  converter_def path_segment_decode #{uri-path-segment-decode}
+  converter_def userinfo_encode #{uri-userinfo-encode}
+  converter_def userinfo_decode #{uri-userinfo-decode}
+  converter_def unreserved_encode #{uri-unreserved-encode}
+  converter_def unreserved_decode #{uri-unreserved-decode}
+  converter_def path_segment_unreserved_encode #{uri-path-segment-unreserved-encode}
+  converter_def path_segment_unreserved_decode #{uri-path-segment-unreserved-decode}
+
+namespace form:
+  export:
+    list_to_urlencoded
+    urlencoded_to_list
+    AListSeparatorMode
+    current_separator_mode
+
+  converter_def urlencoded_encode #{form-urlencoded-encode}
+  converter_def urlencoded_decode #{form-urlencoded-decode}
+
+  fun list_to_urlencoded(kv :: List.of(KeyValue)) :~ String:
+    let [KeyValue(k, v), ...] = kv
+    parameterize { #{current-alist-separator-mode}: current_separator_mode_as_rkt() }:
+      to_string(#{alist->form-urlencoded}(PairList(Pair(Symbol.from_string(k), v), ...)))
+  fun urlencoded_to_list(s :: String) :~ List.of(KeyValue):
+    let PairList[Pair(k, v), ...]:
+      parameterize { #{current-alist-separator-mode}: current_separator_mode_as_rkt() }:
+        #{form-urlencoded->alist}(s)
+    [KeyValue(to_string(k), to_string(v)), ...]
+
+  enum AListSeparatorMode:
+    amp
+    semi
+    amp_or_semi
+    semi_or_amp
+
+  Parameter.def current_separator_mode :: AListSeparatorMode:
+    match #{current-alist-separator-mode}()
+    | #'#{amp-or-semi}: #'amp_or_semi
+    | #'#{semi-or-amp}: #'semi_or_amp
+    | s: s
+

--- a/rhombus-url/info.rkt
+++ b/rhombus-url/info.rkt
@@ -1,0 +1,16 @@
+#lang info
+
+(define collection 'multi)
+
+(define deps '("base"
+               "rhombus-lib"
+               "rhombus-url-lib"))
+(define implies '("rhombus-url-lib"))
+
+(define build-deps
+  '("rhombus"
+    "rhombus-scribble-lib"))
+
+(define pkg-desc "Rhombus URL library")
+
+(define license '(Apache-2.0 OR MIT))

--- a/rhombus-url/rhombus/net/info.rkt
+++ b/rhombus-url/rhombus/net/info.rkt
@@ -1,0 +1,3 @@
+#lang info
+
+(define scribblings '(("scribblings/rhombus-url.scrbl" (multi-page))))

--- a/rhombus-url/rhombus/net/scribblings/rhombus-url.scrbl
+++ b/rhombus-url/rhombus/net/scribblings/rhombus-url.scrbl
@@ -1,0 +1,212 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      net/url open)
+
+@title(~style: #'toc){Rhombus URL and Form Parsing}
+
+@docmodule(net/url)
+
+The @rhombusmodname(net/url) library provides functions for parsing and
+manipulating URLs, as well as functions for HTML form and URI component
+encoding and decoding.
+
+@table_of_contents()
+
+@section(~tag: "url"){URL Parsing}
+
+@doc(
+  class URL(
+    ~scheme: scheme :: maybe(String) = #false,
+    ~user: user :: maybe(String) = #false,
+    ~host: host :: maybe(String) = #false,
+    ~port: port :: maybe(NonnegInt) = #false,
+    ~is_path_absolute: is_path_absolute :: Boolean = #false,
+    ~path: path :: List.of(PathWithParams) = [],
+    ~query: query :: List.of(KeyValue) = [],
+    ~fragment: fragment :: maybe(String) = #false
+  )
+  class PathWithParams(
+    path :: String || Path.Dot,
+    params :: List.of(String)
+  )
+  class KeyValue(
+    key :: Symbol,
+    value :: maybe(String)
+  )
+){
+
+ A class to represent URLs as defined by
+ @hyperlink("http://www.ietf.org/rfc/rfc1939.txt"){RFC 3986}. The
+ following diagram illustrates the parts:
+
+@verbatim(~indent: 2)|{
+  http://sky@www:801/cgi-bin/finger;xyz?name=shriram;host=nw#top
+  {1-}   {2} {3} {4}{---5---------} {6} {----7-------------} {8}
+
+  1 = scheme, 2 = user, 3 = host, 4 = port,
+  5 = path (two elements),  6 = param (of second path element),
+  7 = query, 8 = fragment
+}|
+
+ The strings inside the @rhombus(user), @rhombus(path), @rhombus(query),
+ and @rhombus(fragment) fields are represented without
+ URL-syntax-specific quoting. The @rhombus(URL.from_string) function and
+ @rhombus(URL.to_string) method translate encodings, such as converting a
+ @litchar{%20} into a space and back again.
+
+ By default, query associations are parsed with either @litchar{;} or
+ @litchar{&} as a separator, and they are generated with @litchar{&} as a
+ separator. The @rhombus(form.current_separator_mode) parameter adjusts
+ the behavior.
+
+ An empty string at the end of the @rhombus(path) list corresponds to a
+ URL that ends in a slash. For example, the result of
+ @rhombus(URL.from_string("http://rhombus-lang.org/a/")) has a path field
+ with strings @rhombus("a") and @rhombus(""), while the result of
+ @rhombus(URL.from_string("http://rhombus-lang.org/a"))
+ (string->url "http://racket-lang.org/a") has a path field with only the
+ string @rhombus("a").
+
+ When a @rhombus("file") URL is represented by a @rhombus(URL, ~class)
+ instance, the path field is mostly a list of path elements. For Unix
+ paths, the root directory is not included in @rhombus(path); its
+ presence or absence is implicit in the @rhombus(is_path_absolute) flag.
+ For Windows paths, the first element typically represents a drive, but a
+ UNC path is represented by a first element that is @rhombus("") and then
+ successive elements complete the drive components that are separated by
+ @litchar{/} or @litchar{\}.
+
+}
+
+@doc(
+  fun URL.from_string(s :: String) :: URL
+  fun URL.from_path(p :: PathString || CrossPath) :: URL
+  fun relative_path_to_relative_url_string(
+    p :: (PathString.to_path || CrossPath) && CrossPath.Relative
+  ) :: String
+){
+
+ The @rhombus(URL.from_string) and @rhombus(URL.from_string) functions
+ convert from strings and paths to URLs.
+
+ The @rhombus(relative_path_to_relative_url_string) converts a relative
+ path into a string that represents a relative URL reference (e.g., using
+ forward slashes, even on Windows).
+
+}
+
+@doc(
+  method (u :: URL).to_string() :: String
+  method (u :: URL).to_path(
+    conv :: CrossPath.Convention = CrossPath.Convention.current()
+  ) :: CrossPath
+){
+
+ Converts a @rhombus(URL, ~annot) to a string or path.
+
+ The @rhombus(URL.to_string) conversion is used to @rhombus(print) a
+ @rhombus(URL, ~class) object in @rhombus(#'text) mode, while
+ @rhombus(#'expr) mode uses the default printing format for a class
+ instance.
+
+}
+
+@doc(
+  method (u :: URL).add(rel :: String) :: URL
+){
+
+ Adds a relative URL @rhombus(rel) to @rhombus(u) to produce a new URL.
+
+}
+
+@doc(
+  Parameter.def current_encode_mode :: EncodeMode
+  enum EncodeMode:
+    recommended
+    unreserved
+){
+
+
+ The @rhombus(current_encode_mode) parameter determines how queries are
+ encoded.
+
+}
+
+@doc(
+  fun URL.from_handle(handle :: Any) :: URL
+  method (u :: URL).to_handle() :: Any
+){
+
+ Converts between @rhombus(URL, ~class) objects and the URL
+ representation used by Racket libraries.
+
+}
+
+@section(~tag: "form"){HTML Form Parsing}
+
+@doc(
+  fun form.urlencoded_encode(str :: String) :: String
+  fun form.urlencoded_decode(str :: String) :: String
+  fun form.list_to_urlencoded(kv :: List.of(KeyValue)) :: String
+  fun form.urlencoded_to_list(s :: String) :: List.of(KeyValue)
+  Parameter.def form.current_separator_mode
+    :: AListSeparatorMode
+  enum form.AListSeparatorMode:
+    amp
+    semi
+    amp_or_semi
+    semi_or_amp
+
+){
+
+ Encodes and decodes according to @tt{application/x-www-form-urlencoded}
+ rules from the HTML 4.0 specificiation. Encoding maps @litchar{!},
+ @litchar{~}, @litchar{'}, @litchar{(}, and @litchar{)} using hex
+ representations, which is the same choice as made by Java’s
+ @tt{URLEncoder}.
+
+ The @rhombus(form.urlencoded_encode) and
+ @rhombus(form.urlencoded_decode) functions work on individual strings,
+ while @rhombus(form.list_to_urlencoded) and
+ @rhombus(form.urlencoded_to_list) handle lists of key--value pairs.
+
+ The @rhombus(form.current_separator_mode) parameter determines the
+ separator used/recognized between associations in
+ @rhombus(form.list_to_urlencoded), @rhombus(form.urlencoded_to_list),
+ @rhombus(URL.from_string), and @rhombus(URL.to_string). The default
+ value is @rhombus(#'amp_or_semi), which means that both @litchar{&} and
+ @litchar{;} are treated as separators when parsing, and @litchar{&} is
+ used as a separator when encoding. The @rhombus(#'semi_or_amp) mode is
+ similar, but @litchar{;} is used when encoding. The other modes
+ use/recognize only one of the separators.
+
+}
+
+@section(~tag: "uri"){URI Component Parsing}
+
+@doc(
+  fun uri.encode(str :: String) :: String
+  fun uri.decode(str :: String) :: String
+  fun uri.path_segment_encode(str :: String) :: String
+  fun uri.path_segment_decode (str :: String) :: String
+  fun uri.userinfo_encode(str :: String) :: String
+  fun uri.userinfo_decode(str :: String) :: String
+  fun uri.unreserved_encode(str :: String) :: String
+  fun uri.unreserved_decode(str :: String) :: String
+  fun uri.path_segment_unreserved_encode(str :: String) :: String
+  fun uri.path_segment_unreserved_decode(str :: String) :: String
+){
+
+ Encoding and decoding functions specified by
+ @hyperlink("http://www.ietf.org/rfc/rfc2396.txt"){RFC 2396}.
+ The encoding, in line with RFC 2396’s recommendation, represents a
+ character as-is, if possible. The decoding allows any characters to be
+ represented by it hex value, and it allows a character to be incorrectly
+ represented as-is. The ``unreserved'' encoders convert @litchar{!},
+ @litchar{*}, @litchar{'}, @litchar{(}, and @litchar{)} to hex
+ representations, which is not recommended by RFC 2396 but avoids
+ problems with some contexts.
+
+}

--- a/rhombus-url/rhombus/net/tests/url.rhm
+++ b/rhombus-url/rhombus/net/tests/url.rhm
@@ -1,0 +1,68 @@
+#lang rhombus
+import:
+  net/url open
+
+check URL() ~is_a URL
+check URL(~host: "localhost") ~is_a URL
+
+block:
+  let u = URL.from_string("http://tester@www.rhombus-lang.org:80/~mflatt/guess;x;y/page?ok=some&fair&bad=some#main")
+  check u.to_string() ~is "http://tester@www.rhombus-lang.org:80/~mflatt/guess;x;y/page?ok=some&fair&bad=some#main"
+  check to_string(u) ~is "http://tester@www.rhombus-lang.org:80/~mflatt/guess;x;y/page?ok=some&fair&bad=some#main"
+  check u.host ~is "www.rhombus-lang.org"
+  check u.user ~is "tester"
+  check u.path ~is [PathWithParams("~mflatt", []), PathWithParams("guess", ["x", "y"]), PathWithParams("page", [])]
+  check u.query ~is [KeyValue("ok", "some"), KeyValue("fair", #false), KeyValue("bad", "some")]
+  check u.fragment ~is "main"
+
+check:
+  URL.from_path(Path.current_directory())
+  ~is_a URL
+
+check:
+  URL.from_string("http://rhombus-lang.org/").add("y").to_string()
+  ~is "http://rhombus-lang.org/y"
+
+check:
+  relative_path_to_relative_url_string(Path("x"))
+  ~is "x"
+
+check:
+  relative_path_to_relative_url_string(CrossPath(#"x//y", #'unix))
+  ~is "x/y"
+
+check:
+  relative_path_to_relative_url_string(CrossPath(#"x\\y", #'windows))
+  ~is "x/y"
+
+check:
+  URL(~scheme: "http", ~host: "www").to_string()
+  ~is "http://www"
+
+check:
+  URL(~scheme: "http", ~host: "www", ~query: [KeyValue("x", #false), KeyValue("y", #false)]).to_string()
+  ~is "http://www?x&y"
+
+check:
+  parameterize { form.current_separator_mode: #'semi_or_amp }:
+    URL(~scheme: "http", ~host: "www", ~query: [KeyValue("x", #false), KeyValue("y", #false)]).to_string()
+  ~is "http://www?x;y"
+
+check:
+  parameterize { form.current_separator_mode: #'semi }:
+    URL(~scheme: "http", ~host: "www", ~query: [KeyValue("x", #false), KeyValue("y", #false)]).to_string()
+  ~is "http://www?x;y"
+
+
+def big_str = "abcdefghijklMNOPQRSTUZWXYZ!!()/\\|,.-_=+@#%done"
+
+check form.urlencoded_decode(form.urlencoded_encode(big_str)) ~is big_str
+block:
+  let l = [KeyValue(big_str, "0"), KeyValue("1", big_str)]
+  check form.urlencoded_to_list(form.list_to_urlencoded(l)) ~is l
+
+check uri.decode(uri.encode(big_str)) ~is big_str
+check uri.path_segment_decode(uri.path_segment_encode(big_str)) ~is big_str
+check uri.userinfo_decode(uri.userinfo_encode(big_str)) ~is big_str
+check uri.unreserved_decode(uri.unreserved_encode(big_str)) ~is big_str
+check uri.path_segment_unreserved_decode(uri.path_segment_unreserved_encode(big_str)) ~is big_str


### PR DESCRIPTION
The `net/url` library builds on `net/url-string` and `net/uri-code`. It's in its own package, `rhombus-url-lib` plus `rhombus-url`.

The `net/http` library builds on `http-easy`. It's also in its own package, `rhombus-http-lib` plus `rhombus-http`.

So, to try out the change, use
```
raco pkg install rhombus-url-lib/ rhombus-url/ rhombus-http-lib/ rhombus-http/
```
in a Rhombus repo clone and accept dependency installs.

I think the general approach here is probably uncontroversial, so if there are no objections in the next day or so, I'll merge and register the packages, and then we can refine from there. (In other words, I don't think we're committed to "rare breaking changes" right away for new modules outside of `#lang rhombus`.)