### PR TITLE
disallow 3-D syntax except as initiated via `Syntax.inject`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/injected.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/injected.rkt
@@ -1,0 +1,14 @@
+#lang racket/base
+
+(provide (struct-out injected)
+         uninject)
+
+(struct injected (e)
+  #:mutable ; so content is not converted to syntax
+  #:prefab)
+
+(define (uninject stx)
+  (define e (syntax-e stx))
+  (if (injected? e)
+      (datum->syntax stx (injected-e e) stx stx)
+      stx))

--- a/rhombus-lib/rhombus/private/amalgam/rx.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx.rhm
@@ -127,7 +127,12 @@ meta:
         let stx_str = to_string(stx)
         let rkt_rx = #{#rx""}
         let rkt_full_rx = if is_full | #{#rx"^$"}  | rkt_rx
-        '_RX($rkt_rx, $rkt_full_rx, 0, {}, #false, $stx_str)'
+        '_RX(#%literal $(Syntax.inject(rkt_rx)),
+             #%literal $(Syntax.inject(rkt_full_rx)),
+             0,
+             #%literal $(Syntax.inject({})),
+             #false,
+             $stx_str)'
     | ~else:
         let '[$ast, [$var, ...]]' = rx_meta.unpack(pat)
         let stx_str = to_string(stx)
@@ -143,7 +148,12 @@ meta:
             | compile('sequence(bof, $ast, eof)', vars, num_captures, stx)
             | rkt_rx
           // generate static regexp
-          '_RX($rkt_rx, $rkt_full_rx, $num_captures, $vars, $has_backref, $stx_str)'
+          '_RX(#%literal $(Syntax.inject(rkt_rx)),
+               #%literal $(Syntax.inject(rkt_full_rx)),
+               $num_captures,
+               #%literal $(Syntax.inject(vars)),
+               $has_backref,
+               $stx_str)'
 
 expr.macro
 | '«rx ''»':
