### PR TITLE
Update editor.scrbl

### DIFF
--- a/rhombus/rhombus/scribblings/guide/editor.scrbl
+++ b/rhombus/rhombus/scribblings/guide/editor.scrbl
@@ -28,5 +28,4 @@ specified by the initial @hash_lang() line.
 The
 @hyperlink("https://marketplace.visualstudio.com/items?itemName=evzen-wybitul.magic-racket"){Magic
  Racket} extension for Visual Studio Code provide support for running
-Rhombus programs, but its editor support is currently tied to Racket's
-parenthesis-oriented syntax.
+Rhombus programs, and adds rudimentary support for syntax highlighting as well.


### PR DESCRIPTION
Updates of Magic Racket made highlighting in VSCode better, it can now considered to be rudimentary and this commit reflects that