### PR TITLE
gui: fix TabPanel action annotation

### DIFF
--- a/rhombus-gui-lib/rhombus/gui/private/panel.rhm
+++ b/rhombus-gui-lib/rhombus/gui/private/panel.rhm
@@ -96,7 +96,7 @@ class TabsPanel(private _handle, private _at_selection :: Obs):
                ~choice_to_label: choice_to_label :: Any -> Any = values,
                ~choice_equal: choice_equal :: Function.of_arity(2) = fun (a, b): a == b,
                ~selection: selection :: ObsOrValue.of(Any) = #false,
-               ~action: action :: (TabsPanel.Action, List, maybe(Any)) -> Any = #false,
+               ~action: action :: maybe((TabsPanel.Action, List, maybe(Any)) -> Any) = #false,
                ~alignment: alignment :: ObsOrValue.of(View.Alignment) = [#'center, #'top],
                ~styles: style :: ObsOrValue.of(List.of(TabsPanel.Style)) = [],
                ~is_enabled: is_enabled :: ObsOrValue.of(Boolean) = #true,
@@ -107,8 +107,12 @@ class TabsPanel(private _handle, private _at_selection :: Obs):
                child :: ObsOrValue.of(View),
                ...):
     let at_selection = obs.to_obs(selection)
-    let action = action || (fun (_, _, selected):
-                              at_selection.value := selected)
+    let action:
+      if action
+      | fun(what, choices, selected):
+          action(what, [& choices], selected)
+      | fun(_, _, selected):
+          at_selection.value := selected
     super(easy.tabs(obs.unwrap_list(choices, values),
                     action,
                     ~selection: obs.unwrap(at_selection),

--- a/rhombus-gui/rhombus/gui/scribblings/canvas.scrbl
+++ b/rhombus-gui/rhombus/gui/scribblings/canvas.scrbl
@@ -19,9 +19,9 @@
       ~label: label :: ObsOrValue.of(maybe(View.LabelString)) = "canvas",
       ~is_enabled: is_enabled :: ObsOrValue.of(Boolean) = #true,
       ~styles: styles :: ObsOrValue.of(List.of(Canvas.Style)) = [],
-      ~margin: margin :: ObsOrValue.of(Margin) = [0, 0],
-      ~min_size: min_size :: ObsOrValue.of(Size) = [#false, #false],
-      ~stretch: stretch :: ObsOrValue.of(Stretch) = [#true, #true],
+      ~margin: margin :: ObsOrValue.of(View.Margin) = [0, 0],
+      ~min_size: min_size :: ObsOrValue.of(View.Size) = [#false, #false],
+      ~stretch: stretch :: ObsOrValue.of(View.Stretch) = [#true, #true],
       ~mixin: mix :: Function = values,
     )
 ){

--- a/rhombus-gui/rhombus/gui/scribblings/panel.scrbl
+++ b/rhombus-gui/rhombus/gui/scribblings/panel.scrbl
@@ -64,7 +64,7 @@
     constructor (
       choices :: ObsOrValue.of(List),
       ~selection: selection :: ObsOrValue.of(Any),
-      ~action: action :: (TabsPanel.Action, List, maybe(Any)) -> Any
+      ~action: action :: maybe((TabsPanel.Action, List, maybe(Any)) -> Any)
                  = #,(@rhombus(set_selection, ~var)),
       ~choice_to_label: choice_to_label :: Any -> Any = values,
       ~choice_equal: choice_equal :: Function.of_arity(2) = (_ == _),


### PR DESCRIPTION
Without this, `gui_demo.rhm` currently fails w/ an annotation error.