@@ -505,7 +515,7 @@ meta:
     | #false:
         let rkt_rx = if is_full | #{#rx"^$"} | #{#rx""}
         bind_meta.pack('(rx_infoer,
-                         [$rkt_rx,
+                         [$(Syntax.inject(rkt_rx, 'here')),
                           [],
                           $("matching(" ++ stx.to_source_string() ++ ")")])')
     | ~else:
@@ -522,7 +532,7 @@ meta:
             keep_when var is_a Identifier
             [var, i]
         bind_meta.pack('(rx_infoer,
-                         [$rkt_rx,
+                         [$(Syntax.inject(rkt_rx, 'here')),
                           [[$var, $index], ...],
                           $("matching(" ++ stx.to_source_string() ++ ")")])')
 

--- a/rhombus-lib/rhombus/private/amalgam/rx_charset.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx_charset.rhm
@@ -22,7 +22,7 @@ space.enforest rx_charset:
       pack
       unpack
     fun pack(charset :: Charset, stx) :~ Syntax:
-      do_pack(Array(charset.raw_int_ranges())).relocate_span([stx])
+      do_pack(Syntax.inject(Array(charset.raw_int_ranges()), 'here')).relocate_span([stx])
     fun unpack(stx :: Syntax) :~ Charset:
       Charset.from_raw_int_ranges(Array.get(do_unpack(stx, #false).unwrap_all(), 0))
 

--- a/rhombus/rhombus/scribblings/reference/stxobj.scrbl
+++ b/rhombus/rhombus/scribblings/reference/stxobj.scrbl
@@ -79,7 +79,7 @@ class's name.
  A @rhombus($) as a @rhombus(term, ~var) unquotes (i.e., escapes) the expression
  afterward; the value of that expression replaces the @rhombus($) term and expression. The value
  is normally a syntax object, but except for lists, other kinds of values are coerced
- to a syntax object. Nested @quotes forms are allowed around
+ to a syntax object via @rhombus(Syntax.make). Nested @quotes forms are allowed around
  @rhombus($) and do @emph{not} change whether the @rhombus($) escapes.
 
 @examples(
@@ -870,6 +870,21 @@ class's name.
  as @rhombus(ctx_stx) if it is a syntax object, an empty set of scopes
  otherwise.
 
+ Lists and other @tech{listable} values in @rhombus(term) are converted
+ to compound shrubbery forms, such as a parenthesized term or a sequence
+ of alternatives. Each listable value must start with a symbol that
+ selects the compound form, such as @rhombus(#'parens) or
+ @rhombus(#'alts).
+
+ Alone or within nested listables, only certain kinds of atomic values
+ can be converted to syntax: numbers, @tech{strings}, @tech{byte
+  strings}, @tech{symbols}, @tech{keywords}, @tech{paths},
+ @rhombus(Srcloc, ~annot) values, @rhombus(#true), @rhombus(#false), and
+ @rhombus(#void). Mutable strings and byte strings are implicitly coerced
+ to immutable variants. Other kinds of values can be converted to syntax
+ using @rhombus(Syntax.inject), but with limitations on the use of the
+ resulting syntax object.
+
 @examples(
   Syntax.make(1.0)
   Syntax.make([#'parens, '1.0', '2', '"c"'])
@@ -968,6 +983,31 @@ class's name.
   Syntax.make_temp_id("hello")
   Syntax.make_temp_id("hello", ~keep_name: #true)
 )
+
+}
+
+
+@doc(
+  fun Syntax.inject(v :: Any,
+                    ctx_stx :: maybe(Term) = #false)
+    :: Term
+){
+
+ Similar to @rhombus(Syntax.make), and the result is the same as from
+ @rhombus(Syntax.make) is @rhombus(v) is an allowed atomic value. Other
+ values for @rhombus(v) are also treated as ``atomic'' value, even if
+ @rhombus(v) a @tech{listable} value.
+
+ The value @rhombus(v) can be recovered via @rhombus(Syntax.unwrap), but
+ the syntax object produced by @rhombus(Syntax.inject) is not necessarily
+ suitable for use as an expression or as a literal quoted term to be
+ included in an expression, because it cannot necessarily be serialized
+ in a compiled form. Phase-crossing via syntax quoting can also fail,
+ because some values (including @rhombus(List, ~annot) values) have
+ distinct run-time and compile-time representations. The intent of
+ @rhombus(Syntax.inject) is to support arbitrary values in a syntax
+ object that is constructed and used only within a phase, and especially
+ at run time.
 
 }
 

--- a/rhombus/rhombus/tests/quasiquote.rhm
+++ b/rhombus/rhombus/tests/quasiquote.rhm
@@ -254,6 +254,47 @@ check:
 check:
   '#void'.unwrap() ~is #void
 
+check:
+  '$error'
+  ~throws "cannot coerce value to syntax"
+
+block:
+  class Posn(x, y)
+  check: '$(Posn(1, 2))'
+         ~throws "cannot coerce value to syntax"
+  check: Syntax.make(Posn(1, 2))
+         ~throws "cannot coerce value to term syntax"
+  check: Syntax.inject(Posn(1, 2)).unwrap()
+         ~is Posn(1, 2)
+  check: Syntax.inject([1, 2]).unwrap()
+         ~is [1, 2]
+  check: Syntax.inject([]).unwrap()
+         ~is []
+  check: Syntax.make(Pair(1, 2))
+         ~throws "cannot coerce value to term syntax"
+  check: Syntax.make(PairList.empty)
+         ~throws "cannot coerce value to term syntax"
+  check: Syntax.inject(Pair(1, 1)).unwrap()
+         ~is Pair(1, 1)
+  check: Syntax.inject(PairList.empty).unwrap()
+         ~is PairList.empty
+  check: Syntax.inject({#'a: #'A, #'b: #'B}).unwrap()
+         ~is {#'a: #'A, #'b: #'B}
+  check: Syntax.inject(Array(1, 2, 3, #'z)).unwrap()
+         ~is_now Array(1, 2, 3, #'z)
+  check: Syntax.inject(Box(#'x)).unwrap()
+         ~is_now Box(#'x)
+  class PrePosn(x, y):
+    prefab
+  check: Syntax.inject(PrePosn(#'x, #'y)).unwrap()
+         ~is PrePosn(#'x, #'y)
+  check: 'a: b [$(Syntax.inject(Pair(1, 2)))]'.unwrap_all()
+         ~is [#'group, #'a, [#'block, [#'group, #'b, [#'brackets, [#'group, Pair(1, 2)]]]]]
+  check: 'a
+          $(Syntax.inject(Pair(1, 2)))
+          b'.unwrap_all()
+         ~is [#'multi, [#'group, #'a], [#'group, Pair(1, 2)], [#'group, #'b]]
+
 // prevent construction of ill-formed groups
 block:
   def a = '| 12 | 13'

--- a/rhombus/rhombus/tests/syntax-object.rhm
+++ b/rhombus/rhombus/tests/syntax-object.rhm
@@ -71,7 +71,7 @@ block:
 
 check:
   Syntax.make(1) ~matches '1'
-  Syntax.make([1, 2]) ~throws "invalid as a shrubbery term"
+  Syntax.make([1, 2]) ~throws "cannot coerce value to term syntax"
   Syntax.make([#'parens, [#'group, 1, "a", #'z]]) ~matches '(1 "a" z)'
   Syntax.make([#'parens,
                [#'group, 1],
@@ -85,9 +85,9 @@ check:
 check:
   Syntax.make_group([1, 2]) ~matches '1 2'
   Syntax.make_group(['block', ['block', '1 2', '3']]) ~matches 'block: 1 2; 3'
-  Syntax.make_group([': a', ': b']) ~throws "invalid as a shrubbery non-tail term representation"
-  Syntax.make_group(['any', ['block', '1 2', '3'], 'more']) ~throws "invalid as a shrubbery non-tail term"
-  Syntax.make_group(['any', ['alts', ['block', '1 2', '3']], 'more']) ~throws "invalid as a shrubbery non-tail term"
+  Syntax.make_group([': a', ': b']) ~throws "cannot coerce value to non-tail term syntax"
+  Syntax.make_group(['any', ['block', '1 2', '3'], 'more']) ~throws "cannot coerce value to non-tail term syntax"
+  Syntax.make_group(['any', ['alts', ['block', '1 2', '3']], 'more']) ~throws "cannot coerce value to non-tail term syntax"
   Syntax.make_group([': a', '| b']) ~matches ':« a » | b'
   Syntax.make_group([['block', 'a'], ['alts', ['block', '1 2', '3']]]) ~matches ':« a » | 1 2 ; 3'
 

--- a/shrubbery-render-lib/shrubbery/render/define.rhm
+++ b/shrubbery-render-lib/shrubbery/render/define.rhm
@@ -120,12 +120,12 @@ meta:
     | ~else: literal_term(stxs)
 
 fun sequence_cons_syntax(a, d, context):
-  let a_r: Syntax.relocate(Syntax.make(a), context)
+  let a_r: Syntax.relocate(Syntax.inject(a), context)
   match d
   | '$e ...': '$a_r $e ...'
 
 fun relocate_expansion(e, context):
-  Syntax.relocate(Syntax.make(e), context)
+  Syntax.relocate(Syntax.inject(e), context)
 
 // ----------------------------------------
 


### PR DESCRIPTION
In a syntax `$` escape or other explicit and implicit uses of `Syntax.make()`, allow only numbers, booleans, strings, byte strings, symbols, keywords, path, srclocs, and `#void`. "3-D" syntax objects can still be constructed, but only by injecting some other kind of value into the syntax-object world with `Syntax.inject`.

The intent is to prevent acciental construction of 3-D syntax, which can be confusing and lead to delayed errors. For example `'$gen()'` would create a syntax object containing the closure `gen` followed by `()`, while `$(gen())` is more likely the intent. Without early detection of 3-D syntax, `'$gen()'` may seem to work until marshaling a compiled use fails.

Meanwhile, when intended, 3-D syntax objects can be useful, particularly since syntax objects in Rhombus take over the role that plain S-expression sometimes serve for Racket. As a concrete example, the `rhombusblock` form in Rhombus Scribble supports `#,` escapes that generate Scribble elements, and those element objects need to sit inside a syntax object that otherwise preserves the source of an argument to `rhombusblock`.

The `Syntax.inject` function is the same as `Syntax.make` on values that `Syntax.make` would accept and treat as syntax atoms. Lists and listables other than pair lists are injected as themselves by `Syntax.inject`, not traversed to find atoms. Pairs and pair lists are simply disallowed.