### PR TITLE
optional binding of an escape identifier by `try`

### DIFF
--- a/rhombus/rhombus/scribblings/guide/conditional.scrbl
+++ b/rhombus/rhombus/scribblings/guide/conditional.scrbl
@@ -185,3 +185,8 @@ we can use it to check that two lists are equal:
     lists_equal([1, 2, 3], [1])
     lists_equal([1, 2, 3], [1, 2, 10000])
 )
+
+A @rhombus(guard) form only escapes from its immediately enclosing
+block. Non-local escapes can be implemented with @rhombus(try), either
+by throwing and catching an exception or calling an escape function
+bound by @rhombus(try).

--- a/rhombus/rhombus/scribblings/reference/exn.scrbl
+++ b/rhombus/rhombus/scribblings/reference/exn.scrbl
@@ -6,12 +6,19 @@
 @title{Exceptions}
 
 @doc(
-  expr.macro 'try:
+  ~nonterminal:
+    escape_id: block id
+
+  expr.macro 'try $maybe_escape:
                 $maybe_initially
                 $body
                 ...
                 $maybe_catch
                 $maybe_finally'
+
+  grammar maybe_escape:
+    ~escape_as $escape_id
+    #,(epsilon)
 
   grammar maybe_initially:
     ~initially: $body; ...
@@ -47,11 +54,6 @@
  @rhombus(~catch) clause matches, the exception is re-thrown. Breaks are
  disabled while attempting to match a @rhombus(~catch) clause or
  evaluating its body.
-
- The last @rhombus(body) form of @rhombus(try) are not in tail position
- is any of @rhombus(~initially), @rhombus(~catch), or @rhombus(~finally)
- is present. If none are present, the @rhombus(try) form is the same as
- @rhombus(begin).
 
 @examples(
   ~repl:
@@ -92,6 +94,26 @@
       println("body")
       "again"
 )
+
+ If @rhombus(~escape_as escape_id) is before the block after
+ @rhombus(try), then @rhombus(escape_id) is bound for use in the body of
+ the @rhombus(try) form as an @deftech{escape continuation} function that
+ jumps out of the @rhombus(try) form. The arguments provided to the
+ function are returned as the results of the @rhombus(try) form. Calling
+ @rhombus(escape_id) is an error when outside the dynamic extent of
+ evaluating the @rhombus(try) form.
+
+@examples(
+  ~repl:
+    try ~escape_as escape:
+      1 + escape(0) + 2
+      println("doesn't get here")
+)
+
+ The last @rhombus(body) form of @rhombus(try) is not in tail position
+ if any of @rhombus(~escape_as), @rhombus(~initially), @rhombus(~catch), or @rhombus(~finally)
+ is present. If none are present, the @rhombus(try) form is the same as
+ @rhombus(block).
 
 }
 

--- a/rhombus/rhombus/tests/exn.rhm
+++ b/rhombus/rhombus/tests/exn.rhm
@@ -1,5 +1,20 @@
 #lang rhombus
 
+check:
+  let mutable x = 1
+  let v:
+    try ~escape_as esc:
+      1 + esc("done") + 2
+      x := 2
+  values(v, x)
+  ~is values("done", 1)
+
+check:
+  try ~escape_as esc:
+    esc(1, 2, 3)
+    "done"
+  ~is values(1, 2, 3)
+
 block:
   use_static
   def v:


### PR DESCRIPTION
This PR adds `let/ec`-like support to `try`, where an identifier written after `try` and before the body block is bound as an escape continuation. In other words, `try escape: <body>` is like `(let/ec escape <body>)` in Racket. An escape identifier can be provided while also using forms like `~finally` or `~catch` in the `try` body.

The idea behind overloading `try` this way is to continue bundling control-flow capabilities into `try`, instead of having different control forms like `let/ec`, `with-handlers`, and `dynamic-wind`.