### PR TITLE
rename `Map.add` to `Map.set`

### DIFF
--- a/rhombus/rhombus/scribblings/reference/appendable.scrbl
+++ b/rhombus/rhombus/scribblings/reference/appendable.scrbl
@@ -48,7 +48,8 @@ instances of classes that implement @rhombus(Appendable, ~class).
  @rhombus(set_expr ++ {elem_expr}) is recognized by the compiler and
  turned into an efficient functional update of the map or set produced
  by @rhombus(map_expr) or @rhombus(set_expr), as opposed to creating
- an intermediate map or set.
+ an intermediate map or set. In other words, they are like direct
+ invocations of @rhombus(Map.set) or @rhombus(Set.add).
 
  When @rhombus(v1) is an instance of a class that implements
  @rhombus(Appendable, ~class), then @rhombus(v2) must be an instance of

--- a/rhombus/rhombus/scribblings/reference/map.scrbl
+++ b/rhombus/rhombus/scribblings/reference/map.scrbl
@@ -519,11 +519,26 @@ in an unspecified order.
 
 
 @doc(
+  method (mp :: Map).set(key :: Any, val :: Any) :: Map
+){
+
+ Returns a map like @rhombus(mp), but with a mapping for @rhombus(key)
+ to @rhombus(val), like @rhombus(mp ++ {key: val}).
+
+@examples(
+  Map.set({"a": 1, "b": 2}, "a", 3)
+  Map.set({"a": 1, "b": 2}, "c", 3)
+)
+
+}
+
+
+@doc(
   method (mp :: Map).remove(key :: Any) :: Map
 ){
 
  Returns a map like @rhombus(mp), but without a mapping for
- @rhombus(key) is @rhombus(mp) has one.
+ @rhombus(key) if @rhombus(mp) has one.
 
 @examples(
   Map.remove({"a": 1, "b": 2}, "a")

--- a/rhombus/rhombus/scribblings/reference/set.scrbl
+++ b/rhombus/rhombus/scribblings/reference/set.scrbl
@@ -347,8 +347,8 @@ it supplies its elements in an unspecified order.
   method (st :: Set).add(val :: Any) :: Set
 ){
 
- Returns a set like @rhombus(st) but with @rhombus(val) added if it is
- not already present.
+ Returns a set like @rhombus(st), but with @rhombus(val) added if it is
+ not already present, like @rhombus(st ++ {val}).
 
 @examples(
   {1, 2, 3}.add(4)
@@ -361,7 +361,7 @@ it supplies its elements in an unspecified order.
   method (st :: Set).remove(val :: Any) :: Set
 ){
 
- Returns a set like @rhombus(st) but without @rhombus(val), if it is
+ Returns a set like @rhombus(st), but without @rhombus(val) if it is
  present.
 
 @examples(

--- a/rhombus/rhombus/tests/map.rhm
+++ b/rhombus/rhombus/tests/map.rhm
@@ -13,10 +13,10 @@ block:
     Map.get(mp, k, [default])  ~method ReadableMap
     Map.has_key(mp, k) ~method ReadableMap
     Map.contains(mp, k) ~method ReadableMap
-    Map.add(mp, k, v)  ~method
     Map.copy(mp) ~method ReadableMap
     Map.snapshot(mp) ~method ReadableMap
     Map.append(mp0, mp, ...) ~method
+    Map.set(mp, k, v) ~method
     Map.remove(mp, k) ~method
     MutableMap.set(mp, k, val) ~method
     MutableMap.remove(mp, k) ~method
@@ -67,9 +67,9 @@ block:
     {"a": 1, "b": 2}.contains(1) ~is #false
     {"a": 1, "b": 2}.has_key(1) ~is #false
   check:
-    {"a": 1, "b": 2}.add("c", 3) ~is {"a": 1, "b": 2, "c": 3}
-    {"a": 1, "b": 2}.add("a", 3) ~is {"a": 3, "b": 2}
-    Map.add({"a": 1, "b": 2}, "c", 3) ~is {"a": 1, "b": 2, "c": 3}
+    {"a": 1, "b": 2}.set("c", 3) ~is {"a": 1, "b": 2, "c": 3}
+    {"a": 1, "b": 2}.set("a", 3) ~is {"a": 3, "b": 2}
+    Map.set({"a": 1, "b": 2}, "c", 3) ~is {"a": 1, "b": 2, "c": 3}
   check:
     ({"a": 1, "b": 2} ++ {"a": 3})["a"] ~is 3
     ({"a": 1, "b": 2} ++ {"a": 3, "b": 4})["a"] ~is 3
@@ -120,6 +120,33 @@ check:
   Map.append({1: 1}, {1: 2}) ~is {1: 2}
   Map.append({1: 1}, {1: 2}, {1: 3}) ~is {1: 3}
   Map.append({1: 1}, {1: 2}, {1: 3}, {1: 4}) ~is {1: 4}
+
+block:
+  use_static
+  check:
+    {"a": 1, "b": 2, "c": 3}
+      .append({"d": 4}, {"e": 5, "f": 6})
+      .remove("b")
+    ~is {"a": 1, "c": 3, "d": 4, "e": 5, "f": 6}
+  check:
+    {"a": 1, "b": 2, "c": 3}
+      .set("d", 4)
+      .remove("b")
+      .append({"e": 5, "f": 6})
+    ~is {"a": 1, "c": 3, "d": 4, "e": 5, "f": 6}
+  block:
+    use_dynamic
+    check:
+      dynamic({"a": 1, "b": 2, "c": 3})
+        .append({"d": 4}, {"e": 5, "f": 6})
+        .remove("b")
+      ~is {"a": 1, "c": 3, "d": 4, "e": 5, "f": 6}
+    check:
+      dynamic({"a": 1, "b": 2, "c": 3})
+        .set("d", 4)
+        .remove("b")
+        .append({"e": 5, "f": 6})
+      ~is {"a": 1, "c": 3, "d": 4, "e": 5, "f": 6}
 
 block:
   class Entry(key, val):
@@ -220,7 +247,7 @@ block:
     dynamic({"a": 1, "b": 2}).get("a") ~is 1
     dynamic({"a": 1, "b": 2}).get("c", "other") ~is "other"
   check:
-    dynamic({"a": 1, "b": 2}).add("c", 3) ~is {"a": 1, "b": 2, "c": 3}
+    dynamic({"a": 1, "b": 2}).set("c", 3) ~is {"a": 1, "b": 2, "c": 3}
   check:
     (dynamic({"a": 1, "b": 2}) ++ {"a": 3})["a"] ~is 3
     (dynamic({"a": 1, "b": 2}) ++ {"a": 3, "b": 4})["a"] ~is 3
@@ -1460,6 +1487,12 @@ check:
     error.val("oops").msg,
   )
   ("oops" :~ Map).append() ~throws values(
+    "Map.append: " ++ error.annot_msg(),
+    error.annot("Map").msg,
+    error.val("oops").msg,
+  )
+  // this case is specially optimized
+  ("oops" :~ Map) ++ {"a": 1} ~throws values(
     "Map.append: " ++ error.annot_msg(),
     error.annot("Map").msg,
     error.val("oops").msg,

--- a/rhombus/rhombus/tests/set.rhm
+++ b/rhombus/rhombus/tests/set.rhm
@@ -282,18 +282,34 @@ check:
   Set.append({1}, {2}) ~is {1, 2}
   Set.append({1}, {2}, {1}) ~is {1, 2}
   Set.append({1}, {2}, {1}, {2}) ~is {1, 2}
-
-check:
-  {1, 2, 3}.append({4}, {5, 6}).remove(2) ~is {1, 3, 4, 5, 6}
-  {1, 2, 3}.to_list().length() ~is 3
-  {1, 2, 3}.to_list(#true) ~is [1, 2, 3]
   Set.append({1}, {3, 5}, {2, 4, 6}) ~is {1, 2, 3, 4, 5, 6}
-  {1, 3}.intersect() ~is {1, 3}
-  {1, 3}.intersect({2, 3}) ~is {3}
-  {1, 3}.intersect({2, 3}, {3, 4}) ~is {3}
-  {1, 3}.union() ~is {1, 3}
-  {1, 3}.union({2, 3}) ~is {1, 2, 3}
-  {1, 3}.union({2, 3}, {3, 4}) ~is {1, 2, 3, 4}
+
+block:
+  use_static
+  check:
+    {1, 2, 3}.append({4}, {5, 6}).remove(2) ~is {1, 3, 4, 5, 6}
+    {1, 2, 3}.add(4).remove(2).append({5, 6}) ~is {1, 3, 4, 5, 6}
+    {1, 2, 3}.to_list().length() ~is 3
+    {1, 2, 3}.to_list(#true) ~is [1, 2, 3]
+    {1, 3}.intersect() ~is {1, 3}
+    {1, 3}.intersect({2, 3}) ~is {3}
+    {1, 3}.intersect({2, 3}, {3, 4}) ~is {3}
+    {1, 3}.union() ~is {1, 3}
+    {1, 3}.union({2, 3}) ~is {1, 2, 3}
+    {1, 3}.union({2, 3}, {3, 4}) ~is {1, 2, 3, 4}
+  block:
+    use_dynamic
+    check:
+      dynamic({1, 2, 3}).append({4}, {5, 6}).remove(2) ~is {1, 3, 4, 5, 6}
+      dynamic({1, 2, 3}).add(4).remove(2).append({5, 6}) ~is {1, 3, 4, 5, 6}
+      dynamic({1, 2, 3}).to_list().length() ~is 3
+      dynamic({1, 2, 3}).to_list(#true) ~is [1, 2, 3]
+      dynamic({1, 3}).intersect() ~is {1, 3}
+      dynamic({1, 3}).intersect({2, 3}) ~is {3}
+      dynamic({1, 3}).intersect({2, 3}, {3, 4}) ~is {3}
+      dynamic({1, 3}).union() ~is {1, 3}
+      dynamic({1, 3}).union({2, 3}) ~is {1, 2, 3}
+      dynamic({1, 3}).union({2, 3}, {3, 4}) ~is {1, 2, 3, 4}
 
 block:
   check:
@@ -330,6 +346,19 @@ block:
     use_dynamic
     check dynamic({1, 2}).remove(1) ~is {2}
     check dynamic({1, 2}).remove(3) ~is {1, 2}
+
+block:
+  use_static
+  check {1, 2}.add(1) ~is {1, 2}
+  check {1, 2}.add(3) ~is {1, 2, 3}
+  check 3 in {1, 2}.add(3) ~is #true
+  check Set.add({1, 2}, 1) ~is {1, 2}
+  check Set.add({1, 2}, 3) ~is {1, 2, 3}
+  check 3 in Set.add({1, 2}, 3) ~is #true
+  block:
+    use_dynamic
+    check dynamic({1, 2}).add(1) ~is {1, 2}
+    check dynamic({1, 2}).add(3) ~is {1, 2, 3}
 
 block:
   use_static
@@ -1154,6 +1183,17 @@ check:
     error.val("oops").msg,
   )
   ("oops" :~ Set).append() ~throws values(
+    "Set.append: " ++ error.annot_msg(),
+    error.annot("Set").msg,
+    error.val("oops").msg,
+  )
+  // this case is specially optimized
+  ("oops" :~ Set) ++ {1} ~throws values(
+    "Set.append: " ++ error.annot_msg(),
+    error.annot("Set").msg,
+    error.val("oops").msg,
+  )
+  ("oops" :~ Set) ++ {1, 2} ~throws values(
     "Set.append: " ++ error.annot_msg(),
     error.annot("Set").msg,
     error.val("oops").msg,


### PR DESCRIPTION
Commit a01383c added `Map.add`, but I think the name was a mistake.  Rename it to correspond to `MutableMap.set`, and document it.

Also fix some bugs related to `Map.set`, `Set.add`, and the `++` special case.