### PR TITLE
JSON

### DIFF
--- a/rhombus-json-lib/info.rkt
+++ b/rhombus-json-lib/info.rkt
@@ -1,0 +1,13 @@
+#lang info
+
+(define collection 'multi)
+
+(define deps
+  '("base"
+    "rhombus-lib"))
+
+(define pkg-desc "implementation (no documentation) part of \"rhombus-json\"")
+
+(define license '(Apache-2.0 OR MIT))
+
+(define version "0.1")

--- a/rhombus-json-lib/json/main.rhm
+++ b/rhombus-json-lib/json/main.rhm
@@ -1,0 +1,3 @@
+#lang rhombus
+import: rhombus/json
+export: all_from(.json)

--- a/rhombus-json-lib/rhombus/json.rhm
+++ b/rhombus-json-lib/rhombus/json.rhm
@@ -1,0 +1,124 @@
+#lang rhombus/static/and_meta
+
+import:
+  lib("racket/base.rkt").#{make-immutable-hashalw}
+  lib("json/main.rkt") ! #{for-extension} as rkt_json:
+    rename #{read-json*} as read
+    rename #{write-json*} as write
+
+def known_json = WeakMutableMap.by(===)()
+
+// Using a `json` namespace adds a prefix to names
+namespace json:
+  export:
+    JSON
+    write
+    to_string
+    to_bytes
+    read
+    from_string
+    from_bytes
+
+  fun is_json(v):
+    match v
+    | _ :: (Int || (Flonum && Rational)): #true
+    | _ :: String: #true
+    | _ :: Boolean: #true
+    | #'null: #true
+    | vs :: List:
+        cond
+        | vs in known_json: #true
+        | (for all (v in vs): is_json(v)):
+            known_json[vs] := #true
+            #true
+        | ~else:
+            #false
+    | m :: Map:
+        cond
+        | m in known_json: #true
+        | (for all ((k, v) in m):
+             k is_a String && is_json(v)):
+            known_json[m] := #true
+            #true
+        | ~else:
+            #false
+    | _: #false
+
+  annot.macro 'JSON': 'satisfying(is_json)'
+
+  fun do_write(who, v, out):
+    rkt_json.write(who,
+                   v,
+                   out,
+                   ~encode: #'control,
+                   ~indent: #false,
+                   ~null: #'null,
+                   #{#:object-rep?}: (_ is_a Map),
+                   #{#:object-rep->hash}: values,
+                   #{#:list-rep?}: (_ is_a List),
+                   #{#:list-rep->list}: fun (vs): PairList(&vs),
+                   #{#:key-rep?}: (_ is_a String),
+                   #{#:key-rep->string}: values,
+                   #{#:string-rep?}: (_ is_a String),
+                   #{#:string-rep->string}: values)
+
+  fun write(v :: JSON,
+            ~out: out :: Port.Output = Port.Output.current()):
+    ~who: who
+    do_write(who, v, out)
+
+  fun to_string(v :: JSON) :~ String:
+    ~who: who
+    let s = Port.Output.open_string()
+    do_write(who, v, s)
+    s.get_string()
+
+  fun to_bytes(v :: JSON) :~ Bytes:
+    ~who: who
+    let s = Port.Output.open_bytes()
+    do_write(who, v, s)
+    s.get_bytes()
+
+  fun do_read(who, in, replace_malformed_surrogate):
+    rkt_json.read(who,
+                  in,
+                  ~null: #'null,
+                  #{#:make-object}: #{make-immutable-hashalw},
+                  #{#:make-list}: PairList.to_list,
+                  #{#:make-key}: String.snapshot,
+                  #{#:make-string}: String.snapshot,
+                  #{#:replace-malformed-surrogate?}: replace_malformed_surrogate)
+
+  fun read(~in: in :: Port.Input = Port.Input.current(),
+           ~replace_malformed_surrogate: replace_malformed_surrogate :: Any.to_boolean = #false):
+    ~who: who
+    do_read(who, in, replace_malformed_surrogate)
+
+  fun check_eof(who, v, what, s):
+    when v == Port.eof
+    | error(~who: who,
+            "no value in " ++ what)
+    let v = do_read(who, s, #true)
+    unless v == Port.eof
+    | error(~who: who,
+            "found additional value in " ++ what,
+            error.val(~label: "additional value", v))
+
+  fun from_string(s :: ReadableString,
+                  ~replace_malformed_surrogate: replace_malformed_surrogate :: Any.to_boolean = #false):
+    ~who: who
+    let s = Port.Input.open_string(s)
+    let v= do_read(who, s, replace_malformed_surrogate)
+    check_eof(who, v, "string", s)
+    v
+
+  fun from_bytes(s :: Bytes,
+                 ~replace_malformed_surrogate: replace_malformed_surrogate :: Any.to_boolean = #false):
+    ~who: who
+    let s = Port.Input.open_bytes(s)
+    let v = do_read(who, s, replace_malformed_surrogate)
+    check_eof(who, v, "byte string", s)
+    v
+
+export:
+  all_from(.json)

--- a/rhombus-json/info.rkt
+++ b/rhombus-json/info.rkt
@@ -1,0 +1,15 @@
+#lang info
+
+(define collection 'multi)
+
+(define deps '("base"
+               "rhombus-json-lib"))
+(define implies '("rhombus-json-lib"))
+
+(define build-deps
+  '("rhombus"
+    "rhombus-scribble-lib"))
+
+(define pkg-desc "Rhombus JSON library")
+
+(define license '(Apache-2.0 OR MIT))

--- a/rhombus-json/rhombus/json/info.rkt
+++ b/rhombus-json/rhombus/json/info.rkt
@@ -1,0 +1,3 @@
+#lang info
+
+(define scribblings '(("scribblings/rhombus-json.scrbl" ())))

--- a/rhombus-json/rhombus/json/scribblings/rhombus-json.scrbl
+++ b/rhombus-json/rhombus/json/scribblings/rhombus-json.scrbl
@@ -1,0 +1,162 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      json)
+
+@(def json_eval = make_rhombus_eval())
+@examples(
+  ~eval: json_eval
+  ~hidden:
+    import json
+)
+
+@title{Rhombus JSON}
+
+@docmodule(json)
+
+The @rhombusmodname(json) library provides functions to read and write
+using the JSON exchange format. See See the @hyperlink("http://json.org/"){JSON web site}
+and the @hyperlink("http://www.ietf.org/rfc/rfc8259.txt"){JSON RFC} for more information about JSON.
+
+@doc(
+  annot.macro 'json.JSON'
+){
+
+ The @rhombus(json.JSON, ~annot) annotation matches a subset of Rhombus
+ built-in datatypes that can be read and written in JSON format:
+
+@itemlist(
+
+ @item{@rhombus(#true) and @rhombus(#false)}
+
+ @item{@rhombus(String, ~annot) values}
+
+ @item{@rhombus(Int, ~annot) values}
+
+ @item{@rhombus(Flonum, ~annot) values other than @rhombus(#inf),
+  @rhombus(#neginf), and @rhombus(#nan) (i.e., @rhombus(Flonum && Real, ~annot))}
+
+ @item{@rhombus(List.of(json.JSON), ~annot) values}
+
+ @item{@rhombus(Map.of(String, json.JSON), ~annot) values}
+
+ @item{@rhombus(#'null)}
+
+)
+
+@examples(
+  ~eval: json_eval
+  ~repl:
+    { "a": 1, "b": [2, 3.0, #true] } is_a json.JSON
+    { #'a: 1 } is_a json.JSON
+)
+
+ To check whether a list or map satisfies @rhombus(json.JSON, ~annot),
+ the list or map's content must be traversed recursively. However, a
+ @rhombus(#true) result is cached through a weak reference, so checking
+ again for the same (in the sense of @rhombus(===)) list or map produces
+ @rhombus(#true) immediately. The result for any value within the list or
+ map is similarly cached.
+
+}
+
+@doc(
+  fun json.from_string(
+    str :: String,
+    ~replace_malformed_surrogate: replacement :: Any.to_boolean = #false
+  ) :: json.JSON
+  fun json.from_bytes(
+    bstr :: Bytes,
+    ~replace_malformed_surrogate: replacement :: Any.to_boolean = #false
+  ) :: json.JSON
+  fun json.read(
+    ~in: inp :: Port.Input = Port.Input.current(),
+    ~replace_malformed_surrogate: replacement :: Any.to_boolean = #false
+  ) :: json.JSON || Port.Input.EOF
+){
+
+ Parses a JSON representation to a @rhombus(json.JSON, ~annot) value.
+
+ For @rhombus(json.from_string) and @rhombus(json.from_bytes), the
+ string or byte string must contain a single JSON encoding.
+
+@examples(
+  ~eval: json_eval
+  ~repl:
+    json.from_string("1")
+    json.from_string("{\"a\": [1, 2]}")
+    ~error:
+      json.from_string("1 2")
+    ~error:
+      json.from_string("")
+    json.from_bytes(#"{\"a\": [1, 3.0, null, false]}")
+)
+
+ The @rhombus(json.read) function reads the next JSON encoding from
+ @rhombus(inp), stopping (and leaving remaining bytes in the port intact)
+ as soon as it finds a complete JSON value; @litchar{true},
+ @litchar{false}, or @litchar{null} must be followed by an end-of-file or
+ a non-alphanumeric character (such as whitespace). If no JSON
+ representation is present in @rhombus(inp) before an end-of-file, the
+ result is @rhombus(Port.Input.eof).
+
+@examples(
+  ~eval: json_eval
+  ~repl:
+    def inp = Port.Input.open_string("1 true[\"a\", {\"b\": 3.0}]")
+    json.read(~in: inp)
+    json.read(~in: inp)
+    json.read(~in: inp)
+    json.read(~in: inp)
+)
+
+
+ If @rhombus(replacement) is true, then an unpaired surrogate escape in
+ an input JSON string representation is replaced with
+ @rhombus(Char"\uFFFD"). Otherwise, an unpaired surrogate is treated as
+ an input error.
+
+@examples(
+  ~eval: json_eval
+  ~repl:
+    json.from_string(@str{"\u03BB"})
+    ~error:
+      json.from_string(@str{"\uD870"})
+    json.from_string(@str{"\uD870"},
+                     ~replace_malformed_surrogate: #true)
+)
+
+}
+
+
+@doc(
+  fun json.to_string(j :: json.JSON) :: String
+  fun json.to_bytes(j :: json.JSON) :: Bytes
+  fun json.write(
+    j :: json.JSON,
+    ~out: outp :: Port.Output = Port.Output.current()
+  ) :: Void
+){
+
+ Produces a JSON representation of a @rhombus(json.JSON, ~annot) value.
+
+ The @rhombus(json.to_string) and @rhombus(json.to_bytes) functions
+ return the JSON representation as a string or byte string, while
+ @rhombus(json.write) prints that representation to an output port.
+
+@examples(
+  ~eval: json_eval
+  ~repl:
+    json.to_string(1)
+    json.to_string({ "a": 1, "b": [2, 3.0, #'null, #false] })
+    json.to_bytes(1)
+    json.write([2, 3, 4])
+    block:
+      let outp = Port.Output.open_string()
+      json.write([2, 3, 4], ~out: outp)
+      json.write({ "a": 0 }, ~out: outp)
+      outp.get_string()
+)
+
+}

--- a/rhombus-json/rhombus/json/tests/json.rhm
+++ b/rhombus-json/rhombus/json/tests/json.rhm
@@ -1,0 +1,119 @@
+#lang rhombus
+import:
+  json
+
+check 1 ~is_a json.JSON
+check 1/2 is_a json.JSON ~is #false
+check "a" ~is_a json.JSON
+check "a".copy() is_a json.JSON ~is #false
+check [1, 2] ~is_a json.JSON
+check { "a": 1 } ~is_a json.JSON
+check { #'a: 1 } is_a json.JSON ~is #false
+check { "a": [1, #nan] } is_a json.JSON ~is #false
+check #'null ~is_a json.JSON
+
+check json.to_string(1) ~is "1"
+check json.to_string("apple") ~is "\"apple\""
+check json.to_string("\"apple\"") ~is "\"\\\"apple\\\"\""
+check json.to_string([1, 2, 3.0]) ~is "[1,2,3.0]"
+check json.to_string([1, [2], 3]) ~is "[1,[2],3]"
+check json.to_string({ "a": 1, "b": 2 }) ~is "{\"a\":1,\"b\":2}"
+check json.to_string({}) ~is "{}"
+check json.to_string(#true) ~is "true"
+check json.to_string(#'null) ~is "null"
+check json.to_string([1, #'null]) ~is "[1,null]"
+
+check json.to_string(1/2) ~throws values("json.to_string",
+                                         error.annot_msg("argument"),
+                                         error.val(~label: "argument", 1).msg)
+check json.to_string(#inf) ~throws values("json.to_string",
+                                          error.annot_msg("argument"),
+                                          error.val(~label: "argument", #inf).msg)
+check json.to_string({ 1: 2 }) ~throws values("json.to_string",
+                                              error.annot_msg("argument"),
+                                              error.val(~label: "argument", { 1: 2 }).msg)
+check json.to_string({ #'null: 2 }) ~throws values("json.to_string",
+                                                   error.annot_msg("argument"),
+                                                   error.val(~label: "argument", { #'null: 2 }).msg)
+
+check json.to_string([1,3/2,4]) ~throws values(error.annot_msg("argument"),
+                                               error.val(~label: "argument", [1, 3/2, 4]).msg)
+
+check json.to_bytes(1) ~is_now #"1"
+check json.to_bytes({ "a": 1, "b": 2 }) ~is_now #"{\"a\":1,\"b\":2}"
+
+check json.to_bytes(1/2) ~throws values("json.to_bytes",
+                                        error.annot_msg("argument"),
+                                        error.val(~label: "argument", 1).msg)
+
+check:
+  json.write([1, 2, 3])
+  ~prints "[1,2,3]"
+
+check:
+  let o = Port.Output.open_string()
+  json.write([1, 2, 3], ~out: o)
+  o.get_string()
+  ~is "[1,2,3]"
+
+check json.write(1/2) ~throws values("json.write",
+                                     error.annot_msg("argument"),
+                                     error.val(~label: "argument", 1).msg)
+check json.write([1, 2, 3], ~out: 0) ~throws values("json.write",
+                                                    error.annot_msg("argument"),
+                                                    error.val(~label: "argument", 0).msg)
+
+check json.from_string("1") ~is 1
+check json.from_string("1".copy()) ~is 1
+check json.from_string("[1, 2, 3.0]") ~is [1, 2, 3.0]
+check json.from_string("{\"a\":1,\"b\":2}") ~is { "a": 1, "b": 2 }
+check json.from_string("{}") ~is {}
+check json.from_string("{ \"a\": null }") ~is { "a": #'null }
+check json.from_string("true") ~is #true
+check json.from_string("false") ~is #false
+
+check json.from_string("bad") ~throws values("json.from_string",
+                                             "bad input")
+check json.from_string("()") ~throws values("json.from_string",
+                                            "bad input")
+check json.from_string("{null:1}") ~throws values("json.from_string",
+                                                  "non-string value used for json object key")
+
+check json.from_string("") ~throws values("json.from_string",
+                                          "no value in string")
+check json.from_string("1 2") ~throws values("json.from_string",
+                                             "found additional value in string")
+
+check json.from_bytes(#"1") ~is 1
+check json.from_bytes(#"[1, 2, 3.0]") ~is [1, 2, 3.0]
+
+check json.from_bytes(#"bad") ~throws values("json.from_bytes",
+                                             "bad input")
+check json.from_bytes(#"{null:1}") ~throws values("json.from_bytes",
+                                                  "non-string value used for json object key")
+check json.from_bytes(#"") ~throws values("json.from_bytes",
+                                          "no value in byte string")
+check json.from_bytes(#"1 2") ~throws values("json.from_bytes",
+                                             "found additional value in byte string")
+
+check json.read(~in: Port.Input.open_string("")) ~is Port.eof
+check json.read(~in: Port.Input.open_string("bad")) ~throws values("json.read",
+                                                                   "bad input")
+
+block:
+  let inp = Port.Input.open_string("1 [2, 3] false")
+  check json.read(~in: inp) ~is 1
+  check json.read(~in: inp) ~is [2, 3]
+  check json.read(~in: inp) ~is #false
+  check json.read(~in: inp) ~is Port.eof
+
+check json.read(~in: Port.Input.open_string("1a")) ~is 1
+check json.read(~in: Port.Input.open_string("1,a")) ~is 1
+check json.read(~in: Port.Input.open_string("true,a")) ~is #true
+check json.read(~in: Port.Input.open_string("truea")) ~throws "bad input"
+check json.read(~in: Port.Input.open_string("true1")) ~throws "bad input"
+
+check json.from_string(@str{"x"}) ~is "x"
+check json.from_string(@str{"\u03BB"}) ~is "λ"
+check json.from_string(@str{"\uD870"}) ~throws "bad string"
+check json.from_string(@str{"\uD870"}, ~replace_malformed_surrogate: #true) ~is "\uFFFD"


### PR DESCRIPTION
This is @samdphillips's JSON wrapper in a "rhombus-json" and "rhombus-json-lib" package:

* `json.JSON` - the annotation
* `json.read`, `json.from_string`, `json.from_bytes` - parsing
* `json.write`, `json.to_string`, `json.to_bytes` - printing

Some notable choices in this implementation:

* Keys in a map `json.JSON` are strings, not symbols.
* `json.JSON` recognizes lists, maps with string keys, etc., without wrapping. The result of a successful `json.JSON` check via `is_a` or `::` is cached (similar to `list?` in Racket), so it's amortized constant-time for satisfying values.
* `json.from_string` and `json.from_bytes` complain if the given string or byte string doesn't contain a single JSON representation. That's different from the Racket library, where `(string->jsexpr "")` produces `eof` and `(string->jsexpr "1 2")` produces `1`.
* `json.read`, `json.from_string`, and `json.from_bytes` have a `~replace_malformed_surrogate` argument that defaults to `#false`, the same as the Racket library.
