### PR TITLE
XML library

### DIFF
--- a/rhombus-xml-lib/info.rkt
+++ b/rhombus-xml-lib/info.rkt
@@ -1,0 +1,13 @@
+#lang info
+
+(define collection 'multi)
+
+(define deps
+  '("base"
+    "rhombus-lib"))
+
+(define pkg-desc "implementation (no documentation) part of \"rhombus-xml\"")
+
+(define license '(Apache-2.0 OR MIT))
+
+(define version "0.1")

--- a/rhombus-xml-lib/rhombus/xml.rhm
+++ b/rhombus-xml-lib/rhombus/xml.rhm
@@ -1,0 +1,181 @@
+#lang rhombus/static/and_meta
+import:
+  lib("xml/main.rkt") as rkt
+  "xml/private/class.rhm":
+    expose:
+      Document
+      Element
+  "xml/private/to_rhm.rhm" open
+  "xml/private/to_rkt.rhm" open
+  "xml/private/to_xstx.rhm" open
+  "xml/private/from_xstx.rhm" open
+  "xml/private/swap.rhm" open
+
+export:
+  all_from(.class)
+  to_syntax
+  from_syntax
+
+namespace xml:
+  export:
+    read
+    from_string
+    from_bytes
+    read_syntax
+    string_to_syntax
+    bytes_to_syntax
+
+    write
+    to_string
+    to_bytes
+    write_syntax
+    syntax_to_string
+    syntax_to_bytes
+
+    Indentation
+
+    current_read_normalize
+    current_read_comments
+    current_read_processing_instructions
+    current_read_count_bytes
+    current_read_collapse_whitespace
+    current_write_empty_shorthand
+
+    doc
+    syntax
+
+  fun read(~in: inp :: Port.Input = Port.Input.current(),
+           ~read_post_misc: read_post_misc = #true)
+    :~ Document:
+      let x:
+        parameterize { rkt.#{read-comments}: current_read_comments(),
+                       rkt.#{xml-count-bytes}: current_read_count_bytes(),
+                       rkt.#{collapse-whitespace}: current_read_collapse_whitespace() }:
+          if read_post_misc
+          | rkt.#{read-xml}(inp)
+          | rkt.#{read-xml/document}(inp)      
+      to_rhm(x,
+             ~keep_pi: current_read_processing_instructions(),
+             ~normalize: current_read_normalize())
+
+  fun read_syntax(~in: inp :: Port.Input = Port.Input.current())
+    :~ Syntax:
+      to_syntax(read(~in: inp))
+
+  fun from_string(str :: String)
+    :~ Document:
+      read(~in: Port.Input.open_string(str))
+
+  fun string_to_syntax(str :: String)
+    :~ Document:
+      to_syntax(read(~in: Port.Input.open_string(str)))
+
+  fun from_bytes(bstr :: Bytes)
+    :~ Document:
+      read(~in: Port.Input.open_bytes(bstr))
+
+  fun bytes_to_syntax(bstr :: Bytes)
+    :~ Document:
+      to_syntax(read(~in: Port.Input.open_bytes(bstr)))
+
+  enum Indentation:
+    none
+    peek
+    scan
+
+  fun write(doc :: Document || Element,
+            ~out: outp :: Port.Output = Port.Output.current(),
+            ~indentation: indentation :: Indentation = #'none):
+    parameterize { rkt.#{permissive-xexprs}: class.current_permissive(),
+                   rkt.#{empty-tag-shorthand}: (if current_write_empty_shorthand()
+                                                | #'always
+                                                | #'never) }:
+      if doc is_a Document
+      | rkt.#{display-xml}(to_rkt(doc), outp,
+                           ~indentation: indentation)
+      | rkt.#{display-xml/content}(element_to_rkt(doc), outp,
+                                   ~indentation: indentation)
+
+  fun write_syntax(xstx :: Syntax,
+                   ~swap_underscore_dash: swap = default_swap,
+                   ~out: outp :: Port.Output = Port.Output.current(),
+                   ~indentation: indentation :: Indentation = #'none):
+    ~who: who
+    let doc = _from_syntax(~who: who,
+                           xstx,
+                           ~swap_underscore_dash: swap)
+    write(doc,
+          ~out: outp,
+          ~indentation: indentation)
+
+  fun to_string(doc :: Document || Element,
+                ~indentation: indentation :: Indentation = #'none)
+    :~ String:
+      let outp = Port.Output.open_string()
+      write(doc,
+            ~out: outp,
+            ~indentation: indentation)
+      outp.get_string()
+
+  fun to_bytes(doc :: Document || Element,
+               ~indentation: indentation :: Indentation = #'none)
+    :~ Bytes:
+      let outp = Port.Output.open_string()
+      write(doc,
+            ~out: outp,
+            ~indentation: indentation)
+      outp.get_bytes()
+
+  fun syntax_to_string(xstx :: Syntax,
+                       ~indentation: indentation :: Indentation = #'none,
+                       ~swap_underscore_dash: swap = default_swap)
+    :~ String:
+      ~who: who
+      let doc = _from_syntax(~who: who,
+                             xstx,
+                             ~swap_underscore_dash: swap)
+      to_string(doc,
+                ~indentation: indentation)
+
+  fun syntax_to_bytes(xstx :: Syntax,
+                      ~indentation: indentation :: Indentation = #'none,
+                      ~swap_underscore_dash: swap = default_swap)
+    :~ Bytes:
+      ~who: who
+      let doc = _from_syntax(~who: who,
+                             xstx,
+                             ~swap_underscore_dash: swap)
+      to_bytes(doc,
+               ~indentation: indentation)
+
+  Parameter.def current_read_normalize :: Any.to_boolean = #true
+  Parameter.def current_read_comments :: Any.to_boolean = #false
+  Parameter.def current_read_processing_instructions :: Any.to_boolean = #true
+  Parameter.def current_read_count_bytes :: Any.to_boolean = #false
+  Parameter.def current_read_collapse_whitespace :: Any.to_boolean = #false
+  Parameter.def current_write_empty_shorthand :: Any.to_boolean = #false
+
+  expr.macro 'doc:
+                $(group_option_sequence
+                  | '~swap_underscore_dash: $do_swap')
+                $content
+                ...':
+    ~op_stx: who
+    '«to_doc('$who', '$content; ...', $(do_swap || 'default_swap'))»'
+
+  expr.macro 'syntax: $content':
+    ~op_stx: who
+    '«check_syntax('$who', '$content')»'
+
+  fun to_doc(who, xstx, swap):
+    _from_syntax(~who: who,
+                 xstx,
+                 ~swap_underscore_dash: swap)
+  
+  fun check_syntax(who, xstx):
+    // ignoring result:
+    to_doc(who, xstx, #false)
+    xstx
+
+export:
+  all_from(.xml)

--- a/rhombus-xml-lib/rhombus/xml/private/class.rhm
+++ b/rhombus-xml-lib/rhombus/xml/private/class.rhm
@@ -1,0 +1,110 @@
+#lang rhombus/static/and_meta
+import:
+  lib("xml/main.rkt") as rkt
+
+export:
+  Document
+
+  Content
+  Element
+  Text
+  Entity
+  Inject
+  OtherPermitted
+
+  Prolog
+  DTD
+
+  SrclocRange
+
+  Comment
+  ProcessingInstruction
+  Misc
+
+  Attribute
+
+  EntityInt
+
+  current_permissive
+
+class SrclocRange(start :: Srcloc,
+                  end :: Srcloc)
+
+class Comment(~text: text :: String)
+
+class ProcessingInstruction(~target_name: target_name :: String,
+                            ~instruction: instruction :: String,
+                            ~srcloc: srcloc :: maybe(SrclocRange) = #false)
+
+class DTD(~name: name :: String,
+          ~system: system :: String,
+          ~public: public :: maybe(String) = #false)
+
+annot.macro 'Misc': 'Comment || ProcessingInstruction'
+
+class Prolog(~pre_misc: post_misc :: List.of(Misc) = [],
+             ~dtd: dtd :: maybe(DTD) = #false,
+             ~post_misc: pst_misc :: List.of(Misc) = [])
+
+Parameter.def current_permissive :: Any.to_boolean = #false
+
+annot.macro 'OtherPermitted': 'satisfying(fun (v): current_permissive())'
+
+annot.macro 'Content': 'satisfying(is_content)'
+
+fun is_content(v):
+  v is_a Element
+    || v is_a Entity
+    || v is_a Text
+    || v is_a Inject
+    || v is_a Misc
+    || v is_a OtherPermitted
+
+class Attribute(~name: name :: String,
+                ~value: value :: String || OtherPermitted,
+                ~srcloc: srcloc :: maybe(SrclocRange) = #false)
+
+enum WriteMode:
+  default
+  cdata
+  entity
+
+class Text(~text: text :: String,
+           ~srcloc: srcloc :: maybe(SrclocRange) = #false,
+           ~write_mode: write_mode :: WriteMode = #'default):
+  export:
+    WriteMode
+  constructor (~text: text :: String,
+               ~srcloc: srcloc :: maybe(SrclocRange) = #false,
+               ~write_mode: write_mode :: WriteMode described_as Text.WriteMode = #'default):
+    ~who: who
+    when write_mode == WriteMode.cdata && String.contains(text, "]]>")
+    | error(~who: who,
+            "cannot write as CData, because text includes `]]>`",
+            error.val(~label: "text", text))
+    when write_mode == WriteMode.entity && text.length() != 1
+    | error(~who: who,
+            "cannot write as an entity, because text is not of length 1",
+            error.val(~label: "text", text))
+    super(~text: text, ~srcloc: srcloc, ~write_mode: write_mode)
+  reconstructor (text, srcloc, write_mode):
+    Text(~text: text, ~srcloc: srcloc, ~write_mode: write_mode)
+
+class Inject(~text: text :: String,
+             ~srcloc: srcloc :: maybe(SrclocRange) = #false)
+
+annot.macro 'EntityInt': 'Int.in(1, 0xD7FF)
+                            || Int.in(0xE000, 0xFFFD)
+                            || Int.in(0x10000, 0x10FFFF)'
+
+class Entity(~text: text :: String || EntityInt,
+             ~srcloc: srcloc :: maybe(SrclocRange) = #false)             
+
+class Element(~name: name :: String,
+              ~attributes: attributes :: List.of(Attribute) = [],
+              ~content: content :: List.of(Content) = [],
+              ~srcloc: srcloc :: maybe(SrclocRange) = #false)
+
+class Document(~prolog: prolog :: Prolog = Prolog(),
+               ~element: element :: Element,
+               ~misc: misc :: List.of(Misc) = [])

--- a/rhombus-xml-lib/rhombus/xml/private/from_xstx.rhm
+++ b/rhombus-xml-lib/rhombus/xml/private/from_xstx.rhm
@@ -1,0 +1,123 @@
+#lang rhombus/static/and_meta
+import:
+  "class.rhm" open
+  "swap.rhm" open
+
+export:
+  from_syntax
+  _from_syntax
+
+fun from_syntax(xstx :: Syntax,
+                ~swap_underscore_dash: swap = default_swap):
+  ~name: xml.from_xstx
+  ~who: who
+  Document(~element: element(who, xstx, swap))
+
+fun _from_syntax(~who: who,
+                 xstx :: Syntax,
+                 ~swap_underscore_dash: swap = default_swap):
+  Document(~element: element(who, xstx, swap))
+
+fun extract_name(str :: String, swap):
+  if swap
+  | swap_underscore_dash(str)
+  | str
+
+fun element(who, xstx :~ Syntax, swap):
+  match xstx
+  | '$(name :: Identifier):
+       $blk':
+      let (attrs, content) = content(who, blk, swap, [], [])
+      Element(~srcloc: make_srcloc(name),
+              ~name: extract_name(to_string(name), swap),
+              ~attributes: attrs,
+              ~content: content)
+  | ~else:
+      error(~who: who,
+            ~exn: Exn.Fail.Annot,
+            ~srcloc: xstx.srcloc(),
+            "invalid XML syntax",
+            error.val(xstx))
+    
+fun content(who, es, swap, attrs :~ List, cs :~ List):
+  match es
+  | '':
+      values(attrs, cs)
+  | '$(name :: Keyword): $rhs
+     $e; ...':
+      unless cs == []
+      | error(~who: who,
+              ~exn: Exn.Fail.Annot,
+              ~srcloc: name.srcloc(),            
+              "misplaced attribute",
+              error.val(name))
+      unless rhs.unwrap() is_a (String || OtherPermitted)
+      | error(~who: who,
+              ~exn: Exn.Fail.Annot,
+              ~srcloc: rhs.srcloc(),            
+              "expected a string for an attribute value",
+              error.val(rhs))
+      let attr = Attribute(~name: extract_name(to_string(name.unwrap()), swap),
+                           ~value:
+                             let v = rhs.unwrap()
+                             if v is_a ReadableString
+                             | to_string(v)
+                             | v)
+      content(who, '$e; ...', swap, attrs.add(attr), cs)
+  | '$(name :: Identifier): $blk
+     $e; ...':
+      let (c_attrs, c_cs) = content(who, blk, swap, [], [])
+      let c = Element(~srcloc: make_srcloc(name),
+                      ~name: extract_name(to_string(name), swap),
+                      ~attributes: c_attrs,
+                      ~content: c_cs)
+      content(who, '$e; ...', swap, attrs, cs.add(c))
+  | '$g
+     $e; ...':
+      let es = '$e; ...'
+      recur group(g = g, attrs :~ List = attrs, cs :~ List = cs):
+        match g
+        | '':
+            content(who, es, swap, attrs, cs)
+        | '($g0, ...) $(g :: Sequence)':
+            content(who, '$g0; ...; $g; $es', swap, attrs, cs)
+        | '[$g0, ...] $(g :: Sequence)':
+            content(who, '$g0; ...; $g; $es', swap, attrs, cs)
+        | '& $(entity :: Term) $(g :: Sequence)':
+            match entity
+            | '$(s :: Identifier)':
+                let c = Entity(~srcloc: make_srcloc(s),
+                               ~text: to_string(s))
+                group(g, attrs, cs.add(c))
+            | '$(i :: Int)' when i.unwrap() is_a EntityInt:
+                let c = Entity(~srcloc: make_srcloc(i),
+                               ~text: i.unwrap())
+                group(g, attrs, cs.add(c))
+            | ~else:
+                error(~who: who,
+                      ~srcloc: entity.srcloc(),
+                      ~exn: Exn.Fail.Annot,
+                      "invalid entity",
+                      error.val(entity))
+        | '$(head :: Term) $(g :: Sequence)':            
+            match head
+            | '$(s :: String)':
+                let c = Text(~srcloc: make_srcloc(head),
+                             ~text: s.unwrap())
+                group(g, attrs, cs.add(c))
+            | ~else:
+                let c = head.unwrap()
+                if c is_a Content
+                | group(g, attrs, cs.add(c))
+                | error(~who: who,
+                        ~srcloc: head.srcloc(),
+                        ~exn: Exn.Fail.Annot,
+                        "invalid content",
+                        error.val(head))
+
+fun make_srcloc(s :~ Syntax):
+  match s.srcloc()
+  | srcloc && Srcloc(src, line, col, pos, span):
+      SrclocRange(srcloc,
+                  Srcloc(src, line, col, pos && span && pos + span, #false))
+  | else: #false

--- a/rhombus-xml-lib/rhombus/xml/private/swap.rhm
+++ b/rhombus-xml-lib/rhombus/xml/private/swap.rhm
@@ -1,0 +1,18 @@
+#lang rhombus/static/and_meta
+import:
+  rhombus/rx open
+
+export:
+  default_swap
+  swap_underscore_dash
+
+def default_swap = #false
+
+fun swap_underscore_dash(str :: String):
+  fun underscore_to_dash(str):
+    rx'"_"'.replace_all(str, "-")
+  let strs = str.split("-")
+  if strs.length() == 1
+  | underscore_to_dash(str)
+  | let [str, ...] = strs
+    String.join([underscore_to_dash(str), ...], "_")

--- a/rhombus-xml-lib/rhombus/xml/private/to_rhm.rhm
+++ b/rhombus-xml-lib/rhombus/xml/private/to_rhm.rhm
@@ -1,0 +1,180 @@
+#lang rhombus/static/and_meta
+import:
+  lib("xml/main.rkt") as rkt
+  "class.rhm" open
+
+export:
+  to_rhm
+
+fun to_rhm(doc,
+           ~keep_pi: keep_pi,
+           ~normalize: normalize):
+  let PairList[misc, ...] = rkt.#{document-misc}(doc)
+  Document(~prolog: prolog_to_rhm(rkt.#{document-prolog}(doc), keep_pi),
+           ~element: element_to_rhm(rkt.#{document-element}(doc), normalize, keep_pi),
+           ~misc: filter_pi([misc_to_rhm(misc), ...], keep_pi))
+
+fun prolog_to_rhm(prolog, keep_pi):
+  let PairList[pre_misc, ...] = rkt.#{prolog-misc}(prolog)
+  let dtd = rkt.#{prolog-dtd}(prolog)
+  let PairList[post_misc, ...] = rkt.#{prolog-misc2}(prolog)
+  Prolog(~pre_misc: filter_pi([misc_to_rhm(pre_misc), ...], keep_pi),
+         ~dtd: dtd && DTD(~name: rkt.#{document-type-name}(dtd),
+                          ~system: to_string(rkt.#{external-dtd-system}(dtd)),
+                          ~public:
+                            let pub = rkt.#{external-dtd/public?}(dtd) && rkt.#{external-dtd/public-public}(dtd)
+                            pub && to_string(pub)),
+         ~post_misc: filter_pi([misc_to_rhm(post_misc), ...], keep_pi))
+
+fun element_to_rhm(e, normalize, keep_pi):
+  let PairList[attr, ...] = rkt.#{element-attributes}(e) 
+  let PairList[content, ...] = rkt.#{element-content}(e) 
+  Element(~srcloc: source_to_rhm(e),
+          ~name: to_string(rkt.#{element-name}(e)),
+          ~attributes: [attribute_to_rhm(attr), ...],
+          ~content: normalize_text(filter_pi([content_to_rhm(content, normalize, keep_pi), ...], keep_pi),
+                                   normalize))
+
+fun content_to_rhm(c, normalize, keep_pi):
+  cond
+  | rkt.#{element?}(c):
+      element_to_rhm(c, normalize, keep_pi)
+  | rkt.#{entity?}(c):
+      entity_to_rhm(c, normalize)
+  | rkt.#{pcdata?}(c):
+      pcdata_to_rhm(c)
+  | rkt.#{cdata?}(c):
+      cdata_to_rhm(c)
+  | rkt.#{comment?}(c):
+      comment_to_rhm(c)
+  | rkt.#{p-i?}(c):
+      p_i_to_rhm(c)
+  | ~else:
+      // permissive mode
+      c
+
+fun misc_to_rhm(misc):
+  cond
+  | rkt.#{comment?}(misc):
+      comment_to_rhm(misc)
+  | rkt.#{p-i?}(misc):
+      p_i_to_rhm(misc)
+
+fun pcdata_to_rhm(pc):
+  Text(~srcloc: source_to_rhm(pc),
+       ~text: to_string(rkt.#{pcdata-string}(pc)))
+
+fun cdata_to_rhm(c):
+  let srcloc = source_to_rhm(c)
+  let s = to_string(rkt.#{cdata-string}(c))
+  if (s.length() >= 12
+        && s.substring(0, 9) == "<![CDATA["
+        && s.substring(s.length() - 3, s.length()) == "]]>")
+  | let sub = s.substring(9, s.length() - 3)
+    if sub.contains("]]>")
+    | Inject(~srcloc: srcloc,
+             ~text: s)
+    | Text(~srcloc: srcloc,
+           ~text: sub,
+           ~write_mode: Text.WriteMode.cdata)
+  | Inject(~srcloc: srcloc,
+           ~text: s)
+
+fun comment_to_rhm(c):
+  Comment(~text: to_string(rkt.#{comment-text}(c)))
+
+fun p_i_to_rhm(pi):
+  ProcessingInstruction(~target_name: to_string(rkt.#{p-i-target-name}(pi)),
+                        ~instruction: to_string(rkt.#{p-i-instruction}(pi)))
+
+fun source_to_rhm(s):
+  let start = rkt.#{source-start}(s)
+  let stop = rkt.#{source-stop}(s)
+  if start is_a Symbol || stop is_a Symbol
+  | #false
+  | SrclocRange(Srcloc(#false,
+                       rkt.#{location-line}(start),
+                       rkt.#{location-char}(start),
+                       rkt.#{location-offset}(start),
+                       rkt.#{location-offset}(stop) - rkt.#{location-offset}(start)),
+                Srcloc(#false,
+                       rkt.#{location-line}(stop),
+                       rkt.#{location-char}(stop),
+                       rkt.#{location-offset}(stop),
+                       #false))
+
+fun attribute_to_rhm(attr):
+  Attribute(~srcloc: source_to_rhm(attr),
+            ~name: to_string(rkt.#{attribute-name}(attr)),
+            ~value:
+              let v = rkt.#{attribute-value}(attr)
+              if v is_a ReadableString
+              | to_string(v)
+              | v)
+  
+fun entity_to_rhm(e, normalize):
+  let v = rkt.#{entity-text}(e)
+  let srcloc = source_to_rhm(e)
+  if v is_a Int
+  | if normalize
+    | Text(~srcloc: srcloc,
+           ~text: to_string(Char.from_int(v)),
+           ~write_mode: Text.WriteMode.entity)
+    | Entity(~srcloc: srcloc,
+             ~text: v)
+  | Entity(~srcloc: srcloc,
+           ~text: to_string(v))
+
+fun filter_pi(misc :: List, keep_pi):
+  if keep_pi
+  | misc
+  | misc.filter(~skip: fun (x): x is_a ProcessingInstruction)
+
+fun normalize_text(content :: List, normalize):
+  if !normalize
+  | content
+  | fun merge_tail(new_content :~ List, tail_text :~ List.of(Text)) :~ List:
+      if tail_text.length() <= 1
+      | new_content
+      | let [t, ...] = tail_text
+        let new_t = Text(~srcloc: for fold(new_srcloc = #false) (srcloc in [t.srcloc, ...]):
+                                    merge_srclocs(new_srcloc, srcloc),
+                         ~text: String.append(t.text, ...))
+        new_content.drop_last(1).add(new_t)
+    let (new_content, tail_strs):
+      for fold (new_content :~ List = [], tail_strs :~ List = []) (c in content):        
+        if new_content == [] || tail_strs == []:
+        | values(new_content.add(c),
+                 match c
+                 | t :: Text: [t]
+                 | ~else: [])
+        | match c
+          | t :: Text:
+              values(new_content, tail_strs.add(t))
+          | ~else:
+              values(merge_tail(new_content, tail_strs).add(c),
+                     [])
+    merge_tail(new_content, tail_strs)
+
+
+fun merge_srclocs(new_srcloc, srcloc):
+  match [new_srcloc, srcloc]
+  | [#false, srcloc]: srcloc
+  | [new_srcloc, #false]: new_srcloc
+  | [SrclocRange(Srcloc(src, line, col, offset, _),
+                 Srcloc(_, end_line, end_col, end_offset, _)),
+     SrclocRange(Srcloc(_, line2, col2, offset2, _),
+                 Srcloc(_, end_line2 :~ Int, end_col2, end_offset2, _))]:
+      let new_line = math.min(line, line2)
+      let new_col = math.min(col, col2)
+      let new_offset = math.min(offset, offset2)
+      let new_end_line = math.max(end_line, end_line2)
+      let new_end_col:
+        cond
+        | end_line2 > end_line: end_col2
+        | end_line > end_line2: end_col
+        | ~else: math.max(end_col, end_col2)
+      let new_end_offset = math.max(end_offset, end_offset2)
+      SrclocRange(Srcloc(src, new_line, new_col, new_offset, new_end_offset - new_offset),
+                  Srcloc(src, new_end_line, new_end_col, new_end_offset, #false))
+    

--- a/rhombus-xml-lib/rhombus/xml/private/to_rkt.rhm
+++ b/rhombus-xml-lib/rhombus/xml/private/to_rkt.rhm
@@ -1,0 +1,111 @@
+#lang rhombus/static/and_meta
+import:
+  lib("xml/main.rkt") as rkt
+  "class.rhm" open
+
+export:
+  to_rkt
+  element_to_rkt
+
+fun to_rkt(Document(~prolog: prolog, ~element: e, ~misc: [misc, ...])):
+  rkt.document(prolog_to_rkt(prolog),
+               element_to_rkt(e),
+               PairList[misc_to_rkt(misc), ...])
+  
+fun prolog_to_rkt(Prolog(~pre_misc: [pre_misc, ...],
+                         ~dtd: dtd,
+                         ~post_misc: [post_misc, ...])):
+  rkt.prolog(PairList[misc_to_rkt(pre_misc), ...],
+             match dtd
+             | #false: #false
+             | dtd :: DTD:
+                 rkt.#{document-type}(dtd.name,
+                                      if dtd.public
+                                      | rkt.#{external-dtd/public}(dtd.system,
+                                                                   dtd.public)
+                                      | rkt.#{external-dtd/system}(dtd.system)),
+             PairList[misc_to_rkt(post_misc), ...])
+
+fun element_to_rkt(Element(~srcloc: srcloc,
+                           ~name: name,
+                           ~attributes: [attr, ...],
+                           ~content: [c, ...])):
+  let (start, end) = srcloc_to_rkt(srcloc)
+  rkt.element(start, end,
+              Symbol.from_string(name),
+              PairList[attribute_to_rkt(attr), ...],
+              PairList[content_to_rkt(c), ...])
+
+fun content_to_rkt(c):
+  match c
+  | _ :: Element:      
+      element_to_rkt(c)
+  | _ :: Entity:
+      entity_to_rkt(c)
+  | _ :: Text:
+      text_to_rkt(c)
+  | _ :: Inject:
+      inject_to_rkt(c)
+  | _ :: Comment:
+      comment_to_rkt(c)
+  | _ :: ProcessingInstruction:
+      p_i_to_rkt(c)
+  | ~else:
+      // permissive mode
+      c
+
+fun misc_to_rkt(misc):
+  match misc
+  | _ :: Comment:
+      comment_to_rkt(misc)
+  | _ :: ProcessingInstruction:
+      p_i_to_rkt(misc)
+
+fun text_to_rkt(Text(~srcloc: srcloc, ~text: text, ~write_mode: write_mode)):
+  let (start, end) = srcloc_to_rkt(srcloc)
+  match write_mode
+  | Text.WriteMode.default: 
+      rkt.pcdata(start, end,
+                 text)
+  | Text.WriteMode.cdata: 
+      rkt.cdata(start, end,
+                "<![CDATA[" ++ text ++ "]]>")
+  | Text.WriteMode.entity: 
+      rkt.entity(start, end,
+                 text[0].to_int())
+
+fun inject_to_rkt(Inject(~srcloc: srcloc, ~text: text)):
+  let (start, end) = srcloc_to_rkt(srcloc)
+  rkt.cdata(start, end,
+            text)
+
+fun comment_to_rkt(Comment(~text: text)):
+  rkt.comment(text)
+
+fun p_i_to_rkt(ProcessingInstruction(~srcloc: srcloc, ~target_name: tn, ~instruction: i)):
+  let (start, end) = srcloc_to_rkt(srcloc)
+  rkt.#{p-i}(start, end,
+             Symbol.from_string(tn), i)
+
+fun srcloc_to_rkt(s):
+  match s
+  | #false: values(#'rhombus, #'rhombus)
+  | SrclocRange(Srcloc(_, start_line, start_col, start_offset, _),
+                Srcloc(_, end_line, end_col, end_offset, _)):
+      values(rkt.location(start_line, start_col, start_offset),
+             rkt.location(end_line, end_col, end_offset))
+
+fun attribute_to_rkt(Attribute(~srcloc: srcloc,
+                               ~name: name,
+                               ~value: v)):
+  let (start, end) = srcloc_to_rkt(srcloc)
+  rkt.attribute(start, end,
+                Symbol.from_string(name),
+                v)
+
+fun entity_to_rkt(Entity(~srcloc: srcloc,
+                         ~text: v)):
+  let (start, end) = srcloc_to_rkt(srcloc)
+  rkt.entity(start, end, if v is_a String
+                         | Symbol.from_string(v)
+                         | v)

--- a/rhombus-xml-lib/rhombus/xml/private/to_xstx.rhm
+++ b/rhombus-xml-lib/rhombus/xml/private/to_xstx.rhm
@@ -1,0 +1,66 @@
+#lang rhombus/static/and_meta
+import:
+  "class.rhm" open
+  "swap.rhm" open
+
+export:
+  to_syntax
+
+fun to_syntax(xml :: Document || Element,
+              ~swap_underscore_dash: swap = default_swap,
+              ~source: source = #false):
+  ~name: xml.to_xstx
+  ~who: who
+  element(match xml
+          | d :: Document: d.element
+          | ~else: xml,
+          swap,
+          source)
+
+fun build_name(str :: String, swap):
+  if swap
+  | swap_underscore_dash(str)
+  | str
+
+fun at(v, srcloc, source):
+  match srcloc
+  | SrclocRange(Srcloc(_, line, col, offset, span), _):
+      Syntax.make(v).relocate(Srcloc(source, line, col, offset, span))
+  | ~else:
+      v
+
+fun element(Element(~srcloc: srcloc,
+                    ~name: name,
+                    ~attributes: [attr, ...],
+                    ~content: [c, ...]),
+            swap,
+            source):
+  '$(at(Symbol.from_string(build_name(name, swap)), srcloc, source)):
+     $(attribute(attr, swap, source))
+     ...
+     $(content(c, swap, source))
+     ...'
+
+def amp = Syntax.make_op(#'#{&}) // no srcloc
+
+fun attribute(Attribute(~srcloc: srcloc,
+                        ~name: name,
+                        ~value: value),
+              swap,
+              source):
+  '$(at(Keyword.from_string(build_name(name, swap)), srcloc, source)): $value'
+
+fun content(c, swap, source):
+  match c
+  | _ :: Element:
+      element(c, swap, source)
+  | t :: Text:
+      at(t.text, t.srcloc, source)
+  | e :: Entity:
+      '$amp $(at(if e.text is_a Int
+                 | e.text
+                 | Symbol.from_string(e.text),
+                 e.srcloc,
+                 source))'
+  | ~else:
+      Syntax.inject(c)

--- a/rhombus-xml-lib/xml/main.rhm
+++ b/rhombus-xml-lib/xml/main.rhm
@@ -1,0 +1,3 @@
+#lang rhombus
+import: rhombus/xml
+export: all_from(.xml)

--- a/rhombus-xml/info.rkt
+++ b/rhombus-xml/info.rkt
@@ -1,0 +1,15 @@
+#lang info
+
+(define collection 'multi)
+
+(define deps '("base"
+               "rhombus-xml-lib"))
+(define implies '("rhombus-xml-lib"))
+
+(define build-deps
+  '("rhombus"
+    "rhombus-scribble-lib"))
+
+(define pkg-desc "Rhombus XML library")
+
+(define license '(Apache-2.0 OR MIT))

--- a/rhombus-xml/rhombus/xml/info.rkt
+++ b/rhombus-xml/rhombus/xml/info.rkt
@@ -1,0 +1,3 @@
+#lang info
+
+(define scribblings '(("scribblings/rhombus-xml.scrbl"  (multi-page))))

--- a/rhombus-xml/rhombus/xml/scribblings/class.scrbl
+++ b/rhombus-xml/rhombus/xml/scribblings/class.scrbl
@@ -1,0 +1,210 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      xml)
+
+@title(~tag: "class"){XML Document Representation}
+
+@doc(
+  class xml.Document(~prolog: prolog :: xml.Prolog = xml.Prolog(),
+                     ~element: element :: xml.Element,
+                     ~misc: misc :: List.of(xml.Misc) = [])
+){
+
+ Represents an XML document, which always contains a single element. A
+ document optionally contains a document-type descriptor in the prolog,
+ and it may have miscellaneous comments and processing instructions
+ after the element.
+
+}
+
+@doc(
+  class xml.Element(~name: name :: String,
+                    ~attributes: attributes :: List.of(xml.Attribute) = [],
+                    ~content: content :: List.of(xml.Content) = [],
+                    ~srcloc: srcloc :: maybe(xml.SrclocRange) = #false)
+
+  class xml.Attribute(~name: name :: String,
+                      ~value: value :: String || xml.OtherPermitted,
+                      ~srcloc: srcloc :: maybe(xml.SrclocRange) = #false)
+
+  annot.macro 'xml.Content'
+){
+
+ An @rhombus(xml.Element) represents an XML term of them form
+ @litchar{<}@italic{tag}…@litchar{>}…@litchar{</}@italic{tag}@litchar{>},
+ where @rhombus(name) field corresponds to @italic{tag},
+ @rhombus(attributes) correspond to attributes within
+ @litchar{<}@italic{tag}…@litchar{>}, and @rhombus(content) is the
+ content between @litchar{<}@italic{tag}…@litchar{>} and
+ @litchar{</}@italic{tag}@litchar{>}.
+
+ The @rhombus(xml.Content, ~annot) annotation recognizes allowed content
+ values:
+
+@itemlist(
+
+ @item{@rhombus(xml.Text, ~class): Text, potentially written with
+  @litchar{<![CDATA[}…@litchar{]]>} or @litchar{&}…@litchar{;}, depending
+  on @rhombus(xml.Text.write_mode).}
+
+ @item{@rhombus(xml.Entity, ~class): Entities written with
+  @litchar{&}…@litchar{;}. See @rhombus(xml.Entity, ~class) form
+  information about when @rhombus(xml.read) produces
+  @rhombus(xml.Entity, ~class) objects.}
+
+ @item{@rhombus(xml.Inject, ~class): Text, possibly non-conforming, that
+  is written verbatim by @rhombus(xml.write). The @rhombus(xml.read)
+  function never produces this form of content.}
+
+ @item{@rhombus(xml.Comment, ~class): A comment written with
+  @litchar{<!--}…@litchar{-->}, produced by @rhombus(xml.read) only when
+  @rhombus(xml.current_read_comments) is @rhombus(#true).}
+
+ @item{@rhombus(xml.ProcessingInstruction, ~class): A processing
+  instruction written with @litchar{<?}…@litchar{?>}, produced by
+  @rhombus(xml.read) only when
+  @rhombus(xml.current_read_processing_instructions) is @rhombus(#true).}
+
+ @item{@rhombus(xml.OtherPermitted, ~annot): Any other value, but only
+  when @rhombus(xml.current_permissive) is @rhombus(#true).}
+
+)
+
+}
+
+@doc(
+  class xml.Text(~text: text :: String,
+                 ~srcloc: srcloc :: maybe(xml.SrclocRange) = #false,
+                 ~write_mode: write_mode :: xml.Text.WriteMode = #'default)
+  enum xml.Text.WriteMode:
+    default
+    cdata
+    entity
+){
+
+ Represents text for the content of an @rhombus(xml.Element).
+
+ The @rhombus(write_mode) field is used by @rhombus(xml.write) to select
+ an encoding of the text:
+
+@itemlist(
+
+ @item{@rhombus(#'default): Text is written using predefined entities as
+  necessary to escape special characters, verbatim otherwise.}
+
+ @item{@rhombus(#'cdata): Text is written using
+  @litchar{<![CDATA[}…@litchar{]]>}. A @rhombus(xml.Text, ~class) object
+  can be created with this mode only with @rhombus(text) that does not
+  contain a @litchar{]]>}.}
+
+ @item{@rhombus(#'cdata): Text is written using an integer entity form
+  @litchar{&#}…@litchar{;}. A @rhombus(xml.Text, ~class) object can be
+  created with this mode only with @rhombus(text) that contains a single
+  character.}
+
+)
+
+}
+
+@doc(
+  class xml.Entity(~text: text :: String || xml.EntityInt,
+                   ~srcloc: srcloc :: maybe(xml.SrclocRange) = #false)
+
+  annot.macro 'xml.EntityInt'
+){
+
+ Represents entities written with @litchar{&}…@litchar{;} as the content
+ of an @rhombus(xml.Element).
+
+ Reading with normalization (see @rhombus(xml.current_read_normalize))
+ produces this form only for symbolic entities, and reading always uses
+ @rhombus(xml.Text, ~class) instead for the predefined entities
+ @litchar{&amp;}, @litchar{&lt;}, @litchar{&gt;}, @litchar{&apos;}, and
+ @litchar{&quot;}.
+
+}
+
+@doc(
+  class xml.Inject(~text: text :: String,
+                   ~srcloc: srcloc :: maybe(xml.SrclocRange) = #false)
+
+){
+
+ Represents text as the content of an
+ @rhombus(xml.Element) that is written verbatim by @rhombus(xml.write).
+ The text might not conform to XML syntax. A @rhombus(xml.read) never
+ produces this form of content.
+
+}
+
+@doc(
+  class xml.Comment(~text: text :: String)
+
+  class xml.ProcessingInstruction(
+    ~target_name: target_name :: String,
+    ~instruction: instruction :: String,
+    ~srcloc: srcloc :: maybe(xml.SrclocRange) = #false
+  )
+
+  annot.macro 'xml.Misc'
+){
+
+ The @rhombus(xml.Misc, ~annot) annotation recognizes
+ @rhombus(xml.Comment, ~class) and
+ @rhombus(xml.ProcessingInstruction, ~class) instances. These values can
+ appear with an @rhombus(xml.Element) as content, or they can appear
+ before or after the element of a @rhombus(xml.Document).
+
+ @rhombus(xml.Comment, ~class) represents comment written with
+ @litchar{<!--}…@litchar{-->}. Comments are discarded by
+ @rhombus(xml.read) unless @rhombus(xml.current_read_comments) is
+ @rhombus(#true).
+
+ @rhombus(xml.ProcessingInstruction, ~class) represents a processing
+ instruction written with @litchar{<?}…@litchar{?>}. Comments are discarded by
+ @rhombus(xml.read) unless @rhombus(xml.current_read_processing_instructions) is
+ @rhombus(#true).
+
+}
+
+@doc(
+  annot.macro 'xml.OtherPermitted'
+
+  Parameter.def xml.current_permissive :: Any.to_boolean:
+    #false
+){
+
+ When @rhombus(xml.current_permissive) is set to @rhombus(#true), then
+ @rhombus(xml.Element) content and @rhombus(xml.Attribute) values can be
+ anything. Such values can be converted to and from XML syntax objects,
+ but not read or written as XML.
+
+}
+
+@doc(
+  class xml.Prolog(~pre_misc: post_misc :: List.of(xml.Misc) = [],
+                   ~dtd: dtd :: maybe(xml.DTD) = #false,
+                   ~post_misc: pst_misc :: List.of(xml.Misc) = [])
+
+  class xml.DTD(~name: name :: String,
+                ~system: system :: String,
+                ~public: public :: maybe(String) = #false)
+){
+
+ Represents metadata for an XML document.
+
+}
+
+@doc(
+  class xml.SrclocRange(start :: Srcloc, end :: Srcloc)
+){
+
+ Represents the source location of an element, attribute, or content in
+ an XML document. The @rhombus(start) source location has a
+ @rhombus(Srcloc.span) value to capture the difference between the start
+ and end source locations for an XML component, but @rhombus(end)
+ provides additional information about the ending line and column.
+
+}

--- a/rhombus-xml/rhombus/xml/scribblings/read-write.scrbl
+++ b/rhombus-xml/rhombus/xml/scribblings/read-write.scrbl
@@ -1,0 +1,135 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      xml)
+
+@title(~tag: "read-write"){Reading and Writing XML}
+
+@doc(
+  fun xml.read(
+    ~in: inp :: Port.Input = Port.Input.current(),
+    ~read_post_misc: read_post_misc = #true
+  ) :: xml.Document
+  fun xml.write(
+    doc :: xml.Document || xml.Element,
+    ~out: outp :: Port.Output = Port.Output.current(),
+    ~indentation: indentation :: xml.Indentation = #'none
+  ) :: Void
+){
+
+ Reads an XML document into a @rhombus(xml.Document, ~class) object or
+ writes a @rhombus(xml.Document, ~class) object as an XML document.
+ Supplying a @rhombus(xml.Element, ~class) object to @rhombus(xml.write)
+ is a shortcut for supplying a document that contains just the element.
+
+ The @rhombus(xml.read) function normalizes input when the value of
+ @rhombus(xml.current_read_normalize) is @rhombus(#true). In that case,
+ multiple consecutive @rhombus(xml.Text, ~class) objects in content are
+ collapsed into a single @rhombus(xml.Text, ~class) object that has the
+ @rhombus(xml.Text.WriteMode.default) write mode.
+
+ By default, @rhombus(xml.write) does not add newlines or other
+ whitespace that is not explicitly present in @rhombus(doc). If
+ @rhombus(indentation) is @rhombus(#'scan), then whitespace is added
+ within each element unless any content within the element (potentially
+ nested in other elements) is a @rhombus(xml.PCData, ~class) or
+ @rhombus(xml.Entity, ~class). If @rhombus(indentation) is
+ @rhombus(#'peek), then printing is like @rhombus(#'scan), except that
+ only the immediate content of an element is checked, and nested
+ @rhombus(xml.PCData, ~class) or @rhombus(xml.Entity, ~class) do not
+ disable whitespace.
+
+}
+
+@doc(
+  fun xml.from_string(str :: String) :: xml.Document
+  fun xml.from_bytes(bstr :: Bytes) :: xml.Document
+  fun to_string(
+    doc :: xml.Document || xml.Element,
+    ~indentation: indentation :: Indentation = #'none
+  ) :: String
+  fun xml.to_bytes(
+    doc :: xml.Document || xml.Element,
+    ~indentation: indentation :: Indentation = #'none
+  ) :: Bytes
+){
+
+ Shortcuts for @rhombus(xml.read) and @rhombus(xml.write) to read or
+ write XML documents as strings or byte strings.
+
+}
+
+
+@doc(
+  Parameter.def xml.current_read_normalize :: Any.to_boolean:
+    #true
+){
+
+ Then this parameter's value is @rhombus(#true), @rhombus(xml.read)
+ collapses consecutive text content to a @rhombus(xml.Text, ~class) object.
+
+}
+
+@doc(
+  Parameter.def xml.current_read_comments :: Any.to_boolean:
+    #false
+){
+
+ Unless this parameter's value is @rhombus(#true), @rhombus(xml.read)
+ discards comments.
+
+}
+
+@doc(
+  Parameter.def xml.current_read_processing_instructions :: Any.to_boolean:
+    #true
+){
+
+ When this parameter's value is @rhombus(#false), @rhombus(xml.read)
+ discards processing instructions.
+
+}
+
+@doc(
+  Parameter.def xml.current_read_count_bytes :: Any.to_boolean:
+    #false
+){
+
+ If this parameter's value is @rhombus(#true), @rhombus(xml.read) counts
+ by bytes for columns and offsets in source locations. If the parameter's
+ value if @rhombus(#false), @rhombus(xml.read) counts by characters,
+ instead.
+
+}
+
+@doc(
+  Parameter.def xml.current_read_collapse_whitespace :: Any.to_boolean:
+    #false
+){
+
+ If this parameter's value is @rhombus(#true), @rhombus(xml.read)
+ collapses consecutive whitespace characters to a single space.
+
+}
+
+@doc(
+ Parameter.def xml.current_write_empty_shorthand :: Any.to_boolean:
+   #false
+){
+
+ If this parameter's value is @rhombus(#true), @rhombus(xml.write)
+ prints elements with empty content using @litchar{<}@italic{tag}…@litchar{/>}.
+
+}
+
+@doc(
+  enum xml.Indentation:
+    none
+    peek
+    scan
+){
+
+ Indentation modes for @rhombus(xml.write).
+
+}

--- a/rhombus-xml/rhombus/xml/scribblings/rhombus-xml.scrbl
+++ b/rhombus-xml/rhombus/xml/scribblings/rhombus-xml.scrbl
@@ -1,0 +1,14 @@
+#lang rhombus/scribble/manual
+
+@title{Rhombus XML}
+
+@docmodule(xml)
+
+The @rhombusmodname(xml) library provides functions to read and write in
+XML format.
+
+@local_table_of_contents()
+
+@include_section("class.scrbl")
+@include_section("read-write.scrbl")
+@include_section("xml-syntax-object.scrbl")

--- a/rhombus-xml/rhombus/xml/scribblings/xml-syntax-object.scrbl
+++ b/rhombus-xml/rhombus/xml/scribblings/xml-syntax-object.scrbl
@@ -1,0 +1,214 @@
+#lang rhombus/scribble/manual
+@(import:
+    meta_label:
+      rhombus open
+      xml)
+
+@title(~tag: "xmlstx"){XML Syntax Objects}
+
+An @deftech{XML syntax object} encodes an XML document as a
+human-readable shrubbery form represented by a Rhombus syntax object.
+The @rhombus(xml.from_syntax) function converts an XML syntax object to
+a @rhombus(xml.Document), and @rhombus(xml.to_syntax) goes in the other
+direction. XML syntax objects can be produced from XML directly with
+@rhombus(xml.read_syntax), @rhombus(xml.string_to_syntax), and
+@rhombus(xml.bytes_to_syntax), and they can converted to XML directly
+with @rhombus(xml.write_syntax), @rhombus(xml.syntax_to_string), and
+@rhombus(xml.syntax_to_bytes).
+
+The @rhombus(xml.syntax) for is essentially an alias of @rhombus('')
+(see @rhombus(#%quotes)), but it checks that the result syntax object
+conforms to XML syntax object constraints.
+
+@examples(
+  ~hidden:
+    import xml
+  ~defn:
+    def my_doc:
+      xml.syntax:
+        words:
+          greeting:
+            ~weight: "bold"
+            "hello"
+          parting:
+            ~weight: "normal"
+            ~size: $(to_string(2 * 12))
+            "bye"
+  ~repl:
+    xml.write_syntax(my_doc, ~indentation: #'peek)
+)
+
+XML application vary in whether tag and attribute names contain
+@litchar{-}, @litchar{_}, or both. XML syntax objects use shrubbery
+identifiers and keywords for tags and attributes, so writing names with
+@litchar{-} would normally require escapes. To improve usability for
+contexts where @litchar{-} names are common, conversion from XML syntax
+objects to a @rhombus(xml.Document) or to XML can optionally swap
+@litchar{-} and @litchar{_} characters in tags and attribute names. For
+example, @rhombus(xml.from_syntax) accepts a
+@rhombus(~swap_underscore_dash) argument.
+
+@doc(
+  expr.macro 'xml.syntax:
+                $element'
+
+  grammar element:
+    $id:
+      $attribute
+      ...
+      $content
+      ...
+
+  grammar attribute:
+    $keyword: $value_string
+
+  grammar content:
+    $element
+    $string
+    #,(@rhombus(&, ~datum)) $entity_id_or_int
+    $content ...
+    ($content, ...)
+    [$content, ...]
+    $other
+){
+
+ Returns the same syntax object as @rhombus('#,(@rhombus(element))'),
+ but with the constraint that the result conforms to the grammar of an
+ XML syntax object. Although not shown above in the grammar for
+ @rhombus(element), an escape using @rhombus($) can appear anywhere in
+ the block after @rhombus(xml.syntax), and it works the same as in
+ @rhombus('#,(@rhombus(element))') (see @rhombus(#%quotes)). Conformance
+ is checked on the result after substituting escapes.
+
+ An @rhombus(element) corresponds to an @rhombus(xml.Element, ~class).
+ It always starts with an identifier, and it is followed by a block
+ (possibly empty) for the element's attributes and content. The
+ attributes must appear first, where each attribute starts with a keyword
+ and is followed by a block for the attribute's value, together
+ corresponding to @rhombus(xml.Attribute, ~class).
+
+ Each @rhombus(content) can be one the following:
+
+@itemlist(
+
+ @item{@rhombus(element): Corresponds to a nested @rhombus(xml.Element, ~class).}
+
+ @item{@rhombus(string): Corresponds to @rhombus(xml.Text, ~class).}
+
+ @item{@rhombus(&, ~datum): Corresponds  to @rhombus(xml.Entity, ~class).}
+
+ @item{@rhombus(content ...), @rhombus((content, ...)), or
+  @rhombus([content, ...]): Content can be spliced from multiple
+  @rhombus(content) forms with a group, within parentheses, or within
+  square brackets. Note that this splicing accommodates @litchar("@")
+  forms, as in the example below.}
+
+ @item{@rhombus(other): Any value that is satisfies
+  @rhombus(Content, ~annot) is allowed. For example, a
+  @rhombus(xml.Comment, ~class) value can appear here. Constructing such
+  objects will require a @rhombus($) escape with @rhombus(Syntax.inject).}
+
+)
+
+@examples(
+  ~hidden:
+    import xml
+  ~repl:
+    xml.write_syntax(
+      xml.syntax:
+        a: "hello <name>"
+    )
+    xml.write_syntax(
+      xml.syntax:
+        a: &something
+    )
+    xml.write_syntax(
+      xml.syntax:
+        a: ("b", "c", [["d"], "e"])
+    )
+    xml.write_syntax(
+      xml.syntax:
+        a: @{say this: "hello <name>"}
+    )
+    xml.write_syntax(
+      xml.syntax:
+        a: $(Syntax.inject(xml.Text(~text: "123", ~write_mode: #'cdata)))
+    )
+)
+
+}
+
+@doc(
+  ~nonterminal:
+    element: xml.syntax
+  expr.macro 'xml.doc:
+                $option
+                ...
+                $element'
+
+  grammar option:
+    ~swap_underscore_dash: $swap_expr
+){
+
+ Like @rhombus(xml.syntax), but converts the XML syntax object to a
+ @rhombus(xml.Document) using @rhombus(xml.from_syntax). The value of a
+ @rhombus(swap_expr) option is used as the
+ @rhombus(~swap_underscore_dash) argument to @rhombus(xml.from_syntax).
+
+}
+
+@doc(
+  fun xml.from_syntax(
+    xml_stx :: Syntax,
+    ~swap_underscore_dash: swap :: Any.to_boolean() = #false
+  ) :: xml.Document
+  fun xml.to_syntax(
+    doc :: xml.Document || xml.Element,
+    ~swap_underscore_dash: swap :: Any.to_boolean() = #false
+  ) :: Syntax
+){
+
+ Converts to and from the @tech{XML syntax object} representation.
+
+}
+
+@doc(
+  fun xml.read_syntax(
+    ~in: inp :: Port.Input = Port.Input.current()
+  ) :: Syntax
+  fun xml.write_syntax(
+    xstx :: Syntax,
+    ~swap_underscore_dash: swap = default_swap,
+    ~out: outp :: Port.Output = Port.Output.current(),
+    ~indentation: indentation :: xml.Indentation = #'none
+  ) :: Void  
+){
+
+ Reads or prints XML directly from the @tech{XML syntax object}
+ representation.
+
+}
+
+@doc(
+  fun xml.syntax_to_string(
+    xml_stx :: Syntax,
+    ~swap_underscore_dash: swap :: Any.to_boolean() = #false
+  ) :: String
+  fun xml.string_to_syntax(
+    xml_str :: String,
+    ~swap_underscore_dash: swap :: Any.to_boolean() = #false
+  ) :: Syntax
+  fun xml.syntax_to_bytes(
+    xml_stx :: Syntax,
+    ~swap_underscore_dash: swap :: Any.to_boolean() = #false
+  ) :: Bytes
+  fun xml.bytes_to_syntax(
+    xml_bstr :: Bytes,
+    ~swap_underscore_dash: swap :: Any.to_boolean() = #false
+  ) :: Syntax
+){
+
+ Converts directly between XML in a string or byte string and a
+ @tech{XML syntax object} representation.
+
+}

--- a/rhombus-xml/rhombus/xml/tests/xml.rhm
+++ b/rhombus-xml/rhombus/xml/tests/xml.rhm
@@ -1,0 +1,308 @@
+#lang rhombus
+import:
+  xml
+
+fun no_srcloc(v):
+  match v
+  | g :: Syntax:
+      Syntax.make_group(g.unwrap_all().rest)
+  | xml.Document(~prolog: xml.Prolog(~pre_misc: [pre_misc, ...],
+                                     ~dtd: dtd,
+                                     ~post_misc: [post_misc, ...]),
+                 ~element: e,
+                 ~misc: [misc, ...]):
+      xml.Document(~prolog: xml.Prolog(~pre_misc: [no_srcloc(pre_misc), ...],
+                                       ~post_misc: [no_srcloc(post_misc), ...]),
+                   ~element: no_srcloc(e),
+                   ~misc: [no_srcloc(misc), ...])
+  | xml.Element(~srcloc: _,
+                ~name: name,
+                ~attributes: [attr, ...],
+                ~content: [c, ...]):
+      xml.Element(~name: name,
+                  ~attributes: [no_srcloc(attr), ...],
+                  ~content: [no_srcloc(c), ...])
+  | t :: xml.Text:
+      t with (srcloc = #false)
+  | e :: xml.Entity:
+      e with (srcloc = #false)
+  | v :: xml.Inject:
+      v with (srcloc = #false)
+  | a :: xml.Attribute:
+      a with (srcloc = #false)
+  | pi :: xml.ProcessingInstruction:
+      pi with (srcloc = #false)
+  | cmt :: xml.Comment:
+      cmt
+
+def hi = xml.Text(~text: "hi")
+check hi.text ~is "hi"
+check hi ~is_a xml.Content
+
+def e = xml.Element(~name: "demo",
+                    ~content: [hi])
+check e ~is_a xml.Content
+check xml.from_syntax(xml.to_syntax(e)).element ~is e
+
+check xml.to_syntax(e) ~matches 'demo: "hi"'
+check xml.from_syntax(no_srcloc('demo: "hi"')).element ~is e
+
+def d = xml.Document(~element: e)
+check d.element ~is e
+check xml.from_syntax(xml.to_syntax(d)) ~is d
+
+check:
+  xml.syntax:
+    greeting:
+      "hi"
+  ~matches 'greeting: "hi"'
+
+check:
+  no_srcloc(xml.doc:
+              demo:
+                "hi")
+  ~is d
+
+check:
+  xml.syntax:
+    greeting:
+      $("hi" ++ " " ++ "there")
+  ~matches 'greeting: "hi there"'
+
+check:
+  no_srcloc(xml.doc:
+              demo_tag:
+                ~#{attr-name}: "yes"
+                "hi")
+  ~is xml.Document(~element:
+                     xml.Element(~name: "demo_tag",
+                                 ~attributes: [xml.Attribute(~name: "attr-name",
+                                                             ~value: "yes")],
+                                 ~content: [xml.Text(~text: "hi")]))
+
+check:
+  no_srcloc(xml.doc:
+              ~swap_underscore_dash: #true
+              demo_tag:
+                ~#{attr-name}: "yes"
+                "hi")
+  ~is xml.Document(~element:
+                     xml.Element(~name: "demo-tag",
+                                 ~attributes: [xml.Attribute(~name: "attr_name",
+                                                             ~value: "yes")],
+                                 ~content: [xml.Text(~text: "hi")]))
+
+block:
+  def ent = xml.Entity(~text: "amp")
+  check ent.text ~is "amp"
+  check ent ~is_a xml.Content
+
+  check: xml.to_syntax(xml.Element(~name: "demo", ~content: [ent]))
+         ~matches 'demo: &amp'
+  check: xml.from_syntax(no_srcloc('demo: &amp')).element
+         ~is xml.Element(~name: "demo", ~content: [ent])
+
+block:
+  def ent = xml.Entity(~text: 1234)
+  check ent.text ~is 1234
+  check ent ~is_a xml.Content
+
+  check: xml.to_syntax(xml.Element(~name: "demo", ~content: [ent]))
+         ~matches 'demo: &1234'
+  check: xml.from_syntax(no_srcloc('demo: &1234')).element
+         ~is xml.Element(~name: "demo", ~content: [ent])
+
+def cdata = xml.Text(~text: "cowbell", ~write_mode: #'cdata)
+check cdata.text ~is "cowbell"
+
+check: xml.Text(~text: "broken]]>", ~write_mode: #'cdata)
+       ~throws "cannot write as CData"
+check: xml.Text(~text: "br", ~write_mode: #'entity)
+       ~throws "cannot write as an entity"
+
+def verb = xml.Inject(~text: "broken]]>")
+check verb.text ~is "broken]]>"
+
+def cmt = xml.Comment(~text: "more cowbell")
+check cmt.text ~is "more cowbell"
+
+def pi = xml.ProcessingInstruction(~target_name: "bell",
+                                   ~instruction: "ring")
+check pi.target_name ~is "bell"
+check pi.instruction ~is "ring"
+
+block:
+  let doc = xml.Document(~element:
+                           xml.Element(~name: "doc",
+                                       ~content:
+                                         [cdata, verb, cmt]))
+  check: xml.from_syntax(xml.to_syntax(doc))
+         ~is xml.Document(~element:
+                           xml.Element(~name: "doc",
+                                       ~content:
+                                         [cdata with (write_mode = xml.Text.WriteMode.default), verb, cmt]))
+
+check:
+  xml.to_string(xml.Document(~element:
+                               xml.Element(~name: "doc",
+                                           ~content:
+                                             [cdata,
+                                              xml.Text(~text: "moo"),
+                                              cmt,
+                                              pi,
+                                              verb])))
+  ~matches "<doc><![CDATA[cowbell]]>moo<!--more cowbell--><?bell ring?>broken]]></doc>"
+
+check: xml.write_syntax('demo:
+                           "hello" &lt
+                           "world" &gt')
+       ~prints "<demo>hello&lt;world&gt;</demo>"
+check: xml.syntax_to_string('demo:
+                               "hello" &lt
+                               "world" &gt')
+       ~is "<demo>hello&lt;world&gt;</demo>"
+check: parameterize { xml.current_read_normalize: #false }:
+         xml.string_to_syntax("<demo>hello&lt;world&gt;</demo>")
+       ~matches 'demo:
+                   "hello"
+                   "<"
+                   "world"
+                   ">"'
+check: xml.string_to_syntax("<demo>hello&lt;world&gt;</demo>")
+       ~matches 'demo:
+                   "hello<world>"'
+check: xml.syntax_to_string(xml.string_to_syntax("<demo>hello&lt;world&gt;</demo>"))
+       ~is "<demo>hello&lt;world&gt;</demo>"
+check: xml.syntax_to_bytes(xml.bytes_to_syntax(#"<demo>hello&lt;world&gt;</demo>"))
+       ~is_now #"<demo>hello&lt;world&gt;</demo>"
+check: xml.to_bytes(xml.from_bytes(#"<demo>hello&lt;world&gt;</demo>"))
+       ~is_now #"<demo>hello&lt;world&gt;</demo>"
+
+check:
+  xml.syntax_to_string(
+    xml.syntax:
+      demo:
+        $(Syntax.inject(xml.Comment(~text: "get ready")))
+        "hello<world>"
+        $(Syntax.inject(xml.Inject(~text: "<>")))
+  )
+  ~is "<demo><!--get ready-->hello&lt;world&gt;<></demo>"
+
+check:
+  parameterize { xml.current_read_normalize: #false }:
+    no_srcloc(xml.from_string("<doc><![CDATA[cowbell]]>moo<!--more cowbell--></doc>"))
+  ~is xml.Document(~element:
+                     xml.Element(~name: "doc",
+                                 ~content:
+                                   [cdata,
+                                    xml.Text(~text: "moo")]))
+check:
+  no_srcloc(xml.from_string("<doc><![CDATA[cowbell]]>moo<!--more cowbell--></doc>"))
+  ~is xml.Document(~element:
+                     xml.Element(~name: "doc",
+                                 ~content:
+                                   [xml.Text(~text: "cowbellmoo")]))
+
+check:
+  no_srcloc(xml.from_string("<doc><![CDATA[cowbell]]>moo<!--more cowbell--><?bell ring?></doc>"))
+  ~is xml.Document(~element:
+                     xml.Element(~name: "doc",
+                                 ~content:
+                                   [xml.Text(~text: "cowbellmoo"),
+                                    pi]))
+
+check:
+  parameterize { xml.current_read_comments: #true }:
+    no_srcloc(xml.from_string("<doc><![CDATA[cowbell]]>moo<!--more cowbell--><?bell ring?></doc>"))
+  ~is xml.Document(~element:
+                     xml.Element(~name: "doc",
+                                 ~content:
+                                   [xml.Text(~text: "cowbellmoo"),
+                                    cmt,
+                                    pi]))
+
+check:
+  parameterize { xml.current_read_normalize: #false,
+                 xml.current_read_processing_instructions: #true }:
+    no_srcloc(xml.from_string("<doc><![CDATA[cowbell]]>moo<!--more cowbell--><?bell ring?></doc>"))
+  ~is xml.Document(~element:
+                     xml.Element(~name: "doc",
+                                 ~content:
+                                   [cdata,
+                                    xml.Text(~text: "moo"),
+                                    pi]))
+
+check: xml.current_permissive() ~is #false
+check: #'oops is_a xml.OtherPermitted ~is #false
+check: xml.Element(~name: "doc", ~content: [#'oops])
+       ~throws values(error.annot_msg())
+check:
+  parameterize { xml.current_permissive: #true }:
+    #'oops is_a xml.OtherPermitted
+  ~is #true
+
+check:
+  parameterize { xml.current_permissive: #true }:
+    xml.Element(~name: "doc", ~content: [#'oops])
+  ~is_a xml.Element
+
+check:
+  xml.to_syntax(parameterize { xml.current_permissive: #true }:             
+                  xml.Element(~name: "doc", ~content: [#'oops]))
+  ~matches 'doc: oops'
+
+check:
+  no_srcloc(xml.from_string("<a>&#48;</a>"))
+  ~is xml.Document(~element: xml.Element(~name: "a",
+                                         ~content:
+                                           [xml.Text(~text: "0",
+                                                     ~write_mode: #'entity)]))
+check:
+  xml.to_string(xml.from_string("<a>&#48;</a>"))
+  ~is "<a>&#48;</a>"
+
+check:
+  no_srcloc(xml.from_string("<a>&other;</a>"))
+  ~is xml.Document(~element: xml.Element(~name: "a",
+                                         ~content:
+                                           [xml.Entity(~text: "other")]))
+check:
+  xml.to_string(xml.from_string("<a>&other;</a>"))
+  ~is "<a>&other;</a>"
+
+check:
+  no_srcloc(xml.from_string("<a>a<!-- c -->b</a>"))
+  ~is xml.Document(~element: xml.Element(~name: "a",
+                                         ~content:
+                                           [xml.Text(~text: "ab")]))
+
+check:
+  match xml.string_to_syntax("<a>\n <b/>\n</a>")
+  | '$a:
+       $_
+       $b
+       $_':
+      [a.srcloc(), b.srcloc()]
+  ~is [Srcloc(#false, 1, 0, 1, 14), Srcloc(#false, 2, 1, 6, 4)]
+
+check:
+  match xml.string_to_syntax("<a>1&amp;2</a>")
+  | '$_:
+       $b':
+      b.srcloc()
+  ~is Srcloc(#false, 1, 3, 4, 7)
+
+check:
+  xml.to_string(
+    xml.doc:
+      a:
+        "a"
+        (["x", "y", "z"],
+         t:
+           "hello")
+        () [] (([[]]))
+        "more"
+        @{(pssst... @($"hey"))}
+  )
+  ~is "<a>axyz<t>hello</t>more(pssst... hey)</a>"
+


### PR DESCRIPTION
Includes a "XML syntax object" representation, which is analogous the to the Racket layer's "xexprs". The `xml.syntax` form is essentially an alias of `''`, but it checks that the result syntax object (after escapes are replaced) conforms to constraints for an XML syntax object.

```
    def my_doc:
      xml.syntax:
        words:
          greeting:
            ~weight: "bold"
            "hello"
          parting:
            ~weight: "normal"
            ~size: $(to_string(2 * 12))
            "bye"

  > my_doc
  'words:
     greeting:
       ~weight: "bold"
       "hello"
     parting:
       ~weight: "normal"
       ~size: "24"
       "bye"'

    > xml.write_syntax(my_doc, ~indentation: #'peek)
    <words>
      <greeting weight="bold">hello</greeting>
      <parting weight="normal" size="24">bye</parting>
    </words>
```

See also #643, which was motivated in part by the use of keywords for attributes in this PR's XML syntax objects. But this `xml` library also supports swapping `_` and `-` on conversion to/from XML syntax objects and XML or `xml.Document`, which seems likely useful in applications that tend to use `-` and not `_`.

The non-syntax-object representation mostly follows the Racket library, except that `cdata` is split into `xml.CData` and `xml.Verbatim`, where `xml.CData` adds `<![CDATA[` and `]]>` when rendering to XML, while `Verbatim` lets you subvert the encoding and write raw text (which I think is a common use of `cdata` in the Racket `xml` library).

"Permissive" mode for XML syntax objects is supported in the same way as in xexprs. I'm not sure that's a good idea, but I find several places where permissive mode is used with Racket `xml`, so I took that as a sign that it's useful.

Currently, this `xml` library doesn't try to support XHTML or other legacy features of the Racket `xml` library.