### PR TITLE
better propagate static infos in `::`/`:~`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annotation-converting.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation-converting.rkt
@@ -50,9 +50,7 @@
              (syntax-parse (respan #`(#,group-tag result-ann ...))
                [res::annotation
                 (build-annotated-expression #'form-id #'res
-                                            (attribute op.check?)
-                                            plain-body
-                                            #'res.parsed
+                                            (attribute op.check?) plain-body #'() #'res.parsed
                                             (lambda (tmp-id)
                                               #`(raise-annotation-failure
                                                  'form-id

--- a/rhombus-lib/rhombus/private/amalgam/class-dot.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-dot.rkt
@@ -448,14 +448,14 @@
 (define-for-syntax ((make-handle-class-instance-dot name do-allow-protected? internal-fields internal-methods)
                     form1 dot field-id
                     tail more-static? repetition?
-                    success failure-in)
+                    success failure)
   (define desc (syntax-local-value* (in-class-desc-space name) objects-desc-ref))
   (unless desc (error "cannot find annotation binding for instance dot provider"))
   (define (do-field fld)
     (cond
       [repetition?
        ;; let dot-provider dispatcher handle repetition construction:
-       (failure-in)]
+       (failure)]
       [else
        (define accessor-id (field-desc-accessor-id fld))
        (syntax-parse tail
@@ -608,14 +608,6 @@
         (get-private-table desc
                            #:fail-v #f
                            #:allow-super-for (syntax-e field-id))))
-  (define (failure)
-    (cond
-      [(and more-static?
-            (not repetition?))
-       (raise-syntax-error #f
-                           (string-append "no such field or method" statically-str)
-                           field-id)]
-      [else (failure-in)]))
   (cond
     [(and (class-desc? desc)
           (or (for/or ([field+acc (in-list (class-desc-fields desc))])
@@ -691,7 +683,7 @@
             [else
              (do-field id/intf/fld)]))]
     [else (failure)]))
-  
+
 (define-for-syntax no-constructor-transformer
   (expression-transformer
    (lambda (stx)

--- a/rhombus/rhombus/scribblings/reference/annotation.scrbl
+++ b/rhombus/rhombus/scribblings/reference/annotation.scrbl
@@ -10,11 +10,15 @@
   repet.macro '$repet :: $annot'
 ){
 
- Checks that the value of @rhombus(expr) satisfies
- @rhombus(annot), and returns the value if so.
+ Checks that the value of @rhombus(expr) satisfies @rhombus(annot),
+ and returns the value if so.
+
+ If @rhombus(annot) is a @tech(~doc: guide_doc){converter annotation},
+ the converted value is returned.
 
 @examples(
   [1, 2, 3] :: List
+  PairList[1, 2, 3] :: Listable.to_list
 )
 
 }
@@ -34,6 +38,7 @@
 
 @examples(
   def x :: List = [1, 2, 3]
+  def [x, y, z] :: Listable.to_list = PairList[1, 2, 3]
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/class.scrbl
+++ b/rhombus/rhombus/scribblings/reference/class.scrbl
@@ -1024,7 +1024,7 @@
     class PosnX(x, y):
       internal _PosnX
       expression 'PosnX< $x ... || $y ... >':
-        '_PosnX($x ..., $y ...) :~ PosnX'
+        'dynamic(_PosnX($x ..., $y ...)) :~ PosnX'
       reconstructor (x, y):
         PosnX< x || y >
   ~repl:

--- a/rhombus/rhombus/scribblings/reference/veneer.scrbl
+++ b/rhombus/rhombus/scribblings/reference/veneer.scrbl
@@ -142,7 +142,7 @@
         | 0: x
         | 1: y
       expression 'Posn($x, $y)':
-        'Pair($x, $y) :~ Posn'
+        'dynamic(Pair($x, $y)) :~ Posn'
   ~repl:
     def p = Posn(10, 20)
     p.x

--- a/rhombus/rhombus/tests/annotation.rhm
+++ b/rhombus/rhombus/tests/annotation.rhm
@@ -207,3 +207,143 @@ check:
   fun access_x(p :: Posn && converting(fun(x :: Posn) :: Posn: x) && satisfying(fun(y :: Posn): #true)):
     p.x
   ~completes
+
+// `::`/`:~` should `&&` static infos for predicate annotations
+block:
+  use_static
+  check:
+    ("a" :~ Int).length() ~is 1
+    ("a" :: Int).length() ~throws values(
+      "::: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("a").msg,
+    )
+  check:
+    ("a" :~ Int) < dynamic(2) ~throws values(
+      ".<: " ++ error.annot_msg(),
+      error.annot("Real").msg,
+      error.val("a").msg,
+    )
+    ("a" :: Int) < dynamic(2) ~throws values(
+      "::: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("a").msg,
+    )
+
+block:
+  use_static
+  class NoLength()
+  check:
+    ("a" :~ NoLength).length() ~is 1
+    ("a" :: NoLength).length() ~throws values(
+      "::: " ++ error.annot_msg(),
+      error.annot("NoLength").msg,
+      error.val("a").msg,
+    )
+  class HasLength():
+    method length():
+      "oops"
+  check:
+    ("a" :~ HasLength).length() ~throws values(
+      "HasLength.length: not an instance for method call",
+      error.val("a").msg,
+    )
+    ("a" :: HasLength).length() ~throws values(
+      "::: " ++ error.annot_msg(),
+      error.annot("HasLength").msg,
+      error.val("a").msg,
+    )
+
+block:
+  use_static
+  let [str, ...] = ["a", "ab", "abc"]
+  check:
+    [(str :~ Int).length(), ...] ~is [1, 2, 3]
+    [(str :: Int).length(), ...] ~throws values(
+      "::: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("a").msg,
+    )
+  check:
+    [(str :~ Int) < dynamic(2), ...] ~throws values(
+      ".<: " ++ error.annot_msg(),
+      error.annot("Real").msg,
+      error.val("a").msg,
+    )
+    [(str :: Int) < dynamic(2), ...] ~throws values(
+      "::: " ++ error.annot_msg(),
+      error.annot("Int").msg,
+      error.val("a").msg,
+    )
+
+block:
+  use_static
+  let [str, ...] = ["a", "ab", "abc"]
+  class NoLength()
+  check:
+    [(str :~ NoLength).length(), ...] ~is [1, 2, 3]
+    [(str :: NoLength).length(), ...] ~throws values(
+      "::: " ++ error.annot_msg(),
+      error.annot("NoLength").msg,
+      error.val("a").msg,
+    )
+  class HasLength():
+    method length():
+      "oops"
+  check:
+    [(str :~ HasLength).length(), ...] ~throws values(
+      "HasLength.length: not an instance for method call",
+      error.val("a").msg,
+    )
+    [(str :: HasLength).length(), ...] ~throws values(
+      "::: " ++ error.annot_msg(),
+      error.annot("HasLength").msg,
+      error.val("a").msg,
+    )
+
+check:
+  ~eval
+  use_static
+  class HasWeirdLength():
+    property length:
+      "oops"
+  (HasWeirdLength() :~ String).length
+  ~throws "method must be called (based on static information)"
+
+check:
+  ~eval
+  use_static
+  class HasWeirdLength():
+    property length:
+      "oops"
+  block:
+    let [x, ...] = [HasWeirdLength(), HasWeirdLength(), HasWeirdLength()]
+    [(x :~ String).length, ...]
+  ~throws "method must be called (based on static information)"
+
+// `::`/`:~` should *not* `&&` static infos for converter annotations
+check:
+  ~eval
+  use_static
+  ("a" :: converting(fun (x) :~ Int: x)).length()
+  ~throws "no such field or method (based on static information)"
+
+check:
+  ~eval
+  use_static
+  block:
+    let [str, ...] = ["a", "ab", "abc"]
+    [(str :: converting(fun (x) :~ Int: x)).length(), ...]
+  ~throws "no such field or method (based on static information)"
+
+// but static infos should be propagated to inner binding
+block:
+  use_static
+  check:
+    "a" :: converting(fun (x): x.length()) ~is 1
+
+block:
+  use_static
+  let [str, ...] = ["a", "ab", "abc"]
+  check:
+    [str :: converting(fun (x): x.length()), ...] ~is [1, 2, 3]

--- a/rhombus/rhombus/tests/class-reconstructor.rhm
+++ b/rhombus/rhombus/tests/class-reconstructor.rhm
@@ -31,7 +31,7 @@ block:
   class Posn(x, y):
     internal _Posn
     expression 'Posn < $x $y >':
-      '_Posn($x, $y) :~ Posn'
+      'dynamic(_Posn($x, $y)) :~ Posn'
     reconstructor (x, y):
       Posn < x  y >
   def p = Posn< 1 2 >
@@ -46,14 +46,14 @@ block:
   class Posn3D(z):
     extends Posn
     reconstructor(x, y, z = this.z):
-      Posn3D(x, y, z+1)  
+      Posn3D(x, y, z+1)
   check Posn3D(1, 2, 3) with (x = 10) ~is Posn3D(10, 2, 4)
   check Posn3D(1, 2, 3) with (x = 11, z = 8) ~is Posn3D(11, 2, 9)
-  check (Posn3D(1, 2, 3) :: Posn) with (x = 10) ~is Posn3D(10, 2, 4)
+  check (dynamic(Posn3D(1, 2, 3)) :: Posn) with (x = 10) ~is Posn3D(10, 2, 4)
   block:
     use_dynamic
     check dynamic(Posn3D(1, 2, 3)) with (w = -1) ~throws "no such reconstructor argument in class"
-    check (Posn3D(1, 2, 3) :: Posn) with (z = 30) ~is Posn3D(1, 2, 31)
+    check (dynamic(Posn3D(1, 2, 3)) :: Posn) with (z = 30) ~is Posn3D(1, 2, 31)
 
 block:
   class Posn(x, y):
@@ -62,7 +62,7 @@ block:
     extends Posn
     nonfinal
     reconstructor(x, y, z = this.z):
-      Posn3D(x, y, z+1)  
+      Posn3D(x, y, z+1)
   class Posn4D(w):
     extends Posn3D
   check Posn3D(1, 2, 3) with (x = 10) ~is Posn3D(10, 2, 4)
@@ -90,7 +90,7 @@ block:
     constructor ():
       super(0, 0)
   class Posn3D(z):
-    extends Posn  
+    extends Posn
     internal _Posn3D
     constructor (z):
       super()(z)
@@ -140,7 +140,7 @@ block:
   class Posn3D(z):
     extends Posn
     reconstructor_fields:
-      extent: this.z          
+      extent: this.z
     reconstructor(x, y, z):
       Posn3D(x, y, z)
   check Posn3D(1, 2, 3) with (extent = 30) ~is Posn3D(1, 2, 30)

--- a/rhombus/rhombus/tests/class.rhm
+++ b/rhombus/rhombus/tests/class.rhm
@@ -60,7 +60,7 @@ block:
   check p with (x = 10) ~is Posn3D(~x: 10, 2, 3)
   check p with (y = 20) ~is Posn3D(~x: 1, 20, 3)
   check p with (z = 30) ~is Posn3D(~x: 1, 2, 30)
-  check (p :: Posn) with (x = 10) ~is Posn3D(~x: 10, 2, 3)
+  check (dynamic(p) :: Posn) with (x = 10) ~is Posn3D(~x: 10, 2, 3)
 
 block:
   class Posn(x, y):

--- a/rhombus/rhombus/tests/enum.rhm
+++ b/rhombus/rhombus/tests/enum.rhm
@@ -130,7 +130,7 @@ check:
   enum NoIntersection:
     ~is_a A
     ~is_a B
-  (A() :: NoIntersection).whoami()
+  (dynamic(A()) :: NoIntersection).whoami()
   ~throws "no such field or method (based on static information)"
 
 // duplicate identifier
@@ -214,4 +214,3 @@ enum ns.Example:
   one
   two
 check #'one ~is_a ns.Example
-

--- a/rhombus/rhombus/tests/function.rhm
+++ b/rhombus/rhombus/tests/function.rhm
@@ -36,7 +36,7 @@ check:
   ~eval
   use_static
   fun g(x, ...): [x, ...]
-  def f :: Function.of_arity(1) = (g :: Function.of_arity(2))
+  def f :: Function.of_arity(1) = (dynamic(g) :: Function.of_arity(2))
   f()
   ~throws "wrong number of arguments in function call"
 
@@ -44,7 +44,7 @@ check:
   ~eval
   use_static
   fun g(x, ...): [x, ...]
-  def f :: Function.of_arity(1) = (g :: Function.of_arity(2))
+  def f :: Function.of_arity(1) = (dynamic(g) :: Function.of_arity(2))
   f(1, 2, 3)
   ~throws "wrong number of arguments in function call"
 

--- a/rhombus/rhombus/tests/port.rhm
+++ b/rhombus/rhombus/tests/port.rhm
@@ -155,7 +155,7 @@ block:
                                                             error.annot("Port.WaitMode").msg)
   check p.read_bytes_to(bstr, ~start: 5, ~end: 6) ~is 1
   check bstr[5] ~is Byte#"d"
-  
+
 block:
   let p = Port.Input.open_string("abλcdefμ")
   check p is_a Port.Input ~is #true
@@ -298,13 +298,13 @@ block:
 check:
   ~eval
   use_static
-  (Port.Output.open_string() :: Port.Output).get_string()
+  (dynamic(Port.Output.open_string()) :: Port.Output).get_string()
   ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
-  (Port.Output.open_string() :: Port.Output).get_bytes()
+  (dynamic(Port.Output.open_string()) :: Port.Output).get_bytes()
   ~throws "no such field or method (based on static information)"
 
 check:

--- a/rhombus/rhombus/tests/veneer.rhm
+++ b/rhombus/rhombus/tests/veneer.rhm
@@ -94,7 +94,7 @@ veneer RevList2(this :: List):
   override get(i):
     this[this.length() - i - 1]
   expression 'RevList2[$elem, ...]':
-    '[$elem, ...] :~ RevList2'
+    'dynamic([$elem, ...]) :~ RevList2'
 
 check:
   RevList2[1, 2, 3][0] ~is 3


### PR DESCRIPTION
This addresses an issue raised on Discord that static infos aren’t property `&&`ed in `::`/`:~` expression.  Now, static infos from the LHS expression are extracted and propagated to RHS annotation.  Specfically, when RHS annotation is predicate annotation, the resulting static infos is the `&&`, while when it’s converter annotation, the static infos is propagated to the inner binding (such as in the argument of `converter`).