### PR TITLE
improve list-as-tuple support with annotation and static-info suppoer

### DIFF
--- a/rhombus-draw-lib/rhombus/draw/private/brush.rhm
+++ b/rhombus-draw-lib/rhombus/draw/private/brush.rhm
@@ -37,7 +37,7 @@ class LinearGradient(private _handle):
     let (x1, y1, x2, y2) = rkt.send handle.#{get-line}()
     [Point(x1, y1), Point(x2, y2)]
 
-  property stops :: List.of(matching([_ :: Real, _ :: Color])):
+  property stops :: List.of([Real, Color]):
     let PairList[PairList[stop, c], ...] = rkt.send handle.#{get-stops}()
     [[stop, _Color(c)], ...]
 
@@ -53,11 +53,11 @@ class RadialGradient(private _handle):
                           pt2.x, pt2.y, r2,
                           PairList[PairList[stop, color.handle], ...]))
 
-  property circles:: List.of(matching([_ :: Point, _ :: Real])):
+  property circles:: List.of([Point, Real]):
     let (x0, y0, r0, x1, y1, r1) = rkt.send handle.#{get-circles}()
     [[Point(x0, y0), r0], [Point(x1, y1), r1]]
 
-  property stops :: List.of(matching([_ :: Real, _ :: Color])):
+  property stops :: List.of([Real, Color]):
     let PairList[PairList[stop, c], ...] = rkt.send handle.#{get-stops}()
     [[stop, _Color(c)], ...]
 

--- a/rhombus-draw-lib/rhombus/draw/private/point.rhm
+++ b/rhombus-draw-lib/rhombus/draw/private/point.rhm
@@ -14,7 +14,7 @@ def zero = Point(0, 0)
 
 dotting.annot_macro 'PointLike' ('to_point' => 'PointLike.to_point'):
   'Point
