### PR TITLE
support multiple-value patterns in `match`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/charset.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/charset.rhm
@@ -90,11 +90,11 @@ class Charset(private _ranges):
     _Charset(
       recur loop(a = _ranges,
                  b = other._ranges):
-        match [a, b]
-        | [[], b]: b
-        | [a, []]: a
-        | [[[as, ae], ar, ...],
-           [[bs, be], br, ...]]:
+        match values(a, b)
+        | ([], b): b
+        | (a, []): a
+        | ([[as, ae], ar, ...],
+           [[bs, be], br, ...]):
             cond
             | bs .< as:
                 loop(b, a)
@@ -115,11 +115,11 @@ class Charset(private _ranges):
     _Charset(
       recur loop(a = _ranges,
                  b = other._ranges):
-        match [a, b]
-        | [[], b]: []
-        | [a, []]: []
-        | [[[as, ae], ar, ...],
-           [[bs, be], br, ...]]:
+        match values(a, b)
+        | ([], b): []
+        | (a, []): []
+        | ([[as, ae], ar, ...],
+           [[bs, be], br, ...]):
             cond
             | bs .< as:
                 loop(b, a)

--- a/rhombus-lib/rhombus/private/amalgam/class-clause-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-clause-primitive.rkt
@@ -21,7 +21,7 @@
          "var-decl.rkt"
          (only-in "function.rkt" fun)
          (submod "function.rkt" for-method)
-         (only-in (submod "function-parse.rkt" for-build) :values-id)
+         (submod "values.rkt" for-parse)
          "op-literal.rkt"
          "not-block.rkt"
          "realm.rkt")
@@ -192,7 +192,7 @@
        (for/list ([ret (syntax->list rets-stx)])
          (syntax-parse ret
            #:datum-literals (group)
-           [(op::annotate-op (~optional _::values-id) (~and p (_::parens (~and g (group ret-seq ...)) ...)))
+           [(op::annotate-op (~optional _::values-id-annot) (~and p (_::parens (~and g (group ret-seq ...)) ...)))
             #:when (attribute op.check?)
             #:with (id ...) (map relocate+reraw
                                  (syntax->list #'(g ...))
@@ -608,7 +608,7 @@
       [(_ _::property (~var m (:property-impl #'#:protected-property))) #'m.form]
       [(_ _::immutable (~and (~seq _::field _ ...) (~var f (:field-spec 'protected 'mutable)))) #'f.form]
       [(_ (~and (~seq _::field _ ...) (~var f (:field-spec 'protected 'mutable)))) #'f.form]
-      [(_ (~and (~seq _::immutable _ ...) (~var f (:field-spec 'protected 'immutable)))) #'f.form]      
+      [(_ (~and (~seq _::immutable _ ...) (~var f (:field-spec 'protected 'immutable)))) #'f.form]
       [(_ (~var m (:method-impl stx #'#:protected))) #'m.form])))
 
 (define-class-clause-syntax protected

--- a/rhombus-lib/rhombus/private/amalgam/cond.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/cond.rkt
@@ -7,7 +7,6 @@
          "else-clause.rkt"
          "static-info.rkt"
          "parens.rkt"
-         "realm.rkt"
          "srcloc-error.rkt")
 
 (provide (rename-out [rhombus-if if]
@@ -51,13 +50,7 @@
                   e::else-clause))
         (define rhs-es (map enforest-expression-block
                             (syntax->list #'((tag rhs ...) ...))))
-        (define els-e (syntax-parse #'e.parsed
-                        #:literals (rhombus-body-at)
-                        [(rhombus-body-at tag else-rhs ...)
-                         (enforest-expression-block #'(tag else-rhs ...))]
-                        [(rhombus-expression g)
-                         (enforest-expression-block #'g)]
-                        [_ #'e.parsed]))
+        (define els-e (enforest-expression-block #'e.rhs))
         (values
          (with-syntax ([(rhs ...) (map discard-static-infos rhs-es)])
            (wrap-static-info*

--- a/rhombus-lib/rhombus/private/amalgam/else-clause.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/else-clause.rkt
@@ -2,17 +2,16 @@
 (require (for-syntax racket/base
                      syntax/parse/pre
                      "tag.rkt")
-         "parens.rkt"
-         "parse.rkt")
+         "parens.rkt")
 
 (provide (for-syntax :else-clause))
 
 (begin-for-syntax
   (define-syntax-class :else-clause
     #:description "`~else` clause"
-    #:attributes (parsed)
+    #:opaque
+    #:attributes (rhs)
     #:datum-literals (group)
-    (pattern (_::block (group #:else (tag::block else-rhs ...)))
-             #:with parsed #'(rhombus-body-at tag else-rhs ...))
-    (pattern (_::block (group #:else else-rhs ...+))
-             #:with parsed #`(rhombus-expression (#,group-tag else-rhs ...)))))
+    (pattern (_::block (group #:else (~and rhs (_::block . _)))))
+    (pattern (_::block (group #:else t ...+))
+             #:with rhs #`(#,group-tag t ...))))

--- a/rhombus-lib/rhombus/private/amalgam/function-parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/function-parse.rkt
@@ -2,7 +2,6 @@
 (require (for-syntax racket/base
                      racket/keyword
                      syntax/parse/pre
-                     enforest/name-parse
                      enforest/syntax-local
                      shrubbery/print
                      "treelist.rkt"
@@ -49,8 +48,7 @@
          "if-blocked.rkt"
          "realm.rkt"
          "mutability.rkt"
-         (only-in "values.rkt"
-                  [values rhombus-values])
+         (submod "values.rkt" for-parse)
          "rhombus-primitive.rkt")
 
 (module+ for-build
@@ -62,7 +60,6 @@
                        :ret-annotation/prepass
                        :maybe-arg-rest
                        :non-...-binding
-                       :values-id
                        check-arg-for-unsafe
                        build-function
                        build-case-function
@@ -250,21 +247,13 @@
                      predicate? ; all predicate annotations?
                      count))    ; the expected number of values
 
-  (define-syntax-class :values-id
-    #:attributes (name)
-    #:description "the literal `values`"
-    #:opaque
-    (pattern ::name
-             #:when (free-identifier=? (in-annotation-space #'name)
-                                       (annot-quote rhombus-values))))
-
   (define-splicing-syntax-class (:ret-annotation [ctx empty-annot-context])
     #:attributes (static-infos ; can be `((#%values (static-infos ...)))` for multiple results
                   converter    ; a `converter` struct, or `#f`
                   annot-str)   ; the raw text of annotation, or `#f`
     #:description "return annotation"
     #:datum-literals (group)
-    (pattern (~seq ann-op::annotate-op (~optional op::values-id) (~and p (_::parens g ...)))
+    (pattern (~seq ann-op::annotate-op (~optional op::values-id-annot) (~and p (_::parens g ...)))
              #:do [(define gs #'(g ...))]
              #:with ((~var c (:annotation ctx)) ...) gs
              #:with (arg ...) (generate-temporaries gs)

--- a/rhombus-lib/rhombus/private/amalgam/guard.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/guard.rhm
@@ -90,7 +90,7 @@ namespace guard:
         match '$g.condition ...'
         | '$(gb :: GuardBindAndRightHandSide(who))':
             values(
-              'match $gb.rhs_expression
+              'match ($gb.rhs_expression)
                | $gb.bind ...: $g.success_body
                | ~else: $g.failure_body',
               ''

--- a/rhombus-lib/rhombus/private/amalgam/parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/parse.rkt
@@ -234,7 +234,7 @@
     [(_ (parsed #:rhombus/expr rhs))
      #'rhs]
     [(_ rhs)
-     (datum->syntax #f (list #'rhombus-expression (list #'group #'rhs)))]))
+     (datum->syntax #f (list #'rhombus-expression #'rhs))]))
 
 ;; For a definition context, interleaves expansion and enforestation:
 (define-syntax (rhombus-body-sequence stx)

--- a/rhombus-lib/rhombus/private/amalgam/values.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/values.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
+                     enforest/name-parse
                      "srcloc.rkt")
          "provide.rkt"
          "binding.rkt"
@@ -33,6 +34,10 @@
                       rhombus/statinfo)
                      (rename-out
                       [call-with-values call_with_values])))
+
+(module+ for-parse
+  (provide (for-syntax :values-id-annot
+                       :values-id-bind)))
 
 (define-syntax rhombus-values
   (expression-transformer
@@ -112,6 +117,18 @@
                             (string-append "not allowed as an annotation (except as a non-nested"
                                            " annotation by forms that specifically recognize it)")
                             #'head)]))))
+
+(begin-for-syntax
+  (define-syntax-rule (define-values-id-class class in-space quote)
+    (define-syntax-class class
+      #:attributes (name)
+      #:description "the literal `values`"
+      #:opaque
+      (pattern ::name
+               #:when (free-identifier=? (in-space #'name)
+                                         (quote values)))))
+  (define-values-id-class :values-id-annot in-annotation-space annot-quote)
+  (define-values-id-class :values-id-bind in-binding-space bind-quote))
 
 (begin-for-syntax
   (define-splicing-syntax-class :accum

--- a/rhombus-pict-lib/rhombus/pict/private/static.rhm
+++ b/rhombus-pict-lib/rhombus/pict/private/static.rhm
@@ -1748,11 +1748,11 @@ fun connect(~on: p :: Pict,
       if label
       | fun ([p, label, from, to]): retry(p, label, from, to, dt, n)
       | fun ([p, from, to]): retry(p, #false, from, to, dt, n)
-    let desc: p.identity
-    match [p, label]
-    | [_ :: NothingPict, _]:
+    let desc = p.identity
+    match values(p, label)
+    | (_ :: NothingPict, _):
         nothing
-    | [p :: _StaticPict, _ :: maybe(_StaticPict)]:
+    | (p :: _StaticPict, _ :: maybe(_StaticPict)):
         let (from_x, from_y) = from.maybe_in(p, dt, n)
         let (to_x, to_y) = to.maybe_in(p, dt, n)
         cond
@@ -2049,7 +2049,7 @@ fun group_by(elems, n):
     | ~else:
         let [l0, & ls] = loop(elems.rest, i + 1)
         [[elems.first] ++ l0, & ls]
-  
+
 // ----------------------------------------
 
 fun explain_bbox(p :: Pict,

--- a/rhombus-xml-lib/rhombus/xml/private/to_rhm.rhm
+++ b/rhombus-xml-lib/rhombus/xml/private/to_rhm.rhm
@@ -27,8 +27,8 @@ fun prolog_to_rhm(prolog, keep_pi):
          ~post_misc: filter_pi([misc_to_rhm(post_misc), ...], keep_pi))
 
 fun element_to_rhm(e, normalize, keep_pi):
-  let PairList[attr, ...] = rkt.#{element-attributes}(e) 
-  let PairList[content, ...] = rkt.#{element-content}(e) 
+  let PairList[attr, ...] = rkt.#{element-attributes}(e)
+  let PairList[content, ...] = rkt.#{element-content}(e)
   Element(~srcloc: source_to_rhm(e),
           ~name: to_string(rkt.#{element-name}(e)),
           ~attributes: [attribute_to_rhm(attr), ...],
@@ -111,7 +111,7 @@ fun attribute_to_rhm(attr):
               if v is_a ReadableString
               | to_string(v)
               | v)
-  
+
 fun entity_to_rhm(e, normalize):
   let v = rkt.#{entity-text}(e)
   let srcloc = source_to_rhm(e)
@@ -142,7 +142,7 @@ fun normalize_text(content :: List, normalize):
                          ~text: String.append(t.text, ...))
         new_content.drop_last(1).add(new_t)
     let (new_content, tail_strs):
-      for fold (new_content :~ List = [], tail_strs :~ List = []) (c in content):        
+      for fold (new_content :~ List = [], tail_strs :~ List = []) (c in content):
         if new_content == [] || tail_strs == []:
         | values(new_content.add(c),
                  match c
@@ -158,13 +158,13 @@ fun normalize_text(content :: List, normalize):
 
 
 fun merge_srclocs(new_srcloc, srcloc):
-  match [new_srcloc, srcloc]
-  | [#false, srcloc]: srcloc
-  | [new_srcloc, #false]: new_srcloc
-  | [SrclocRange(Srcloc(src, line, col, offset, _),
+  match values(new_srcloc, srcloc)
+  | (#false, srcloc): srcloc
+  | (new_srcloc, #false): new_srcloc
+  | (SrclocRange(Srcloc(src, line, col, offset, _),
                  Srcloc(_, end_line, end_col, end_offset, _)),
      SrclocRange(Srcloc(_, line2, col2, offset2, _),
-                 Srcloc(_, end_line2 :~ Int, end_col2, end_offset2, _))]:
+                 Srcloc(_, end_line2 :~ Int, end_col2, end_offset2, _))):
       let new_line = math.min(line, line2)
       let new_col = math.min(col, col2)
       let new_offset = math.min(offset, offset2)
@@ -177,4 +177,3 @@ fun merge_srclocs(new_srcloc, srcloc):
       let new_end_offset = math.max(end_offset, end_offset2)
       SrclocRange(Srcloc(src, new_line, new_col, new_offset, new_end_offset - new_offset),
                   Srcloc(src, new_end_line, new_end_col, new_end_offset, #false))
-    

--- a/rhombus/rhombus/scribblings/guide/var+value.scrbl
+++ b/rhombus/rhombus/scribblings/guide/var+value.scrbl
@@ -76,3 +76,11 @@ look more the same:
     n
     s
 )
+
+The @rhombus(match) form also supports matching multiple values this
+way.
+
+@examples(
+  match values(1, "apple")
+  | (n, s): n + s.length()
+)

--- a/rhombus/rhombus/scribblings/nonterminal.rhm
+++ b/rhombus/rhombus/scribblings/nonterminal.rhm
@@ -10,6 +10,7 @@ export:
   entry_point
   immediate_callee
   bind
+  values_bind
   annot
   reducer
   body
@@ -33,6 +34,7 @@ manual.nonterminal:
   entry_point: block
   immediate_callee: block
   bind: def ~defn
+  values_bind: def ~defn
   annot: ::
   reducer: for
   body: block

--- a/rhombus/rhombus/scribblings/reference/check.scrbl
+++ b/rhombus/rhombus/scribblings/reference/check.scrbl
@@ -18,7 +18,7 @@
   ~nonterminal:
     expected_expr: block expr
     expected_body: block body
-    expected_bind: def lhs_bind ~defn
+    expected_values_bind: def values_bind ~defn
     evaluator_expr: block expr
   expr.macro 'check:
                 $maybe_eval
@@ -44,8 +44,8 @@
     ~is_a: $annot
     ~prints_like $expected_expr
     ~prints_like: $expected_body; ...
-    ~matches $expected_bind
-    ~matches: $expected_bind
+    ~matches $expected_values_bind
+    ~matches: $expected_values_bind
     ~prints $expected_expr
     ~prints: $expected_body; ...
     ~throws $expected_expr
@@ -76,8 +76,8 @@
 
  @item{In @rhombus(~matches) mode, checks that the original result is
   not an exception, that the number of result values matches the number of
-  supplied @rhombus(expected_bind)s, and that each value matches the
-  corresponding @rhombus(expected_bind).}
+  supplied @nontermref(bind)s in @rhombus(expected_values_bind), and that
+  each value matches the corresponding @nontermref(bind).}
 
  @item{In @rhombus(~prints) mode, evaluates the @rhombus(expected_expr)
   or @rhombus(expected_body) in a mode that captures output to

--- a/rhombus/rhombus/scribblings/reference/def.scrbl
+++ b/rhombus/rhombus/scribblings/reference/def.scrbl
@@ -8,34 +8,29 @@
 @doc(
   ~nonterminal:
     rhs_expr: block expr
-    id_name: namespace ~defn
-  defn.macro 'def $lhs_bind = $rhs_expr'
-  defn.macro 'def $lhs_bind:
+  defn.macro 'def $values_bind = $rhs_expr'
+  defn.macro 'def $values_bind:
                 $body
                 ...'
-  grammar lhs_bind:
-    $bind
-    #,(@rhombus(values, ~bind))($bind, ...)
-    ($bind, ...)
 ){
 
- Binds the identifiers of @rhombus(bind)s to the values of @rhombus(rhs_expr) or the
+ Binds the identifiers of @nontermref(bind)s to the values of @rhombus(rhs_expr) or the
  @rhombus(body) sequence. The @rhombus(body) itself can include
  definitions, and it normally ends with an expression to provide the
  result values.
 
- A @rhombus(bind) can be just an identifier or @rhombus(id_name), or it
+ A @nontermref(bind) in @rhombus(values_bind) can be just an identifier or @nontermref(id_name), or it
  can be constructed with a binding operator, such as a pattern form or
  @rhombus(::) for annotations. The number of result values must match
- the number of @rhombus(bind)s. Static information is gathered from
+ the number of @nontermref(bind)s. Static information is gathered from
  @rhombus(rhs_expr) or @rhombus(body) and propagated to
- @rhombus(lhs_bind) as described in @secref(~doc: guide_doc, "static-info-rules")).
+ @rhombus(values_bind) as described in @secref(~doc: guide_doc, "static-info-rules").
 
  An identifier is bound in the @rhombus(expr, ~space) @tech(~doc: meta_doc){space}, and
  most binding operators also create bindings in the
  @rhombus(expr, ~space) space.
 
- When @rhombus(def) is used with @rhombus(=), then @rhombus(lhs_bind) or @rhombus(rhs_expr) must
+ When @rhombus(def) is used with @rhombus(=), then @rhombus(values_bind) or @rhombus(rhs_expr) must
  not contain any immediate @rhombus(=) terms (although @rhombus(=) can
  appear nested in blocks, parentheses, etc.). When a @rhombus(def) group
  both contains a @rhombus(=) and ends in a block, the block is treated as
@@ -64,9 +59,8 @@
 @doc(
   ~nonterminal:
     rhs_expr: block expr
-    lhs_bind: def ~defn
-  defn.macro 'let $lhs_bind = $rhs_expr'
-  defn.macro 'let $lhs_bind:
+  defn.macro 'let $values_bind = $rhs_expr'
+  defn.macro 'let $values_bind:
                 $body
                 ...'
 ){

--- a/rhombus/rhombus/scribblings/reference/for.scrbl
+++ b/rhombus/rhombus/scribblings/reference/for.scrbl
@@ -7,7 +7,7 @@
 
 @doc(
   ~nonterminal:
-    lhs_bind: def ~defn
+    rhs_expr: block expr
 
   expr.macro 'for $maybe_each:
                 $clause_or_body
@@ -39,8 +39,8 @@
     $other_for_clause
     $body
   grammar bind_each:
-    $lhs_bind in $expr
-    $lhs_bind:
+    $values_bind in $rhs_expr
+    $values_bind:
       $body
       ...
   grammar expr_or_block:
@@ -49,8 +49,8 @@
       $body
       ...
   grammar bind_let:
-    $lhs_bind = $expr
-    $lhs_bind:
+    $values_bind = $rhs_expr
+    $values_bind:
       $body
       ...
 ){
@@ -71,10 +71,10 @@
  sequence; see also @rhombus(Sequence, ~annot) and @rhombus(statinfo_meta.sequence_constructor_key).
  A fresh @tech{instantiation} of the sequence is used each
  time the @rhombus(for) form is evaluated. Each element of that sequence is bound in turn to
- the @rhombus(lhs_bind) variables of the @rhombus(each, ~for_clause). If a sequence
+ the @rhombus(values_bind) bindings of the @rhombus(each, ~for_clause). If a sequence
  can have multiple values as its elements (for example, a map as a
  sequence has a key and value for each element), then
- @rhombus(lhs_bind) can be a @rhombus(values, ~bind) pattern or just a
+ @rhombus(values_bind) can be a @rhombus(values, ~bind) pattern or just a
  parenthesized sequence of bindings to receive a matching number of
  element values.
 

--- a/rhombus/rhombus/scribblings/reference/form.scrbl
+++ b/rhombus/rhombus/scribblings/reference/form.scrbl
@@ -150,11 +150,17 @@ identifiers, expressions, or binding patterns.
 @doc(
   ~nonterminal_key: def ~defn
   grammar bind
+  grammar values_bind:
+    $bind
+    #,(@rhombus(values, ~bind))($bind, ...)
+    ($bind, ...)
 ){
 
  In syntax descriptions, @rhombus(bind) refers to any binding form,
  which might be simply an identifier, a binding form annotated with
  @rhombus(::, ~bind) or @rhombus(:~, ~bind), or a larger binding pattern.
+ Some forms also handle multiple-value binding forms, as indicated by
+ @rhombus(values_bind).
 
  Besides all of the binding forms provided by @rhombuslangname(rhombus),
  new ones can be defined with @top_rhombus(bind.macro).

--- a/rhombus/rhombus/scribblings/reference/guard.scrbl
+++ b/rhombus/rhombus/scribblings/reference/guard.scrbl
@@ -21,7 +21,7 @@
 @rhombus(body) sequence if so. If @rhombus(test_expr) produces
 @rhombus(#false), then @rhombus(body) is skipped and @rhombus(failure_body)
 is evaluated, instead. This is equivalent to
-@rhombus(if $test_expr | $body ... | $failure_body ...), and is primarily
+@rhombus(if test_expr | body ... | failure_body ...), and is primarily
 useful when @rhombus(body) is much more complex than @rhombus(failure_body)
 or contains a mixture of definitions and additional @rhombus(guard) forms
 interleaved with each other.
@@ -44,17 +44,17 @@ Static information works the same way as it would in an equivalent
 
 @doc(
   ~nonterminal:
-    test_bind: block expr
+    test_values_bind: def values_bind ~defn
     target_expr: block expr
     target_body: block body
     failure_body: block body
     body: block body
-  defn.sequence_macro 'guard.let $test_bind = $target_expr
+  defn.sequence_macro 'guard.let $test_values_bind = $target_expr
                        | $failure_body
                          ...
                        $body
                        ...'
-  defn.sequence_macro 'guard.let $test_bind:
+  defn.sequence_macro 'guard.let $test_values_bind:
                          $target_body
                          ...
                        | $failure_body
@@ -63,10 +63,10 @@ Static information works the same way as it would in an equivalent
                        ...'
 ){
 
- Checks that @rhombus(target_expr) produces a value that matches
-@rhombus(test_bind) and makes the bindings of @rhombus(test_bind)
+ Checks that @rhombus(target_expr) produces values that match
+@rhombus(test_values_bind) and makes the bindings of @rhombus(test_values_bind)
 available in the subsequent @rhombus(body) sequence. If
-@rhombus(target_expr) does not match @rhombus(test_bind), then the
+@rhombus(target_expr) does not match @rhombus(test_values_bind), then the
 @rhombus(body) sequence is skipped and @rhombus(failure_body) is
 evaluated, instead. This is the pattern matching variant of
 @rhombus(guard), see its documentation for general advice on using

--- a/rhombus/rhombus/scribblings/reference/values.scrbl
+++ b/rhombus/rhombus/scribblings/reference/values.scrbl
@@ -40,14 +40,14 @@
 
 @doc(
   ~nonterminal:
-    lhs_bind: def ~defn
+    values_bind: def ~defn
   bind.macro 'values($bind, ...)'
 ){
 
  The @rhombus(values, ~bind) binding operator can only be used in
  places where it's specifically recognized, normally to match multiple
- result values. For example, the @rhombus(lhs_bind) position of
- @rhombus(def) recognizes @rhombus(values, ~bind).
+ result values. For example, the left-hand side @rhombus(values_bind)
+ position of @rhombus(def) recognizes @rhombus(values, ~bind).
 
  Plain parentheses as a binding (as implemented by the
  @rhombus(#%parens, ~bind) form) work as an alias for

--- a/rhombus/rhombus/tests/alt-fun.rhm
+++ b/rhombus/rhombus/tests/alt-fun.rhm
@@ -94,9 +94,9 @@ block:
     let c2 = fun (): 2
     fun
     | (tmp1, & rst):
-        match [tmp1, rst]
-        | [[], _]: c0(rst)
-        | [_, []]: c1(tmp1)
+        match values(tmp1, rst)
+        | ([], _): c0(rst)
+        | (_, []): c1(tmp1)
     | ():
         let tmp2: [1]
         match tmp2
@@ -119,9 +119,9 @@ block:
     let c2 = fun (): 2
     fun
     | (tmp1, & rst):
-        match [tmp1, rst]
-        | [[], _]: c0(rst)
-        | [_, []]: c1(tmp1)
+        match values(tmp1, rst)
+        | ([], _): c0(rst)
+        | (_, []): c1(tmp1)
     | ():
         let tmp2: []
         match tmp2

--- a/rhombus/rhombus/tests/def.rhm
+++ b/rhombus/rhombus/tests/def.rhm
@@ -123,3 +123,36 @@ check:
   block:
     def [1, 2] = [1, 2]
   ~throws "block does not end with an expression"
+
+// correctness: patterns are matched left-to-right
+check:
+  def (_ :: converting(fun (x): println("first:", x); x),
+       _ :: converting(fun (x): println("second:", x); x),
+       _ :: converting(fun (x): println("third:", x); x)):
+    values(1, 2, 3)
+  #void
+  ~prints "first: 1"
+    ++ "\n" ++ "second: 2"
+    ++ "\n" ++ "third: 3"
+    ++ "\n"
+
+// when wrong number of values, produce arity error
+check:
+  def (_, _) = 1
+  #void
+  ~throws values(
+    "result arity mismatch",
+    "expected number of values not received",
+    "expected: 2",
+    "received: 1",
+  )
+
+check:
+  def _ = values(1, 2)
+  #void
+  ~throws values(
+    "result arity mismatch",
+    "expected number of values not received",
+    "expected: 1",
+    "received: 2",
+  )

--- a/rhombus/rhombus/tests/guard.rhm
+++ b/rhombus/rhombus/tests/guard.rhm
@@ -46,7 +46,6 @@ check:
     x + y
   ~is 3
 
-
 check:
   block:
     guard.let Point(x, y) = #false
@@ -67,7 +66,6 @@ check:
     z
   ~is 3
 
-
 check:
   block:
     guard.let Point(x, y):
@@ -85,6 +83,26 @@ check:
     | 100
     x + y
   ~is 3
+
+check:
+  block:
+    guard.let (Point(x, y),
+               Point(z, w)):
+      values(#false,
+             #false)
+    | 100
+    x + y + z + w
+  ~is 100
+
+check:
+  block:
+    guard.let values(Point(x, y),
+                     Point(z, w)):
+      values(Point(1, 2),
+             Point(3, 4))
+    | 100
+    x + y + z + w
+  ~is 10
 
 check:
   ~eval

--- a/rhombus/rhombus/tests/match.rhm
+++ b/rhombus/rhombus/tests/match.rhm
@@ -84,7 +84,6 @@ block:
     | s: s.length()
     ~is 1
   check:
-    use_static
     match "s"
     | _ :: Int: "can't happen"
     | s: s.length()
@@ -99,15 +98,6 @@ check:
   match error("here"):«»
   ~throws "here"
 
-check:
-  match values(1, 2):«»
-  ~throws values(
-    "result arity mismatch",
-    "expected number of values not received",
-    "expected: 1",
-    "received: 2",
-  )
-
 // `~else` only
 check:
   match 1
@@ -119,17 +109,227 @@ check:
   | ~else "else"
   ~is "else"
 
+
 check:
   match error("here")
   | ~else: "else"
   ~throws "here"
 
+// multiple-value patterns
 check:
-  match values(1, 2)
-  | ~else: "else"
+  match values()
+  | (): "first"
+  | values(): "second"
+  ~is "first"
+
+block:
+  fun matcher(x):
+    match x
+    | 1: "1"
+    | (2): "2"
+    | values(3): "3"
+  check:
+    matcher(1) ~is "1"
+    matcher(2) ~is "2"
+    matcher(3) ~is "3"
+    matcher(4) ~throws "no matching case"
+
+block:
+  fun matcher(x, y):
+    match values(x, y)
+    | (1, 1): "1, 1"
+    | values(2, 2): "2, 2"
+    | ~else: "other"
+  check:
+    matcher(1, 1) ~is "1, 1"
+    matcher(2, 2) ~is "2, 2"
+    matcher(3, 3) ~is "other"
+
+block:
+  fun is_same_length(xs, ys):
+    match values(xs, ys)
+    | ([], []): #true
+    | ([_, _, ...], []): #false
+    | ([], [_, _, ...]): #false
+    | ([_, x, ...], [_, y, ...]):
+        is_same_length([x, ...], [y, ...])
+  check:
+    is_same_length([], []) ~is #true
+    is_same_length([1, 2], [3, 4]) ~is #true
+    is_same_length([1], [2, 3, 4]) ~is #false
+    is_same_length([1, 2, 3], [4]) ~is #false
+    is_same_length("oops", "not list") ~throws "no matching case"
+
+// explicit `~arity` declaration
+check:
+  match values():
+    ~arity: 0
+  | (): ""
+  ~is ""
+
+check:
+  match 1:
+    ~arity 1
+  | 1: "one"
+  ~is "one"
+
+check:
+  match values(1, 2):
+    ~arity: 2
+  | (1, 2): "one, two"
+  ~is "one, two"
+
+check:
+  match values(1, 2, 3):
+    ~arity 3
+  | (1, 2, 3): "one, two, three"
+  ~is "one, two, three"
+
+// correctness: patterns are matched left-to-right
+check:
+  match values(1, 2, 3)
+  | (_ :: converting(fun (x): println("first:", x); x),
+     _ :: converting(fun (x): println("second:", x); x),
+     _ :: converting(fun (x): println("third:", x); x)):
+       #void
+  ~prints "first: 1"
+    ++ "\n" ++ "second: 2"
+    ++ "\n" ++ "third: 3"
+    ++ "\n"
+
+// make sure static info propagates, in multiple-value patterns
+block:
+  use_static
+  check:
+    match values("hello", #"world", [1, 2], PairList[3, 4, 5])
+    | (s, bs, l, pl):
+        values(s.length(), bs.length(), l.length(), pl.length())
+    ~is values(5, 5, 2, 3)
+  check:
+    match values("hello", #"world", [1, 2], PairList[3, 4, 5])
+    | (_ :: Char, _ :: Byte, _ :: Int, _ :: Int):
+        "cannot happen"
+    | (s, bs, l, pl):
+        values(s.length(), bs.length(), l.length(), pl.length())
+    ~is values(5, 5, 2, 3)
+
+// make sure static info does *not* propagate, in multiple-value
+// patterns, when wrong number of values
+check:
+  ~eval
+  use_static
+  match "hello"
+  | (s, bs): s.length()
+  ~throws "no such field or method (based on static information)"
+
+check:
+  ~eval
+  use_static
+  match values("hello", #"world")
+  | s: s.length()
+  ~throws "no such field or method (based on static information)"
+
+// patterns with inconsistent arity shouldn't compile at all
+check:
+  ~eval
+  match 1
+  | (): "0 values"
+  | _: "1 value"
+  ~throws values(
+    "all clauses must match the same number of values",
+    "previous clauses match 0 values, but current clause matches 1 value",
+  )
+
+check:
+  ~eval
+  match 1
+  | 1: "value is 1"
+  | 2: "value is 2"
+  | _: "1 value"
+  | (_, _): "2 values"
+  ~throws values(
+    "all clauses must match the same number of values",
+    "previous clauses match 1 value, but current clause matches 2 values",
+  )
+
+check:
+  ~eval
+  match 1:
+    ~arity: 0
+  | _: "1 value"
+  ~throws values(
+    "current clause is inconsistent with declared arity",
+    "arity is declared to be 0, but current clause matches 1 value",
+  )
+
+check:
+  ~eval
+  match 1:
+    ~arity 1
+  | _: "1 value"
+  | (_, _): "2 values"
+  ~throws values(
+    "current clause is inconsistent with declared arity",
+    "arity is declared to be 1, but current clause matches 2 values",
+  )
+
+// when wrong number of values, produce arity error
+check:
+  match values(1, 2):
+  | _: "one value"
   ~throws values(
     "result arity mismatch",
     "expected number of values not received",
     "expected: 1",
     "received: 2",
+  )
+
+check:
+  match values(1, 2)
+  | ~else: "one value"
+  ~throws values(
+    "result arity mismatch",
+    "expected number of values not received",
+    "expected: 1",
+    "received: 2",
+  )
+
+check:
+  match values(1, 2):«»
+  ~throws values(
+    "result arity mismatch",
+    "expected number of values not received",
+    "expected: 1",
+    "received: 2",
+  )
+
+check:
+  match 1
+  | (_, _): "two values"
+  ~throws values(
+    "result arity mismatch",
+    "expected number of values not received",
+    "expected: 2",
+    "received: 1",
+  )
+
+check:
+  match 1:
+    ~arity: 2
+  | ~else: "two values"
+  ~throws values(
+    "result arity mismatch",
+    "expected number of values not received",
+    "expected: 2",
+    "received: 1",
+  )
+
+check:
+  match 1:
+    ~arity: 2
+  ~throws values(
+    "result arity mismatch",
+    "expected number of values not received",
+    "expected: 2",
+    "received: 1",
   )


### PR DESCRIPTION
The `match` form is extended to support multiple-value patterns, similar to Racket `match/values`.  ~~The syntactic constraints are like in `match/values`: all clauses must match the same number of values, and at least one pattern clause must be provided.~~  Like `match/values`, the target expression is expected to produce a fixed, known number of values.  Unlike `match/values`, though, we support `~else` clause in multiple-value `match`~~, given that at least one pattern clause is provided~~.  Multiple-value patterns take the forms `(<bind>, ...)` or `values(<bind>, ...)`, as in `def`/`let`.

~~Compatibility note: most existing `match` forms will continue to work.  Some `match` forms with *only* `~else` clause or no clause at all (`match <expr>:«»`) will stop working, but I think such forms only really occur in macro expansion (`match <expr> | $clause | ...` with an empty `clause` sequence).  The other option is to still allow such forms, but this would make it that the target expression could produce any number of values when there isn't any pattern clause, and that seems less desirable.~~

The expected arity is inferred in a `match` form:

- when there is at least one pattern clause, infer it from the first pattern clause;
- when no clause or only `~else` clause is provided, take it to be 1.

It can also be explicitly given with an `~arity` declaration.  All clauses must match the same number of values and, if present, be consistent with the `~arity` declaration, otherwise a syntax error is reported.

The `guard.let` form now also supports multiple-value patterns, because it expands into `match`.