### PR TITLE
class: bind inherited nams using superclass or interface reference

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/class-clause-parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-clause-parse.rkt
@@ -49,16 +49,16 @@
           (define clause (car clauses))
           (define new-options
             (syntax-parse clause
-              [(#:extends id)
+              [(#:extends (id name))
                (when (hash-has-key? options 'extends)
                  (raise-syntax-error #f "multiple extension clauses" orig-stx #'id))
-               (hash-set options 'extends #'id)]
-              [(#:implements id ...)
-               (add-implements options 'public-implements #'(id ...))]
-              [(#:private-implements id ...)
-               (add-implements options 'private-implements #'(id ...))]
-              [(#:protected-implements id ...)
-               (add-implements options 'protected-implements #'(id ...))]
+               (hash-set (hash-set options 'extends #'id) 'extends-name #'name)]
+              [(#:implements (id name) ...)
+               (add-implements options 'public-implements #'(id ...) #'(name ...))]
+              [(#:private-implements (id name) ...)
+               (add-implements options 'private-implements #'(id ...) #'(name ...))]
+              [(#:protected-implements (id name) ...)
+               (add-implements options 'protected-implements #'(id ...) #'(name ...))]
               [(#:internal id)
                (hash-set options 'internals (cons #'id (hash-ref options 'internals '())))]
               [(#:annotation block)
@@ -109,14 +109,14 @@
           (define clause (car clauses))
           (define new-options
             (syntax-parse clause
-              [(#:extends id) ; checked in `parse-annotation-options`
-               (hash-set options 'extends #'id)]
-              [(#:implements id ...)
-               (add-implements options 'public-implements #'(id ...))]
-              [(#:private-implements id ...)
-               (add-implements options 'private-implements #'(id ...))]
-              [(#:protected-implements id ...)
-               (add-implements options 'protected-implements #'(id ...))]
+              [(#:extends (id name)) ; checked in `parse-annotation-options`
+               (hash-set (hash-set options 'extends #'id) 'extends-name #'name)]
+              [(#:implements (id name) ...)
+               (add-implements options 'public-implements #'(id ...) #'(name ...))]
+              [(#:private-implements (id name) ...)
+               (add-implements options 'private-implements #'(id ...) #'(name ...))]
+              [(#:protected-implements (id name) ...)
+               (add-implements options 'protected-implements #'(id ...) #'(name ...))]
               [(#:internal id)
                (hash-set options 'internals (cons #'id (hash-ref options 'internals '())))]
               [(#:constructor id forward-rets rhs)
@@ -319,10 +319,12 @@
     [_
      (raise-syntax-error #f "unrecognized clause" orig-stx clause)]))
 
-(define-for-syntax (add-implements options extra-key ids-stx)
+(define-for-syntax (add-implements options extra-key ids-stx names-stx)
   (define l (reverse (syntax->list ids-stx)))
+  (define names-l (reverse (syntax->list names-stx)))
   (define new-options
-    (hash-set options 'implements (append l (hash-ref options 'implements '()))))
+    (hash-set (hash-set options 'implements (append l (hash-ref options 'implements '())))
+              'implements-name (append names-l (hash-ref options 'implements-name '()))))
   (if extra-key
       (hash-set new-options extra-key (append l (hash-ref new-options extra-key '())))
       new-options))
@@ -377,27 +379,27 @@
   (for/list ([a (in-list (reverse (syntax->list accum)))]
              #:do [(define v
                      (syntax-parse a
-                       [(#:extends id) (if (eq? key 'extends)
-                                           (list #'id)
-                                           null)]
-                       [(#:implements id ...) (case key
-                                                [(implements)
-                                                 (syntax->list #'(id ...))]
-                                                [(implements_visibilities)
-                                                 '(public)]
-                                                [else null])]
-                       [(#:private-implements id ...) (case key
-                                                        [(implements)
-                                                         (syntax->list #'(id ...))]
-                                                        [(implements_visibilities)
-                                                         '(private)]
-                                                        [else null])]
-                       [(#:protected-implements id ...) (case key
-                                                          [(implements)
-                                                           (syntax->list #'(id ...))]
-                                                          [(implements_visibilities)
-                                                           '(protected)]
-                                                          [else null])]
+                       [(#:extends (id name)) (if (eq? key 'extends)
+                                                  (list #'id)
+                                                  null)]
+                       [(#:implements (id name) ...) (case key
+                                                       [(implements)
+                                                        (syntax->list #'(id ...))]
+                                                       [(implements_visibilities)
+                                                        '(public)]
+                                                       [else null])]
+                       [(#:private-implements (id name) ...) (case key
+                                                               [(implements)
+                                                                (syntax->list #'(id ...))]
+                                                               [(implements_visibilities)
+                                                                '(private)]
+                                                               [else null])]
+                       [(#:protected-implements (id name) ...) (case key
+                                                                 [(implements)
+                                                                  (syntax->list #'(id ...))]
+                                                                 [(implements_visibilities)
+                                                                  '(protected)]
+                                                                 [else null])]
                        [(#:field mutability id rhs-id ann-seq default form-id mode)
                         (case key
                           [(field-names) (list #'id)]

--- a/rhombus-lib/rhombus/private/amalgam/class-clause-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-clause-primitive.rkt
@@ -79,7 +79,10 @@
                #:context stx
                [() null]
                [(~var id (:hier-name-seq in-name-root-space in-class-desc-space name-path-op name-root-ref))
-                (cons #'id.name (loop #'id.tail))])))))
+                (syntax-parse #'id.head
+                  [(_ ... last-name)
+                   (cons #'(id.name last-name)
+                         (loop #'id.tail))])])))))
 
 (define-for-syntax parse-class-extends
   (lambda (stx data)

--- a/rhombus-lib/rhombus/private/amalgam/class-method.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-method.rkt
@@ -86,7 +86,7 @@
 
 ;; Results:
 ;;   method-mindex   ; symbol -> mindex
-;;   method-names    ; index -> symbol-or-identifier; symbol is inherited
+;;   method-names    ; index -> identifier
 ;;   method-vtable   ; index -> function-identifier or '#:abstract
 ;;   method-results  ; symbol -> nonempty list of identifiers; first one implies others
 ;;   method-private  ; symbol -> identifier or (list identifier); list means property; non-super symbol's identifier attached as 'lhs-id
@@ -94,10 +94,11 @@
 ;;   method-decls    ; symbol -> identifier, intended for checking distinct
 ;;   abstract-name   ; #f or identifier for a still-abstract method
 
-(define-for-syntax (extract-method-tables stx added-methods super interfaces
+(define-for-syntax (extract-method-tables stx added-methods super interfaces super-src-name interface-src-names
                                           private-interfaces protected-interfaces
                                           final? prefab?)
   (define supers (if super (cons super interfaces) interfaces))
+  (define super-src-names (if super-src-name (cons super-src-name interface-src-names) interface-src-names))
   (define-values (super-str supers-str)
     (cond
       [(null? interfaces)
@@ -124,7 +125,8 @@
                   vtable-ht     ; int -> accessor-identifier or '#:abstract
                   from-ht)      ; symbol -> super
     (for/fold ([ht #hasheq()] [priv-ht #hasheq()] [priv-inherit-ht #hasheq()] [vtable-ht #hasheqv()] [from-ht #hasheq()])
-              ([super (in-list supers)])
+              ([super (in-list supers)]
+               [super-src-name (in-list super-src-names)])
       (define super-vtable (syntax-e (objects-desc-method-vtable super)))
       (define private? (hash-ref private-interfaces super #f))
       (define i-protected? (hash-ref protected-interfaces super #f))
@@ -149,7 +151,7 @@
                           (mindex-index (car old-val))
                           (hash-count ht)))
             (values shape
-                    (cons (mindex i final? protected? property? arity #t #f) shape)
+                    (cons (mindex i final? protected? property? arity #t #f) (datum->syntax super-src-name shape))
                     i
                     old-val
                     final?
@@ -916,22 +918,16 @@
                        [(recon-field-accessor recon-field-rhs) ...]
                        serializable)
                  names])
-    (with-syntax ([(field-name ...) (for/list ([id/l (in-list (syntax->list #'(field-name ...)))])
-                                      (if (identifier? id/l)
-                                          (datum->syntax #'name (syntax-e id/l) id/l id/l)
-                                          (car (syntax-e id/l))))]
-                  [(super-protected-field-name ...) (for/list ([id (in-list (syntax->list #'(super-protected-field-name ...)))])
-                                                      (datum->syntax #'name (syntax-e id) id id))]
-                  [((method-name method-index/id method-result-id method-kind) ...)
+    (with-syntax ([((method-name method-index/id method-result-id method-kind) ...)
                    (for/list ([i (in-range (hash-count method-mindex))])
                      (define raw-m-name (hash-ref method-names i))
-                     (define m-name (if (syntax? raw-m-name)
-                                        (syntax-e raw-m-name)
-                                        raw-m-name))
+                     (define m-name (syntax-e raw-m-name))
                      (define mix (hash-ref method-mindex m-name))
                      ;; We use `raw-m-name` to support local references
-                     ;; to macro-introduced methods
-                     (list (datum->syntax #'name raw-m-name)
+                     ;; to macro-introduced methods; in the case of an
+                     ;; inherited name, it will have the scopes of the
+                     ;; named superclass or superinterface
+                     (list raw-m-name
                            (let ([idx (mindex-index mix)])
                              (cond
                                [veneer-vtable

--- a/rhombus-lib/rhombus/private/amalgam/class.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class.rkt
@@ -336,9 +336,11 @@
        (define stxes #'orig-stx)
        (define options (parse-options #'orig-stx #'(option ...) #'(stx-params ...)))
        (define parent-name (hash-ref options 'extends #f))
+       (define parent-src-name (hash-ref options 'extends-name #f))
        (define super (and parent-name
                           (syntax-local-value* (in-class-desc-space parent-name) class-desc-ref)))
        (define interface-names (reverse (hash-ref options 'implements '())))
+       (define interface-src-names (reverse (hash-ref options 'implements-name '())))
        (define-values (all-interfaces interfaces) (interface-names->interfaces stxes interface-names
                                                                                #:results values))
        (define-values (private-interfaces protected-interfaces)
@@ -478,14 +480,14 @@
 
        (define added-methods (reverse (hash-ref options 'methods '())))
        (define-values (method-mindex   ; symbol -> mindex
-                       method-names    ; index -> symbol-or-identifier
+                       method-names    ; index -> identifier
                        method-vtable   ; index -> function-identifier or '#:abstract
                        method-results  ; symbol -> nonempty list of identifiers; first one implies others
                        method-private  ; symbol -> identifier or (list identifier)
                        method-private-inherit ; symbol -> (vector ref-id index maybe-result-id)
                        method-decls    ; symbol -> identifier, intended for checking distinct
                        abstract-name)  ; #f or identifier for a still-abstract method
-         (extract-method-tables stxes added-methods super interfaces
+         (extract-method-tables stxes added-methods super interfaces parent-src-name interface-src-names
                                 private-interfaces protected-interfaces
                                 final? prefab?))
 
@@ -594,7 +596,9 @@
                         super-field-argument)
                        ...)
                       (if super
-                          (class-desc-fields super)
+                          (for/list ([field (in-list (class-desc-fields super))])
+                            (cons (datum->syntax parent-name (car field))
+                                  (cdr field)))
                           '())]
                      [(super-field-keyword ...) super-keywords]
                      [(export ...) exs])
@@ -686,7 +690,7 @@
                        [super-protected-flds (if (and super (class-desc-all-fields super))
                                                  (for/list ([a-field (in-list (class-desc-all-fields super))]
                                                             #:when (protect? a-field))
-                                                   (protect-v a-field))
+                                                   (datum->syntax parent-name (protect-v a-field)))
                                                  null)]
                        [serializable serializable])
            (define defns
@@ -701,7 +705,7 @@
                               #'(name reflect-name name? #f reconstructor-name serializer-name
                                       prop-methods-ref
                                       all-static-infos
-                                      [(field-name) ... super-field-name ...]
+                                      [field-name ... super-field-name ...]
                                       [field-static-infos ... super-field-static-infos ...]
                                       [name-field ... super-name-field ...]
                                       [maybe-set-name-field! ... super-maybe-set-name-field! ...]
@@ -975,7 +979,7 @@
                              ([v (in-vector method-vtable)]
                               [i (in-naturals)])
                      (define name (hash-ref method-names i))
-                     (define mix (hash-ref method-mindex (if (syntax? name) (syntax-e name) name)))
+                     (define mix (hash-ref method-mindex (syntax-e name)))
                      (cond
                        [(mindex-protected? mix)
                         ;; omit from dynamic-dispatch table

--- a/rhombus-lib/rhombus/private/amalgam/interface-clause-parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/interface-clause-parse.rkt
@@ -25,9 +25,12 @@
             (syntax-parse clause
               [(#:internal id)
                (hash-set options 'internals (cons #'id (hash-ref options 'internals '())))]
-              [(#:extends id ...)
-               (hash-set options 'extends (append (reverse (syntax->list #'(id ...)))
-                                                  (hash-ref options 'extends '())))]
+              [(#:extends (id name) ...)
+               (hash-set
+                (hash-set options 'extends (append (reverse (syntax->list #'(id ...)))
+                                                   (hash-ref options 'extends '())))
+                'extends-name (append (reverse (syntax->list #'(name ...)))
+                                      (hash-ref options 'extends-name '())))]
               [(#:annotation block)
                (when (hash-has-key? options 'annotation-rhs)
                  (raise-syntax-error #f "multiple annotation clauses" orig-stx clause))
@@ -59,9 +62,12 @@
             (syntax-parse clause
               [(#:internal id) ; checked in `parse-annotation-options`
                (hash-set options 'internals (cons #'id (hash-ref options 'internals #'id)))]
-              [(#:extends id ...)
-               (hash-set options 'extends (append (reverse (syntax->list #'(id ...)))
-                                                  (hash-ref options 'extends '())))]
+              [(#:extends (id name) ...)
+               (hash-set
+                (hash-set options 'extends (append (reverse (syntax->list #'(id ...)))
+                                                   (hash-ref options 'extends '())))
+                'extends-name (append (reverse (syntax->list #'(name ...)))
+                                      (hash-ref options 'extends-name '())))]
               [(#:implementable id) ; checked in `parse-annotation-options`
                (hash-set options 'implementable #'id)]
               [(#:expression rhs)

--- a/rhombus-lib/rhombus/private/amalgam/interface.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/interface.rkt
@@ -225,19 +225,21 @@
           [option stx-param] ...)
        (define stxes #'orig-stx)
        (define options (parse-options #'orig-stx #'(option ...) #'(stx-param ...)))
-       (define supers (interface-names->interfaces stxes (reverse (hash-ref options 'extends '()))))
+       (define super-names (reverse (hash-ref options 'extends '())))
+       (define super-src-names (reverse (hash-ref options 'extends-name '())))
+       (define supers (interface-names->interfaces stxes super-names))
        (define parent-names (map interface-desc-id supers))
        (define primitive-properties (hash-ref options 'primitive-properties '()))
        (define added-methods (reverse (hash-ref options 'methods '())))
        (define-values (method-mindex   ; symbol -> mindex
-                       method-names    ; index -> symbol-or-identifier
+                       method-names    ; index -> identifier
                        method-vtable   ; index -> function-identifier or '#:abstract
                        method-results  ; symbol -> nonempty list of identifiers; first one implies others
                        method-private  ; symbol -> identifier or (list identifier)
                        method-private-inherit ; symbol -> (vector ref-id index maybe-result-id)
                        method-decls    ; symbol -> identifier, intended for checking distinct
                        abstract-name)  ; #f or identifier
-         (extract-method-tables stxes added-methods #f supers
+         (extract-method-tables stxes added-methods #f supers #f super-src-names
                                 #hasheq() #hasheq()
                                 #f #f))
 

--- a/rhombus-lib/rhombus/private/amalgam/veneer.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/veneer.rkt
@@ -253,14 +253,14 @@
 
        (define added-methods (reverse (hash-ref options 'methods '())))
        (define-values (method-mindex   ; symbol -> mindex
-                       method-names    ; index -> symbol-or-identifier
+                       method-names    ; index -> identifier
                        method-vtable   ; index -> function-identifier or '#:abstract
                        method-results  ; symbol -> nonempty list of identifiers; first one implies others
                        method-private  ; symbol -> identifier or (list identifier)
                        method-private-inherit ; symbol -> (vector ref-id index maybe-result-id)
                        method-decls    ; symbol -> identifier, intended for checking distinct
                        abstract-name)  ; #f or identifier for a still-abstract method
-         (extract-method-tables stxes added-methods super interfaces
+         (extract-method-tables stxes added-methods super interfaces parent-name interface-names
                                 private-interfaces protected-interfaces
                                 final? #f))
 

--- a/rhombus/rhombus/scribblings/reference/class.scrbl
+++ b/rhombus/rhombus/scribblings/reference/class.scrbl
@@ -618,7 +618,9 @@
  directly is the same as using @rhombus(this) and @rhombus(.) in static
  mode (which implies that a direct reference to a method name must be a
  call of the method). An argument that has the same name as a field,
- method, or property shadows the field, method, or property.
+ method, or property shadows the field, method, or property. Inherited methods
+ are bound using same scopes as the reference to the relevant superclass
+ or superinterface.
 
  A @rhombus(~doc) @rhombus(option) is similarly analogous to
  @rhombus(~doc) within a @rhombus(fun, ~defn) definition, but a

--- a/rhombus/rhombus/tests/class-together.rhm
+++ b/rhombus/rhombus/tests/class-together.rhm
@@ -106,3 +106,26 @@ block:
     A().b() ~throws "A.b: " ++ error.annot_msg("result")
     B().c() ~throws "B.c: " ++ error.annot_msg("result")
     C().a() ~throws "C.a: " ++ error.annot_msg("result")
+
+class.together:
+  class A(s :~ String):
+    nonfinal
+
+    property t: "this is t"
+
+    method u():
+      "uuuu"
+
+    protected method u2(): "u2"
+    protected field s2 = "s2"
+
+  class B():
+    extends A
+
+    protected method u3(): "u3"
+    protected field s3 = "s3"
+
+    method foo():
+      [s, s2, s3, t, u(), u2(), u3()]
+
+check B("str").foo() ~is ["str", "s2", "s3", "this is t", "uuuu", "u2", "u3"]


### PR DESCRIPTION
In issue #793, the problem is that `class.together` changes each `class` form to define a name that is hidden by scopes, and then introduce the original name as an alias. Meanwhile, inherited fields and methods are bound using the defined class name. This commit changes inherited names and fields to be bound using the reference to a superclass or interface, instead. That avoids a problem with `class.together` specifically, but also seems like more the right choice in general.

This is a backward-incompatible change. I'm not expecting any current programs to break, but it's possible. In particular, there could be Rhombus programs already that macro-introduce a superclass or interface reference, and this change will cause inherited field and method names to be bound as macro-introduced.