-     || matching([_ :: Real, _ :: Real])
+     || [Real, Real]
      || matching({#'x: _ :: Real, #'y: _ :: Real})'
 
 namespace PointLike:

--- a/rhombus-draw-lib/rhombus/draw/private/rect.rhm
+++ b/rhombus-draw-lib/rhombus/draw/private/rect.rhm
@@ -29,8 +29,8 @@ def zero = Rect(0, 0, 0, 0)
 
 dotting.annot_macro 'RectLike' ('to_rect' => 'RectLike.to_rect'):
   'Rect
-     || matching([_ :: Real, _ :: Real, _ :: NonnegReal, _ :: NonnegReal])
-     || matching([_ :: PointLike, _ :: SizeLike])
+     || [Real, Real, NonnegReal, NonnegReal]
+     || [PointLike, SizeLike]
      || matching({#'x: _ :: Real, #'y: _ :: Real, #'width: _ :: NonnegReal, #'height: _ :: NonnegReal})
      || matching({#'point: _ :: PointLike, #'size: _ :: Size})'
 

--- a/rhombus-draw-lib/rhombus/draw/private/size.rhm
+++ b/rhombus-draw-lib/rhombus/draw/private/size.rhm
@@ -14,7 +14,7 @@ def zero = Size(0, 0)
 
 dotting.annot_macro 'SizeLike' ('to_size' => 'SizeLike.to_size'):
   'Size
-     || matching([_ :: NonnegReal, _ :: NonnegReal])
+     || [NonnegReal, NonnegReal]
      || matching({#'width: _ :: NonnegReal, #'height: _ :: NonnegReal})'
 
 namespace SizeLike:

--- a/rhombus-draw/rhombus/draw/scribblings/brush.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/brush.scrbl
@@ -71,9 +71,9 @@
                  pt2 :: PointLike,
                  [[stop :: Real.in(0.0, 1.0), color :: Color], ...])
   property (grad :: draw.LinearGradient).line
-    :: matching([_ :: Point, _ :: Point])
+    :: [Point, _ :: Point]
   property (grad :: draw.LinearGradient).stops
-    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: Color]))
+    :: List.of([Real.in(0.0, 1.0), Color])
 ){
 
  A linear gradient for a @rhombus(Brush, ~class).
@@ -86,10 +86,10 @@
                  [[pt2 :: PointLike], r2 :: Real],
                  [[stop :: Real.in(0.0, 1.0), color :: Color], ...])
   property (grad :: draw.RadialGradient).circles
-    :: matching([[_ :: PointLike, _ :: Real],
-                 [_ :: PointLike, _ :: Real]])
+    :: [[PointLike, Real],
+        [PointLike, Real]]
   property (grad :: draw.RadialGradient).stops
-    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: Color]))
+    :: List.of([Real.in(0.0, 1.0), Color])
 ){
 
  A radial gradient for a @rhombus(Brush, ~class).

--- a/rhombus-draw/rhombus/draw/scribblings/point-et-al.scrbl
+++ b/rhombus-draw/rhombus/draw/scribblings/point-et-al.scrbl
@@ -36,7 +36,7 @@
 
  @item{@rhombus(Point, ~annot): a @rhombus(Point, ~class) instance;}
 
- @item{@rhombus(matching([_ :: Real, _ :: Real]), ~annot): a
+ @item{@rhombus([Real, Real], ~annot): a
   @rhombus(List) containing two @rhombus(Real, ~annot) values; or}
 
  @item{@rhombus(matching({#'x: _ :: Real, #'y: _ :: Real}), ~annot):
@@ -79,7 +79,7 @@
 
  @item{@rhombus(Size, ~annot); a @rhombus(Size, ~class) instance;}
 
- @item{@rhombus(matching([_ :: NonnegReal, _ :: NonnegReal]), ~annot):
+ @item{@rhombus([NonnegReal, NonnegReal], ~annot):
   a @rhombus(List) containing two @rhombus(NonnegReal, ~annot)
   values; or}
 
@@ -125,11 +125,11 @@
 
  @item{a @rhombus(Rect, ~class) instance;}
 
- @item{@rhombus(matching([_ :: Real, _ :: Real, _ :: NonnegReal, _ :: NonnegReal]), ~annot):
+ @item{@rhombus([Real, Real, NonnegReal, NonnegReal], ~annot):
   a @rhombus(List) containing two @rhombus(Real, ~annot) values for the top-left point
   followed by two @rhombus(NonnegReal, ~annot) values for the size;}
 
- @item{@rhombus(matching([_ :: PointLike, _ :: SizeLike]), ~annot):
+ @item{@rhombus([PointLike, SizeLike], ~annot):
   a @rhombus(List) containing a @rhombus(PointLike, ~annot) value
   followed by a @rhombus(SizeLike, ~annot) value;}
 

--- a/rhombus-gui-lib/rhombus/gui/private/button.rhm
+++ b/rhombus-gui-lib/rhombus/gui/private/button.rhm
@@ -17,9 +17,9 @@ class Button(private _handle):
 
   constructor (label :: ObsOrValue.of(View.LabelString
                                         || Bitmap
-                                        || matching([_ :: Bitmap,
-                                                     _ :: View.LabelString,
-                                                     _ :: Button.LabelPosition])),
+                                        || [Bitmap,
+                                            View.LabelString,
+                                            Button.LabelPosition]),
                ~action: action :: () -> ~any = values,
                ~is_enabled: is_enabled :: ObsOrValue.of(Boolean) = #true,
                ~styles: style :: ObsOrValue.of(List.of(Button.Style)) = [],

--- a/rhombus-gui-lib/rhombus/gui/private/type.rhm
+++ b/rhombus-gui-lib/rhombus/gui/private/type.rhm
@@ -12,20 +12,20 @@ annot.macro '(View.SizeInt)':
   'Int.in(0, 1000000)'
 
 annot.macro '(View.Size)':
-  'matching([_ :: maybe(View.SizeInt), _ :: maybe(View.SizeInt)])'
+  '[maybe(View.SizeInt), maybe(View.SizeInt)]'
 
 annot.macro '(View.PositionInt)':
   'Int.in(-1000000, 1000000)'
 
 enum View.Position:
   center
-  ~is_a matching([_ :: View.PositionInt, _ :: View.PositionInt])
+  ~is_a [View.PositionInt, View.PositionInt]
 
 annot.macro '(View.SpacingInt)':
   'Int.in(0, 1000)'
 
 annot.macro '(View.Margin)':
-  'matching([_ :: View.SpacingInt, _ :: View.SpacingInt])'
+  '[View.SpacingInt, View.SpacingInt]'
 
 enum View.HorizAlignment:
   left
@@ -38,10 +38,10 @@ enum View.VertAlignment:
   bottom
 
 annot.macro '(View.Alignment)':
-  'matching([_ :: View.HorizAlignment, _ :: View.VertAlignment])'
+  '[View.HorizAlignment, View.VertAlignment]'
 
 annot.macro '(View.Stretch)':
-  'matching([_ :: Boolean, _ :: Boolean])'
+  '[Boolean, Boolean]'
 
 
 annot.macro '(View.LabelString)':

--- a/rhombus-gui/rhombus/gui/scribblings/control.scrbl
+++ b/rhombus-gui/rhombus/gui/scribblings/control.scrbl
@@ -11,10 +11,10 @@
     implements View
     constructor (
       label :: ObsOrValue.of(View.LabelString
-                               || Bitmap
-                               || matching([_ :: Bitmap,
-                                            _ :: LabelString,
-                                            _ :: Button.LabelPosition])),
+                               || draw.Bitmap
+                               || [draw.Bitmap,
+                                   View.LabelString,
+                                   Button.LabelPosition]),
       ~action: action :: () -> ~any = fun (): #void,
       ~is_enabled: is_enabled :: ObsOrValue.of(Boolean) = #true,
       ~styles: styles :: ObsOrValue.of(List.of(Button.Style)) = [],

--- a/rhombus-lib/rhombus/private/amalgam.rkt
+++ b/rhombus-lib/rhombus/private/amalgam.rkt
@@ -4,7 +4,7 @@
 ;; Disable amalgam demodularization with the following keyword,
 ;; which may be useful during development to avoid having to
 ;; compile everything four times
-#:no-demod
+#; #:no-demod
 
 #:include (#:dir "amalgam"
            ;; Although Rhombus is implemented with these libraries,

--- a/rhombus-lib/rhombus/private/amalgam/annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation.rkt
@@ -1365,7 +1365,7 @@
 (define-syntax (like-element-accessor data deps)
   (define si (get-argument-static-infos data deps))
   (or (static-info-lookup si #'#%sequence-element)
-      (static-info-lookup si #'#%index-result)
+      (extract-index-uniform-result (static-info-lookup si #'#%index-result))
       #'()))
 
 (define-annotation-syntax Any.like_element

--- a/rhombus-lib/rhombus/private/amalgam/array.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/array.rkt
@@ -244,10 +244,11 @@
   (define args (annotation-dependencies-args deps))
   (define arr-i 0)
   (define si
-    (or (static-info-lookup (or (and (< arr-i (length args))
-                                     (list-ref args arr-i))
-                                #'())
-                            #'#%index-result)
+    (or (extract-index-uniform-result
+         (static-info-lookup (or (and (< arr-i (length args))
+                                      (list-ref args arr-i))
+                                 #'())
+                             #'#%index-result))
         #'()))
   (cond
     [(static-infos-empty? si)

--- a/rhombus-lib/rhombus/private/amalgam/for.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/for.rkt
@@ -257,7 +257,8 @@
      #:with (static-infos ...) (normalize-static-infos/values
                                 (length lhs-parsed-stxes)
                                 (or (syntax-local-static-info #'rhs #'#%sequence-element)
-                                    (syntax-local-static-info #'rhs #'#%index-result)
+                                    (extract-index-uniform-result
+                                     (syntax-local-static-info #'rhs #'#%index-result))
                                     #'()))
      #:with (lhs-impl::binding-impl ...) #'((lhs-e.infoer-id static-infos lhs-e.data) ...)
      #:with (lhs-i::binding-info ...) #'(lhs-impl.info ...)

--- a/rhombus-lib/rhombus/private/amalgam/implicit.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/implicit.rkt
@@ -7,6 +7,7 @@
          "expression.rkt"
          "binding.rkt"
          "repetition.rkt"
+         (submod "annotation.rkt" for-class)
          "entry-point.rkt"
          "immediate-callee.rkt"
          "parse.rkt"
@@ -47,6 +48,8 @@
                     #%brackets
                     #%braces
                     #%call)
+         (for-space rhombus/annot
+                    #%brackets)
          (for-space rhombus/entry_point
                     #%parens)
          (for-space rhombus/immediate_callee
@@ -324,6 +327,14 @@
    (lambda (stxes)
      (check-brackets stxes)
      (parse-list-repetition stxes))))
+
+(define-annotation-syntax #%brackets
+  (annotation-prefix-operator
+   #f
+   '((default . stronger))
+   'macro
+   (lambda (stx ctx)
+     (parse-list-annotation stx ctx))))
 
 (define-for-syntax (check-brackets stxes)
   (syntax-parse stxes

--- a/rhombus-lib/rhombus/private/amalgam/index-result-key.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/index-result-key.rkt
@@ -1,7 +1,128 @@
 #lang racket/base
-(require (for-syntax racket/base)
+(require (for-syntax racket/base
+                     syntax/parse/pre)
          "static-info.rkt")
 
+(provide (for-syntax extract-index-uniform-result
+                     extract-index-result
+                     or-index-results
+                     add-index-result))
+
+;; An #%index-result value is either
+;;   (#:at_index default-static-infos (key static-infos) ...)
+;;   static-infos  => equivalent to (#:at_index static-infos)
+;; where `default-static-infos` can be #f to indicate that the `key`s are
+;; the only possibilities, and `default-static-infos` needs
+;; to be "or"ed with all `static-infos` for an unknown key
+
 (define-static-info-key-syntax/provide #%index-result
-  (static-info-key static-infos-or
-                   static-infos-and))
+  (static-info-key (lambda (a b)
+                     (or-index-results a b))
+                   (lambda (a b)
+                     (and-index-results a b))))
+
+(define-for-syntax (extract-index-uniform-result si)
+  (cond
+    [(not si) #f]
+    [else
+     (syntax-parse si
+       [(#:at_index #f)
+        #'()]
+       [(#:at_index #f (idx0 i-si0) (idx i-si) ...)
+        (for/fold ([si #'i-si0]) ([i-si (syntax->list #'(i-si ...))])
+          (static-infos-or si i-si))]
+       [(#:at_index other-si (idx i-si) ...)
+        (for/fold ([si #'other-si]) ([i-si (syntax->list #'(i-si ...))])
+          (static-infos-or si i-si))]
+       [else si])]))
+
+(define-for-syntax (extract-index-result si key)
+  (cond
+    [(not si) #f]
+    [else
+     (syntax-parse si
+       [(#:at_index other-si (idx i-si) ...)
+        (or (for/or ([idx (in-list (syntax->list #'(idx ...)))]
+                     [i-si (in-list (syntax->list #'(i-si ...)))])
+              (and (equal? key (syntax-e idx))
+                   i-si))
+            (if (syntax-e #'other-si)
+                #'other-si
+                #'()))]
+       [else si])]))
+
+(define-for-syntax (parse-index-results si)
+  (syntax-parse si
+    [(#:at_index other (idx si) ...)
+     (values (and (syntax-e #'other)
+                  #'other)
+             (for/hash ([idx (in-list (syntax->list #'(idx ...)))]
+                        [si (in-list (syntax->list #'(si ...)))])
+               (values (syntax-e idx) si)))]
+    [_ (values si #hash())]))
+
+(define-for-syntax (add-index-result si i i-isi)
+  (syntax-parse si
+    [(#:at_index other-si i-case ...)
+     #`(#:at_index other-si (#,i #,i-isi) i-case ...)]
+    [else
+     #`(#:at_index #,si (#,i #,i-isi))]))
+
+(define-for-syntax (or-index-results a b)
+  (define-values (a-default a-ht) (parse-index-results a))
+  (define-values (b-default b-ht) (parse-index-results b))
+  (define defaults (and (or a-default b-default)
+                        (static-infos-or (or a-default #'()) (or b-default #'()))))
+  (cond
+    [(and (= 0 (hash-count a-ht))
+          (= 0 (hash-count b-ht)))
+     defaults]
+    [else
+     (define-values (new-defaults new-ht)
+       (for/fold ([new-defaults defaults] [new-ht #hash()]) ([(key a-si) (in-hash a-ht)])
+         (cond
+           [(hash-ref b-ht key #f)
+            => (lambda (b-si)
+                 (values new-defaults (hash-set new-ht key (static-infos-or a-si b-si))))]
+           [else
+            (values (if new-defaults (static-infos-or new-defaults a-si) a-si) new-ht)])))
+     (define all-defaults
+       (for/fold ([new-defaults new-defaults]) ([(key b-si) (in-hash b-ht)])
+         (cond
+           [(hash-ref a-ht key #f) new-defaults]
+           [else (if new-defaults (static-infos-or new-defaults b-si) b-si)])))
+     (if (= 0 (hash-count new-ht))
+         all-defaults
+         #`(#:at_index #,all-defaults
+            #,@(for/list ([(key si) (in-hash new-ht)])
+                 #`(#,key #,si))))]))
+
+(define-for-syntax (and-index-results a b)
+  (define-values (a-default a-ht) (parse-index-results a))
+  (define-values (b-default b-ht) (parse-index-results b))
+  (define defaults (and (or a-default b-default)
+                        (static-infos-and (or a-default #'()) (or b-default #'()))))
+  (cond
+    [(and (= 0 (hash-count a-ht))
+          (= 0 (hash-count b-ht)))
+     defaults]
+    [else
+     (define new-ht
+       (for/fold ([new-ht #hash()]) ([(key a-si) (in-hash a-ht)])
+         (cond
+           [(hash-ref b-ht key #f)
+            => (lambda (b-si)
+                 (hash-set new-ht key (static-infos-and a-si b-si)))]
+           [else
+            (hash-set new-ht key (if b-default (static-infos-and b-default a-si) a-si))])))
+     (define all-ht
+       (for/fold ([new-ht new-ht]) ([(key b-si) (in-hash b-ht)])
+         (cond
+           [(hash-ref a-ht key #f) new-ht]
+           [else
+            (hash-set new-ht key (if a-default (static-infos-and a-default b-si) b-si))])))
+     (if (= 0 (hash-count all-ht))
+         defaults
+         #`(#:at_index #,defaults
+            #,@(for/list ([(key si) (in-hash all-ht)])
+                 #`(#,key #,si))))]))

--- a/rhombus-lib/rhombus/private/amalgam/indexable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/indexable.rkt
@@ -175,7 +175,8 @@
                                 (span-srcloc indexable #'head)
                                 #'head))
        (define result-static-infos (cond
-                                     [(or (indexable-static-info #'#%index-result)
+                                     [(or (extract-index-uniform-result
+                                           (indexable-static-info #'#%index-result))
                                           (syntax-local-static-info indexable-ref-id #'#%call-result))
                                       => (lambda (results)
                                            (find-call-result-at results 2 null #f

--- a/rhombus-lib/rhombus/private/amalgam/key-comp-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/key-comp-macro.rkt
@@ -179,7 +179,7 @@
       [(and (pair? p) (pair? (cdr p)) (null? (cddr p)))
        (hash-set! ht (car p) (cadr p))]
       [else
-       (raise-annotation-failure who p "Listable.to_list && matching([_, _])")]))
+       (raise-annotation-failure who p "Listable.to_list && [Any, Any]")]))
   ht)
 
 (define (build-mutable-set who ht args)

--- a/rhombus-lib/rhombus/private/amalgam/map-maybe.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/map-maybe.rkt
@@ -72,7 +72,8 @@
   arg-id)
 
 (define-for-syntax (do-extract-maybe-statinfo lhs-si)
-  (define si (static-info-lookup lhs-si #'#%index-result))
+  (define si (extract-index-uniform-result
+              (static-info-lookup lhs-si #'#%index-result)))
   (cond
     [(not si) #f]
     [(static-info-lookup si #'#%maybe)
@@ -107,10 +108,11 @@
 (define-syntax (select-elem data deps)
   (define args (annotation-dependencies-args deps))
   (define mm-i 0)
-  (or (static-info-lookup (or (and (< mm-i (length args))
-                                   (list-ref args mm-i))
-                              #'())
-                          #'#%index-result)
+  (or (extract-index-uniform-result
+       (static-info-lookup (or (and (< mm-i (length args))
+                                    (list-ref args mm-i))
+                               #'())
+                           #'#%index-result))
       #'()))
 
 (define/arity (Map.maybe ht)

--- a/rhombus-lib/rhombus/private/amalgam/map.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/map.rkt
@@ -291,7 +291,7 @@
       [else
        (define lst (to-list #f arg))
        (unless (and (pair? lst) (pair? (cdr lst)) (null? (cddr lst)))
-         (raise-annotation-failure who arg "Listable.to_list && matching([_, _])"))
+         (raise-annotation-failure who arg "Listable.to_list && [Any, Any]"))
        (hash-set ht (car lst) (cadr lst))])))
 
 (define (list->map key+vals)

--- a/rhombus-lib/rhombus/private/amalgam/tuple-annot.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/tuple-annot.rkt
@@ -1,0 +1,130 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     "srcloc.rkt"
+                     "tag.rkt"
+                     "annot-context.rkt")
+         racket/treelist
+         "binding.rkt"
+         "parse.rkt"
+         (submod "annotation.rkt" for-class)
+         (only-in "annotation.rkt" ::)
+         "static-info.rkt"
+         "index-key.rkt"
+         "call-result-key.rkt"
+         "index-result-key.rkt"
+         "parens.rkt"
+         (rename-in "ellipsis.rkt"
+                    [... rhombus...]))
+
+(provide (for-syntax build-tuple-annotation))
+
+(define-for-syntax (build-tuple-annotation src-stxes list-id anns last-ann treelist-static-infos kind)
+  (define base-pred (with-syntax ([x-list? (case kind
+                                             [(treelist) #'treelist?]
+                                             [(list) #'list?])]
+                                  [x-length (case kind
+                                              [(treelist) #'treelist-length]
+                                              [(list) #'length])])
+                      #`(lambda (v)
+                          (and (x-list? v)
+                               (#,(if last-ann #'>= #'=)
+                                (x-length v)
+                                #,(length (syntax->list anns)))))))
+  (define (make-si sis last-si)
+    (or (for/fold ([si last-si]) ([a-si (in-list (syntax->list sis))]
+                                  [i (in-naturals)])
+          (add-index-result si i a-si))
+        #'()))
+  (define (build-predicate-annotation base-pred preds-stx sis last-pred last-si)
+    (define si (make-si sis last-si))
+    (define preds (syntax->list preds-stx))
+    (with-syntax ([(pred ...) preds]
+                  [(pred-id ...) (generate-temporaries preds)]
+                  [(idx ...) (for/list ([p (in-list preds)]
+                                        [i (in-naturals)])
+                               i)])
+      (define new-pred #`(let ([pred-id pred]
+                               ...
+                               #,@(if last-pred
+                                      #`([last-pred-id #,last-pred])
+                                      #'()))
+                           (lambda (v)
+                             (and (#,base-pred v)
+                                  #,(case kind
+                                      [(treelist)
+                                       #`(and (pred-id (treelist-ref v idx))
+                                              ...
+                                              #,@(if last-pred
+                                                     #`((for/and ([i (in-range #,(length preds) (treelist-length v))])
+                                                          (last-pred-id (treelist-ref v i))))
+                                                     #'()))]
+                                      [(list)
+                                       (let loop ([pred-ids (syntax->list #'(pred-id ...))])
+                                         (cond
+                                           [(null? pred-ids)
+                                            (if last-pred
+                                                #`(for/and ([i (in-list v)])
+                                                    (last-pred-id i))
+                                                #'#t)]
+                                           [else #`(and (#,(car pred-ids) (car v))
+                                                        (let ([v (cdr v)])
+                                                          #,(loop (cdr pred-ids))))]))])))))
+      (annotation-predicate-form new-pred
+                                 #`((#%index-result #,si)
+                                    . #,treelist-static-infos))))
+  (define (build-converter-annotation base-pred annots sis last-annot last-si)
+    (define si (make-si sis last-si))
+    (with-syntax ([(arg-id ...) (generate-temporaries annots)]
+                  [(annot ...) annots]
+                  [(last-id ...) (if last-annot
+                                     (generate-temporaries '(last))
+                                     '())]
+                  [(last-annot ...) (if last-annot
+                                        (list last-annot)
+                                        null)]
+                  [(last-dots ...) (if last-annot
+                                       (list #'(group rhombus...))
+                                       null)]
+                  [List list-id])
+      (syntax-parse #'(group List (brackets (group arg-id (op ::) (parsed #:rhombus/annot annot)) ...
+                                            (group last-id (op ::) (parsed #:rhombus/annot last-annot)) ...
+                                            last-dots ...))
+        [all::binding
+         (annotation-binding-form #'all.parsed
+                                  #'(rhombus-expression (group List (brackets (group arg-id) ... (group last-id) ... last-dots ...)))
+                                  #`((#%index-result #,si)
+                                     . #,treelist-static-infos))])))
+  (relocate+reraw
+   (datum->syntax #f src-stxes)
+   (cond
+     [last-ann
+      (syntax-parse anns
+        [(ann::annotation-predicate-form ...)
+         #:with last-ann::annotation-predicate-form last-ann
+         (build-predicate-annotation base-pred
+                                     #'(ann.predicate ...)
+                                     #'(ann.static-infos ...)
+                                     #'last-ann.predicate
+                                     #'last-ann.static-infos)]
+        [(ann::annotation-binding-form ...)
+         #:with last-ann::annotation-binding-form last-ann
+         (build-converter-annotation base-pred
+                                     anns
+                                     #'(ann.static-infos ...)
+                                     #'last-ann
+                                     #'last-ann.static-infos)])]
+     [else
+      (syntax-parse anns
+        [(ann::annotation-predicate-form ...)
+         (build-predicate-annotation base-pred
+                                     #'(ann.predicate ...)
+                                     #'(ann.static-infos ...)
+                                     #f
+                                     #f)]
+        [(ann::annotation-binding-form ...)
+         (build-converter-annotation base-pred
+                                     anns
+                                     #'(ann.static-infos ...)
+                                     #f
+                                     #f)])])))

--- a/rhombus/rhombus/scribblings/guide/annotation-list.scrbl
+++ b/rhombus/rhombus/scribblings/guide/annotation-list.scrbl
@@ -1,0 +1,100 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    "../macro.rhm")
+
+@(def list_eval = macro.make_macro_eval())
+
+@title(~tag: "annotation-list"){List Annotations}
+
+As explained in @secref("list"), the @rhombus(List, ~annot) annotation
+matches any list, while @rhombus(List.of, ~annot) matches a list whose
+elements all satisfy another annotation.
+
+@examples(
+  ~eval: list_eval
+  [1, "two", #'three] is_a List
+  [1, "two", #'three] is_a List.of(String)
+  ["1", "two", "three"] is_a List.of(String)
+)
+
+The @rhombus(matching, ~annot) form can create an annotation that
+matches a list with a more specific shape, such as one that has an
+integer as its first element and a string as is second element. A
+@rhombus(List.tuple_of, ~annot) annotation is a kind of shorthand for a
+@rhombus(matching, ~annot) annotation with a list pattern and
+@rhombus(_, ~bind) wildcards. Using @brackets directly for an annotation
+(i.e., @rhombus(#%brackets, ~annot)) is an even more compact form that
+it is equivalent to using @rhombus(List.tuple_of, ~annot).
+
+@examples(
+  ~eval: list_eval
+  [1, "two"] is_a matching([_ :: Int, _ :: String])
+  [1, "two"] is_a List.tuple_of[Int, String]
+  [1, "two"] is_a [Int, String]
+  ["two", 1] is_a [Int, String]
+)
+
+A @rhombus(List.tuple_of, ~annot) or @brackets annotation can end with
+@rhombus(..., ~bind) to indicate zero or more elements that match the
+preceding annotation (but, unlike a list @rhombus(List, ~bind) pattern
+in @rhombus(matching, ~annot), the @rhombus(..., ~bind) is allowed only at
+the end of the annotation sequence). This means that
+@rhombus([String, ...], ~annot) is another way to write
+@rhombus(List.of(String), ~annot), for example.
+
+@examples(
+  ~eval: list_eval
+  ["1", "two"] is_a List.of(String)
+  ["1", "two"] is_a [String, ...]
+  [1, "two", "three"] is_a [Int, String, ...]
+)
+
+A @rhombus(List.tuple_of, ~annot) or @brackets annotation supplies
+element-specific static information, which is the sense in which it
+corresponds to a tuple. A tuple-style list annotation can be an
+alternative to @rhombus(values, ~annot), for example, that also works in
+contexts where @rhombus(values, ~annot) is not allowed.
+
+@examples(
+  ~eval: list_eval
+  use_static
+  fun enumerated(s :: String, ...) :~ [[Int, String], ...]:
+    for List (s in [s, ...],
+              i in 0 ..):
+      [i, s]
+  def strs = enumerated("a", "bb", "cccc")
+  strs
+  def [[i0, str0], [i1, str1], [i2, str2]] = strs
+  :
+    str0.length() // static call to String.length
+  str2.length()
+)
+
+A list construction using @rhombus(List) or @brackets propagates
+element-specific, tuple-style static information to pattern matching,
+but the @rhombus(List.get) or the @brackets indexing operation (i.e.,
+@rhombus(#%index)) is not statically sensitive to a literal index.
+
+@examples(
+  ~eval: list_eval
+  use_static
+  class Posn(x, y):
+    nonfinal
+  class Posn3D(z):
+    extends Posn
+  def ps && [p0, p1, p2] = [Posn(1, 2),
+                            Posn3D(4, 5, 6),
+                            Posn(7, 8)]
+  p0.x
+  p1.z
+  ~error:
+    p0.z
+  :
+    ps[1].x // because all elements are Posns
+  ~error:
+    :
+      ps[1].z // not all elements are Posn3Ds
+)
+
+@(close_eval(list_eval))

--- a/rhombus/rhombus/scribblings/guide/annotation-overview.scrbl
+++ b/rhombus/rhombus/scribblings/guide/annotation-overview.scrbl
@@ -12,3 +12,4 @@ and @secref("annotation"), and annotation macros are described in
 @include_section("annotation-maybe.scrbl")
 @include_section("annotation-satisfying.scrbl")
 @include_section("annotation-convert.scrbl")
+@include_section("annotation-list.scrbl")

--- a/rhombus/rhombus/scribblings/meta/static-info.scrbl
+++ b/rhombus/rhombus/scribblings/meta/static-info.scrbl
@@ -181,6 +181,49 @@
 
 @doc(
   ~meta
+  fun statinfo_meta.pack_index_result(
+    default_statinfo_stx :: maybe(Syntax),
+    [[key :: Any, statinfo_stx :: Syntax],
+     ...]
+  ) :: Syntax
+  fun statinfo_meta.unpack_index_result(call_stx :: Syntax)
+    :: values(maybe(Syntax), [[Any, Syntax], ...])
+  fun statinfo_meta.unpack_uniform_index_result(call_stx :: Syntax)
+    :: Syntax
+  fun statinfo_meta.unpack_index_result_at_index(call_stx :: Syntax,
+                                                 key :: Any)
+    :: Syntax
+){
+
+ Analogous to @rhombus(statinfo_meta.pack) and
+ @rhombus(statinfo_meta.unpack), but for information that represents an
+ indexing result via @rhombus([]) (i.e., @rhombus(#%index)).
+
+ In the simple case, the static information for indexing is packed
+ static information (in the sense of @rhombus(statinfo_meta.pack)) that
+ applies to all indices. In the more general case, a specific indexing
+ key can have specific packed information. The
+ @rhombus(statinfo_meta.pack_index_result) and
+ @rhombus(statinfo_meta.unpack_index_result) functions work on that
+ general form. The @rhombus(default_statinfo_stx) information applies to
+ any key that is not among the specifically listed @rhombus(key)s. If
+ @rhombus(default_statinfo_stx) is @rhombus(#false), the implication is
+ that only keys listed as @rhombus(key)s are available.
+
+ For an unknown index, the right static information is not just
+ @rhombus(default_statinfo_stx), but that information combined via
+ @rhombus(statinfo_meta.or) with all @rhombus(key)-specific
+ @rhombus(statinfo_stx)s. The
+ @rhombus(statinfo_meta.unpack_uniform_index_result) convenience function
+ performs that combination, while the
+ @rhombus(statinfo_meta.unpack_index_result_at_index) convenience
+ function extracts a key-specific value, if available, or uses
+ @rhombus(default_statinfo_stx) otherwise.
+
+}
+
+@doc(
+  ~meta
   fun statinfo_meta.lookup(expr_stx :: Syntax,
                            key :: Identifier)
     :: maybe(Syntax)
@@ -330,7 +373,8 @@
 
   @item{@rhombus(statinfo_meta.index_result_key): Packed static information
         for the result value if the expression is used with
-        @rhombus([]) to access an element.}
+        @rhombus([]) to access an element, potentially with static information
+        for specific index values. See @rhombus(statinfo_meta.unpack_index_result).}
 
   @item{@rhombus(statinfo_meta.index_get_key): An identifier bound to a
         function to call (instead of falling back to a generic dynamic

--- a/rhombus/rhombus/scribblings/reference/list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/list.scrbl
@@ -25,10 +25,41 @@ it supplies its elements in order.
 @doc(
   annot.macro 'List'
   annot.macro 'List.of($annot)'
+  annot.macro 'List.tuple_of[$annot, ..., $maybe_ellipsis]'
+  annot.macro '#%brackets [$annot, ..., $maybe_ellipsis]'
+  grammar maybe_ellipsis:
+    #,(epsilon)
+    $ellipsis
+  grammar ellipsis:
+    #,(dots)
 ){
 
- Matches any list in the form without @rhombus(of). The @rhombus(of)
- variant matches a list whose elements satisfy @rhombus(annot).
+ The @rhombus(List, ~annot) annotation by itself matches any list. The
+ @rhombus(List.of, ~annot) variant matches a list whose elements all satisfy
+ @rhombus(annot).
+
+ The @rhombus(List.tuple_of, ~annot) annotation matches a list whose
+ elements each match the corresponding @rhombus(annot). If the last
+ @rhombus(annot) is not followed by @rhombus(ellipsis), then the
+ annotation matches only lists that have the same number of elements as
+ the number of @rhombus(annot)s. If the last @rhombus(annot) is followed
+ by @rhombus(ellipsis), then the annotation matches lists that have at
+ least as many elements as @rhombus(annot)s except the last one, and all
+ additional elements must match the last @rhombus(annot). For example,
+ @rhombus(List.tuple_of[String, ...], ~annot) is the same as
+ @rhombus(List.of(String), ~annot). If any @rhombus(annot) is a
+ @tech(~doc: guide_doc){converter annotation}, then the
+ @rhombus(List.tuple_of, ~annot) annotation is also a converter
+ annotation where a converted list has converted elements. When all
+ @rhombus(annot)s are @tech(~doc: guide_doc){predicate annotations}, then
+ @rhombus(List.tuple_of(annot, ...), ~annot) is equivalent to
+ @rhombus(matching(List[_ :: annot, ...]), ~annot).
+
+ @see_implicit(@rhombus(#%brackets, ~annot), @brackets, "annotation")
+ A @rhombus(#%brackets, ~annot) annotation is equivalent to a
+ @rhombus(List.tuple_of, ~annot) annotation, so
+ @rhombus([String, ...], ~annot) is also the same as
+ @rhombus(List.of(String), ~annot).
 
  Static information associated by @rhombus(List, ~annot) or
  @rhombus(List.of, ~annot) makes an expression acceptable as a sequence

--- a/rhombus/rhombus/scribblings/reference/pair.scrbl
+++ b/rhombus/rhombus/scribblings/reference/pair.scrbl
@@ -115,10 +115,21 @@ which case it supplies its elements in order.
 @doc(
   annot.macro 'PairList'
   annot.macro 'PairList.of($annot)'
+  annot.macro 'PairList.tuple_of[$annot, ..., $maybe_ellipsis]'
+  grammar maybe_ellipsis:
+    #,(epsilon)
+    $ellipsis
+  grammar ellipsis:
+    #,(dots)
+
 ){
 
- Matches any @tech{pair list} in the form without @rhombus(of). The @rhombus(of)
- variant matches a pair list whose elements satisfy @rhombus(annot).
+ The @rhombus(PairList, ~annot) annotation by itself matches any
+ @tech{pair list}. The @rhombus(PairList.of, ~annot) variant matches a
+ pair list whose elements all satisfy @rhombus(annot).
+
+ The @rhombus(PairList.tuple_of, ~annot) annotation is analogous to the
+ @rhombus(List.tuple_of, ~annot) annotation, but for pair lists.
 
  Static information associated by @rhombus(PairList, ~annot) or
  @rhombus(PairList.of, ~annot) makes an expression acceptable as a sequence

--- a/rhombus/rhombus/tests/list.rhm
+++ b/rhombus/rhombus/tests/list.rhm
@@ -1007,3 +1007,49 @@ check:
   ~throws values("length",
                  "no such field or method",
                  "based on static information")
+
+block:
+  use_static
+  let [x, y] :: [String, String] = dynamic(["a", "b"])
+  check x.length() ~is 1
+  check y.length() ~is 1
+
+block:
+  use_static
+  let xs :: [String, ...] = dynamic(["a", "bb"])
+  check xs[0].length() ~is 1
+  check xs[1].length() ~is 2
+
+block:
+  use_static
+  let xs :: List.tuple_of[String, ...] = dynamic(["a", "bb"])
+  check xs[0].length() ~is 1
+  check xs[1].length() ~is 2
+
+block:
+  use_static
+  let ps :: [[Bytes, String], ...] = dynamic([[#"a", "a"], [#"bb", "bb"]])
+  check ps[0].length() ~is 2
+  let [[pa, pa2], [pb, pb2]] = ps
+  check pa.length() ~is 1
+  check pa2.length() ~is 1
+  check pb.length() ~is 2
+  check pb2.length() ~is 2
+
+block:
+  use_static
+  let ps = [[#"a", "a"], [#"bb", "bb"]]
+  check ps[0].length() ~is 2
+  let [[pa, pa2], [pb, pb2]] = ps
+  check pa.length() ~is 1
+  check pa2.length() ~is 1
+  check pb.length() ~is 2
+  check pb2.length() ~is 2
+
+block:
+  use_static
+  class Posn(x, y): nonfinal
+  class Posn3D(z): extends Posn
+  let [x, y, ...] :: [Posn3D, Posn, ...] = dynamic([Posn3D(1, 2, 3), Posn(4, 5), Posn(6, 7)])
+  check x.z ~is 3
+  check [y.y, ...] ~is [5, 7]

--- a/rhombus/rhombus/tests/map.rhm
+++ b/rhombus/rhombus/tests/map.rhm
@@ -167,56 +167,56 @@ block:
     Map([1, "1", "oops"])
     ~throws values(
       "Map: " ++ error.annot_msg(),
-      error.annot("Listable.to_list && matching([_, _])").msg,
+      error.annot("Listable.to_list && [Any, Any]").msg,
       "[1, \"1\", \"oops\"]",
     )
   check:
     Map(PairList[1, "1", "oops"])
     ~throws values(
       "Map: " ++ error.annot_msg(),
-      error.annot("Listable.to_list && matching([_, _])").msg,
+      error.annot("Listable.to_list && [Any, Any]").msg,
       "PairList[1, \"1\", \"oops\"]",
     )
   check:
     Map(Array(1, "1", "oops"))
     ~throws values(
       "Map: " ++ error.annot_msg(),
-      error.annot("Listable.to_list && matching([_, _])").msg,
+      error.annot("Listable.to_list && [Any, Any]").msg,
       "Array(1, \"1\", \"oops\")",
     )
   check:
     Map(Broken())
     ~throws values(
       "Map: " ++ error.annot_msg(),
-      error.annot("Listable.to_list && matching([_, _])").msg,
+      error.annot("Listable.to_list && [Any, Any]").msg,
       "Broken()",
     )
   check:
     MutableMap([1, "1", "oops"])
     ~throws values(
       "MutableMap: " ++ error.annot_msg(),
-      error.annot("Listable.to_list && matching([_, _])").msg,
+      error.annot("Listable.to_list && [Any, Any]").msg,
       "[1, \"1\", \"oops\"]",
     )
   check:
     MutableMap(PairList[1, "1", "oops"])
     ~throws values(
       "MutableMap: " ++ error.annot_msg(),
-      error.annot("Listable.to_list && matching([_, _])").msg,
+      error.annot("Listable.to_list && [Any, Any]").msg,
       "PairList[1, \"1\", \"oops\"]",
     )
   check:
     MutableMap(Array(1, "1", "oops"))
     ~throws values(
       "MutableMap: " ++ error.annot_msg(),
-      error.annot("Listable.to_list && matching([_, _])").msg,
+      error.annot("Listable.to_list && [Any, Any]").msg,
       "Array(1, \"1\", \"oops\")",
     )
   check:
     MutableMap(Broken())
     ~throws values(
       "MutableMap: " ++ error.annot_msg(),
-      error.annot("Listable.to_list && matching([_, _])").msg,
+      error.annot("Listable.to_list && [Any, Any]").msg,
       "Broken()",
     )
 

--- a/rhombus/rhombus/tests/pair.rhm
+++ b/rhombus/rhombus/tests/pair.rhm
@@ -183,3 +183,16 @@ block:
   def p = Pair("a", #"bb")
   check Pair.first(p).length() ~is 1
   check Pair.rest(p).length() ~is 2
+
+block:
+  use_static
+  let PairList[x, y] :: PairList.tuple_of[String, String] = dynamic(PairList["a", "bb"])
+  check x.length() ~is 1
+  check y.length() ~is 2
+
+block:
+  use_static
+  let xs :: PairList.tuple_of[String, ...] = dynamic(PairList["a", "bb"])
+  check xs[0].length() ~is 1
+  check xs[1].length() ~is 2
+


### PR DESCRIPTION
Improve support for lists as tuples by allowing `[]` as an annotation. An annotation `[annot, ...]` or `List.tuple_of[annot, ...]` is equivalent to `matching([_ :: annot, ...])`, and both of those forms now preserve index-specific static information. For example, `def [i, s] = [10 , "y"]` binds `i` with static information for `Int` and `s` with static information for `String`.

Adapted form the updated Guide:

The `List` annotation matches any list, while `List.of` matches a list
whose elements all satisfy another annotation.

```
> [1, "two", #'three] is_a List
#true
> [1, "two", #'three] is_a List.of(String)
#false
> ["1", "two", "three"] is_a List.of(String)
#true
```

The `matching` form can create an annotation that matches a list with a
more specific shape, such as one that has an integer as its first
element and a string as is second element. A `List.tuple_of` annotation
is a kind of shorthand for a `matching` annotation with a list pattern
and `_` wildcards. Using `[`…`]` directly for an annotation \(i.e.,
`#%brackets`) is an even more compact form that it is equivalent to
using `List.tuple_of`.

```
> [1, "two"] is_a matching([_ :: Int, _ :: String])
#true
> [1, "two"] is_a List.tuple_of[Int, String]
#true
> [1, "two"] is_a [Int, String]
#true
> ["two", 1] is_a [Int, String]
#false
```

A `List.tuple_of` or `[`…`]` annotation can end with `...` to indicate
zero or more elements that match the preceding annotation (but, unlike a
list `List` pattern in `matching`, the `...` is allowed only at the end
of the annotation sequence). This means that `[String`, `...]` is
another way to write `List.of(String)`, for example.

```
> ["1", "two"] is_a List.of(String)
#true
> ["1", "two"] is_a [String, ...]
#true
> [1, "two", "three"] is_a [Int, String, ...]
#true
```

A `List.tuple_of` or `[`…`]` annotation supplies element-specific static
information, which is the sense in which it corresponds to a tuple. A
tuple-style list annotation can be an alternative to `values`, for
example, that also works in contexts where `values` is not allowed.

```
> use_static
> fun enumerated(s :: String, ...) :~ [[Int, String], ...]:
    for List (s in [s, ...],
              i in 0 ..):
      [i, s]
> def strs = enumerated("a", "bb", "cccc")
> strs
[[0, "a"], [1, "bb"], [2, "cccc"]]
> def [[i0, str0], [i1, str1], [i2, str2]] = strs
> str0.length() // static call to String.length
1
> str2.length()
4
```

A list construction using `List` or `[`…`]` propagates element-specific,
tuple-style static information to pattern matching, but the `List.get`
or the `[`…`]` indexing operation (i.e., `#%index`) is not statically
sensitive to a literal index.

```
> use_static
> class Posn(x, y):
    nonfinal
> class Posn3D(z):
    extends Posn
> def ps && [p0, p1, p2] = [Posn(1, 2),
                            Posn3D(4, 5, 6),
                            Posn(7, 8)]
> p0.x
1
> p1.z
6
> p0.z
z: no such field or method (based on static information)
> ps[1].x // because all elements are Posns
4
> ps[1].z // not all elements are Posn3Ds
z: no such field or method (based on static information)
```
