### PR TITLE
Shrubbery: add `~#{....}` notation for keywords

### DIFF
--- a/rhombus-json-lib/rhombus/json.rhm
+++ b/rhombus-json-lib/rhombus/json.rhm
@@ -53,14 +53,14 @@ namespace json:
                    ~encode: #'control,
                    ~indent: #false,
                    ~null: #'null,
-                   #{#:object-rep?}: (_ is_a Map),
-                   #{#:object-rep->hash}: values,
-                   #{#:list-rep?}: (_ is_a List),
-                   #{#:list-rep->list}: fun (vs): PairList(&vs),
-                   #{#:key-rep?}: (_ is_a String),
-                   #{#:key-rep->string}: values,
-                   #{#:string-rep?}: (_ is_a String),
-                   #{#:string-rep->string}: values)
+                   ~#{object-rep?}: (_ is_a Map),
+                   ~#{object-rep->hash}: values,
+                   ~#{list-rep?}: (_ is_a List),
+                   ~#{list-rep->list}: fun (vs): PairList(&vs),
+                   ~#{key-rep?}: (_ is_a String),
+                   ~#{key-rep->string}: values,
+                   ~#{string-rep?}: (_ is_a String),
+                   ~#{string-rep->string}: values)
 
   fun write(v :: JSON,
             ~out: out :: Port.Output = Port.Output.current()):
