### PR TITLE
implement `keep_let` in `for`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/for-clause-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/for-clause-primitive.rkt
@@ -1,11 +1,15 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
+                     enforest/name-parse
                      "srcloc.rkt"
                      "tag.rkt")
          "for-clause.rkt"
          "parens.rkt"
          "parse.rkt"
+         "binding.rkt"
+         (rename-in "values.rkt"
+                    [values rhombus-values])
          (submod "membership-testable.rkt" in-operator))
 
 (provide (for-space rhombus/for_clause
@@ -16,21 +20,42 @@
                     final_when))
 
 (begin-for-syntax
-  ;; Like `:var-decl`, but we don't allow `=` here
+  (define-syntax-class :values-id
+    #:attributes (name)
+    #:description "the literal `values`"
+    #:opaque
+    (pattern ::name
+             #:when (free-identifier=? (in-binding-space #'name)
+                                       (bind-quote rhombus-values))))
+
+  (define (check-multiple-ins stx)
+    (syntax-parse stx
+      [(_ _ ... in::in (~seq _ ... more::in) ...+ _ ...)
+       (raise-syntax-error #f
+                           (string-append "multiple immediate membership operators not allowed in this group;"
+                                          "\n use parentheses to disambiguate")
+                           stx
+                           #'in
+                           (syntax->list #'(more ...)))]
+      [(_ _ ... _::in _ ...)
+       (void)]))
+
+  ;; Like `:var-decl`, but `in` is recognized in place of `=`
   (define-splicing-syntax-class (:each-decl stx)
     #:datum-literals (group)
-    #:attributes ([bind 1] blk)
-    (pattern (~seq bind ...+ _::in expr ...+)
-             #:do [(syntax-parse #'(bind ... expr ...)
-                     [(_ ... i::in _ ...)
-                      (raise-syntax-error #f
-                                          (string-append "multiple immediate membership operators not allowed in this group;"
-                                                         "\n use parentheses to disambiguate")
-                                          stx
-                                          #'i)]
-                     [_ (void)])]
-             #:attr blk #'(block (group expr ...)))
-    (pattern (~seq bind ...+ (~and blk (_::block . _))))))
+    #:attributes ([bind-g 1] blk)
+    (pattern (~seq (~optional _::values-id) (_::parens bind-g ...) (~and blk (_::block . _))))
+    (pattern (~and (~seq t ...)
+                   (~seq (~optional _::values-id) (_::parens bind-g ...) _::in expr ...+))
+             #:do [(check-multiple-ins #'(t ...))]
+             #:with blk #`(block (#,group-tag expr ...)))
+    (pattern (~and (~seq t ...)
+                   (~seq bind ...+ _::in expr ...+))
+             #:do [(check-multiple-ins #'(t ...))]
+             #:with (bind-g ...) #`((#,group-tag bind ...))
+             #:with blk #`(block (#,group-tag expr ...)))
+    (pattern (~seq bind ...+ (~and blk (_::block . _)))
+             #:with (bind-g ...) #`((#,group-tag bind ...)))))
 
 (define-for-clause-syntax each
   (for-clause-transformer
@@ -38,10 +63,9 @@
      (syntax-parse stx
        #:datum-literals (group)
        [(form-id (~var d (:each-decl stx)))
-        #`(#:each d.bind ... d.blk)]
+        #`(#:each ((d.bind-g ...)) (d.blk))]
        [(form-id (tag::block (group (~var d (:each-decl stx))) ...))
-        #`(#:each (tag (group d.bind ... d.blk)
-                       ...))]
+        #`(#:each ((d.bind-g ...) ...) (d.blk ...))]
        [_
         (raise-syntax-error #f
                             "needs a binding or a block of bindings, each followed by a block"

--- a/rhombus/rhombus/tests/for.rhm
+++ b/rhombus/rhombus/tests/for.rhm
@@ -229,6 +229,34 @@ check:
   ~is 15
 
 check:
+  for values(sum = 0):
+    each lst in [[], [1], [1, 2], [1, 2, 3]]
+    keep_let [fst, _, ...] = lst
+    sum + fst
+  ~is 3
+
+check:
+  for values(sum = 0):
+    each lst in [[], [1], [1, 2], [1, 2, 3]]
+    keep_let [fst, _, ...]: lst
+    sum + fst
+  ~is 3
+
+check:
+  for values(sum = 0):
+    each lst in [[], [1], [1, 2], [1, 2, 3]]
+    keep_let ([fst, _, ...], [_, snd, _, ...]) = values(lst, lst)
+    sum + fst + snd
+  ~is 6
+
+check:
+  for values(sum = 0):
+    each lst in [[], [1], [1, 2], [1, 2, 3]]
+    keep_let ([fst, _, ...], [_, snd, _, ...]): values(lst, lst)
+    sum + fst + snd
+  ~is 6
+
+check:
   use_static
   def set:
     for values(set :~ Set = dynamic({1, 4, 9, 16, 25})):
@@ -754,6 +782,15 @@ version_guard.at_least "8.11.1.4":
       final_when true_or_false
       i
     ~is [0]
+
+  check:
+    for List:
+      each i in 0..2
+      syntax_parameter.relet true_or_false_val:
+        #true
+      keep_let #true = true_or_false
+      i
+    ~is [0, 1]
 
   syntax_parameter.bridge a_range_stx:
     #false

--- a/shrubbery-render-lib/shrubbery/render/private/rhombus-spacer.rhm
+++ b/shrubbery-render-lib/shrubbery/render/private/rhombus-spacer.rhm
@@ -63,6 +63,7 @@ export:
       s_WeakMutableSet as WeakMutableSet
     for
     each
+    keep_let
     import
     export
     described_as
@@ -1033,6 +1034,10 @@ spacer.bridge each(self, tail, context, esc):
   | '': self
   | ~else:
       '$self $(adjust_bind_each(tail, context, esc))'
+
+spacer.bridge keep_let(self, tail, context, esc):
+  ~in: ~for_clause
+  '$self $(adjust_def(tail, esc))'
 
 spacer.bridge import(self, tail, context, esc):
   ~in: ~defn


### PR DESCRIPTION
`keep_let` is like `keep_when`, but matches values to bindings instead of testing expressions.  The relationship is similar to `guard.let` vs. `guard`.