### PR TITLE
add `as` support in `only`

### DIFF
--- a/rhombus/rhombus/scribblings/reference/import.scrbl
+++ b/rhombus/rhombus/scribblings/reference/import.scrbl
@@ -341,14 +341,20 @@
 }
 
 @doc(
-  impo.modifier 'only $id'
+  ~nonterminal:
+    id: block
+    id_or_rename_as: expose ~impo
+  impo.modifier 'only $id_or_rename_as'
   impo.modifier 'only:
-                   $id ...
+                   $id_or_rename_as
                    ...'
 ){
 
  Modifies an @rhombus(import) clause so that only the listed
  @rhombus(id)s are imported.
+
+ Similar to @rhombus(expose, ~impo), if @rhombus(as, ~impo) is used,
+ the @rhombus(id) is renamed in addition.
 
 }
 

--- a/rhombus/rhombus/tests/import.rhm
+++ b/rhombus/rhombus/tests/import.rhm
@@ -136,18 +136,6 @@ check:
   beta
   ~throws "beta: undefined"
 
-// This test assumes too much about the implementation of `Pair`
-#//
-check:
-  import:
-    lib("racket/base.rkt") as r:
-      rename:
-        cons as make_pair
-      only:
-        make_pair
-  r.make_pair
-  ~is Pair.cons
-
 check:
   import:
     rhombus/meta.expr
@@ -157,6 +145,16 @@ check:
         cons as make_pair
       only:
         make_pair
+  p.make_pair
+  ~is Pair.cons
+
+check:
+  import:
+    rhombus/meta.expr
+    rhombus.Pair as p:
+      only_space expr
+      only:
+        cons as make_pair
   p.make_pair
   ~is Pair.cons
 


### PR DESCRIPTION
This extends the change to `expose` (in 67856a6) to `only`.  Renaming support can be found in Racket’s `only-in`, and can be occasionally useful in Rhombus when used in combination with `open` (to avoid “namespace dumping”).