@@ -83,11 +83,11 @@ namespace json:
     rkt_json.read(who,
                   in,
                   ~null: #'null,
-                  #{#:make-object}: #{make-immutable-hashalw},
-                  #{#:make-list}: PairList.to_list,
-                  #{#:make-key}: String.snapshot,
-                  #{#:make-string}: String.snapshot,
-                  #{#:replace-malformed-surrogate?}: replace_malformed_surrogate)
+                  ~#{make-object}: #{make-immutable-hashalw},
+                  ~#{make-list}: PairList.to_list,
+                  ~#{make-key}: String.snapshot,
+                  ~#{make-string}: String.snapshot,
+                  ~#{replace-malformed-surrogate?}: replace_malformed_surrogate)
 
   fun read(~in: in :: Port.Input = Port.Input.current(),
            ~replace_malformed_surrogate: replace_malformed_surrogate :: Any.to_boolean = #false):

--- a/rhombus/rhombus/scribblings/rhombus-racket/data.scrbl
+++ b/rhombus/rhombus/scribblings/rhombus-racket/data.scrbl
@@ -27,12 +27,22 @@ basic forms of data:
  @item{Symbols and keywords. A keyword is written in shrubbery notation
  for Rhombus with a @litchar{~} prefix, and it is written in S-expression
  notation with a @litchar{#:} prefix, but the representation does not
- include that prefix.}
+ include that prefix.
+
+ A Racket identifier with non-alphabetic characters can be written in
+ Rhombus using @litchar("#{")…@litchar("}") notation, as in
+ @rhombus(#{finish-work}). A Racket keyword with non-alphabetic
+ characters can be written in Rhombus using @litchar("~#{")…@litchar("}")
+ notation, as in @rhombus(~#{fast?}), or using
+ @litchar("#{")…@litchar("}") notation, as in @rhombus(#{#:fast?}), and
+ the former is usually preferred.}
 
  @item{Functions, including functions with keyword arguments are the
- same. Note that a Racket keyword with non-alphabetic characters can be
- written in rhombus using @litchar("#{")…@litchar("}") notation, as in
- @rhombus(work(#{#:fast?}: #true)).}
+ same.
+
+ The @litchar("#{")…@litchar("}") and @litchar("~#{")…@litchar("}")
+ notations can be useful for calling Racket functions with keyword
+ arguments, as in @rhombus(#{finish-work}(~#{fast?}: #true)).}
 
  @item{Pairs are the same. Racket @tech(~doc: racket_doc){lists} are
  Rhombus @tech(~doc: rhombus_doc){pair lists}, Rhombus

--- a/shrubbery-lib/shrubbery/write.rkt
+++ b/shrubbery-lib/shrubbery/write.rkt
@@ -357,11 +357,21 @@
 (define (write-escaped v op)
   (cond
     [(symbol? op)
-     (twice (format "#{~s}" v))]
+     (cond
+       [(keyword? v)
+        (twice (format "~~#{~s}" (string->symbol (keyword->immutable-string v))))]
+       [else
+        (twice (format "#{~s}" v))])]
     [else
-     (display "#{" op)
-     (write v op)
-     (display "}" op)]))
+     (cond
+       [(keyword? v)
+        (display "~#{" op)
+        (write (string->symbol (keyword->immutable-string v)) op)
+        (display "}" op)]
+       [else
+        (display "#{" op)
+        (write v op)
+        (display "}" op)])]))
 
 (define (twice v)
   (values v v #f #t))

--- a/shrubbery/shrubbery/scribblings/quote.rhm
+++ b/shrubbery/shrubbery/scribblings/quote.rhm
@@ -7,6 +7,7 @@ export:
   brackets
   braces
   s_exp_braces
+  s_exp_kw_braces
   quotes
   guillemets
   block_comment
@@ -18,6 +19,7 @@ def parens = @open_close("(", ")")
 def brackets = @open_close("[", "]")
 def braces = @open_close("{", "}")
 def s_exp_braces = @open_close("#{", "}")
+def s_exp_kw_braces = @open_close("~#{", "}")
 def quotes = @open_close("'", "'")
 def block_comment = @open_close("/*", "*/")
 def guillemets = @open_close("«", "»")

--- a/shrubbery/shrubbery/scribblings/token-parsing.scrbl
+++ b/shrubbery/shrubbery/scribblings/token-parsing.scrbl
@@ -76,7 +76,9 @@ shrubbery-notation identifier. The same holds for numbers, booleans,
 strings, byte strings, and keywords. A @s_exp_braces
 escape must @emph{not} describe a pair, because pairs are used to represent a
 parsed shrubbery, and allowing pairs would create ambiguous or
-ill-formed representations.
+ill-formed representations. The @s_exp_kw_braces shorthand always
+produces a keyword, where the content of @s_exp_kw_braces must be
+an S-expression identifier that is converted to a keyword.
 
 Lines and indentation-influencing whitespace are not represented as
 tokens. Instead, each token conceptually has a line and column derived
@@ -235,6 +237,7 @@ but the table below describes the shape of @litchar("@") forms.
     [no_lex, @nonterm{bytestrelem}, bis, @italic{like Racket, but no literal newline}, ""],
     empty_line,
     [is_lex, @nonterm{sexpression}, bis, bseq(@litchar("#{"), @nonterm{racket}, @litchar("}")), ""],
+    ["", "", bis, bseq(@litchar("~#{"), @nonterm{racket-identifier}, @litchar("}")), ""],
     empty_line,
     [no_lex, @nonterm{racket}, bis, @italic{any non-pair Racket S-expression}, ""],
     empty_line,

--- a/shrubbery/shrubbery/tests/input.rkt
+++ b/shrubbery/shrubbery/tests/input.rkt
@@ -1931,6 +1931,7 @@ then @{8}
 
 @(in #{s-exp} mode)
 @{also in @(#{s-exp}) mode}
+@{this time in @(~#{s-exp-keyword}) mode}
 
 @elem{@a()@b()}
 @elem{@a{}@b()}
@@ -2057,6 +2058,13 @@ INPUT
        (brackets
         (group "also in ")
         (group (parens (group s-exp)))
+        (group " mode")))))
+    (group
+     (parens
+      (group
+       (brackets
+        (group "this time in ")
+        (group (parens (group #:s-exp-keyword)))
         (group " mode")))))
     (group
      elem


### PR DESCRIPTION
A `~#{....}` form is equivalent to `#{#:....}`, but it's less noisy and connects more clearly to normal Shrubbery keyword syntax. The content of `~#{....}` is restricted to S-expression identifiers.

In more detail: S-expression escapes have worked ok for writing identifiers like `#{read-json*}`. For a keyword, which is almost always followed by `:`, writing `#{#:object-rep?}:` is less obvious, feels like an awful lot of `#`s and `:`s, and doesn't have the leading `~` that normally distinguishes keywords. Adding this keyword shorthand allows `~#{object-rep?}:`. Before this change, `~#` was always a syntax error, so the change doesn't break anything.