### PR TITLE
add `annot` definition form and `annot.def`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annot-def.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annot-def.rkt
@@ -1,0 +1,108 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     "group.rkt")
+         "definition.rkt"
+         (submod "annotation.rkt" for-class)
+         "binding.rkt"
+         "dotted-sequence-parse.rkt"
+         (submod "equal.rkt" for-parse)
+         "parens.rkt"
+         "static-info.rkt"
+         "indirect-static-info-key.rkt"
+         "if-blocked.rkt")
+
+(provide (for-space rhombus/defn
+                    annot.def))
+
+(define-defn-syntax annot.def
+  (definition-transformer
+    (lambda (stx name-prefix effect-id)
+      (define (parse form-id lhs rhs)
+        (syntax-parse lhs
+          [name::dotted-identifier
+           (syntax-parse rhs
+             [a::annotation
+              (syntax-parse #'a.parsed
+                [a::annotation-predicate-form
+                 #`((define ann-pred a.predicate)
+                    (define-static-info-syntax ann-si . a.static-infos)
+                    #,(build-syntax-definition/maybe-extension
+                       'rhombus/annot #'name.name #'name.extends
+                       #'(identifier-annotation ann-pred ((#%indirect-static-info ann-si)))
+                       #:form form-id))]
+                [a::annotation-binding-form
+                 #:with arg-parsed::binding-form #'a.binding
+                 #:with arg-impl::binding-impl #`(arg-parsed.infoer-id () arg-parsed.data)
+                 #:with arg-info::binding-info #'arg-impl.info
+                 #:with ((bind-id bind-use . bind-static-infos) ...) #'arg-info.bind-infos
+                 #`((define (ann-converter v)
+                      (let* ([tmp-id (let ([arg-info.name-id v])
+                                       arg-info.name-id)])
+                        (arg-info.oncer-id arg-info.data)
+                        (arg-info.matcher-id tmp-id
+                                             arg-info.data
+                                             if/blocked
+                                             (lambda ()
+                                               (arg-info.committer-id tmp-id arg-info.evidence-ids arg-info.data)
+                                               (arg-info.binder-id tmp-id arg-info.evidence-ids arg-info.data)
+                                               (define-static-info-syntax/maybe bind-id . bind-static-infos)
+                                               ...
+                                               a.body)
+                                             #f)))
+                    (define-static-info-syntax ann-si . a.static-infos)
+                    #,(build-syntax-definition/maybe-extension
+                       'rhombus/annot #'name.name #'name.extends
+                       #'(identifier-binding-annotation #,(binding-form #'annot-def-infoer
+                                                                        #'(ann-converter result ann-si arg-info.matcher-id))
+                                                        result
+                                                        ((#%indirect-static-info ann-si)))
+                       #:form form-id))])])]))
+      (syntax-parse stx
+        #:datum-literals (op |.|)
+        [(form-id (op |.|) . _)
+         (raise-syntax-error #f
+                             "not defined or imported as a namespace"
+                             #'form-id)]
+        [(form-id lhs ...+ _::equal rhs ...+)
+         (check-multiple-equals stx)
+         (parse #'form-id #'(lhs ...) (regroup #'(rhs ...)))]
+        [(form-id lhs ...+ (~and blk (_::block rhs-g more-g ...)))
+         (unless (null? (attribute more-g))
+           (raise-syntax-error #f
+                               "expected a block with a single group"
+                               stx
+                               #'blk))
+         (parse #'form-id #'(lhs ...) #'rhs-g)]))))
+
+(define-syntax (annot-def-infoer stx)
+  (syntax-parse stx
+    [(_ static-infos (converter-id result-id ann-si left-matcher-id))
+     (binding-info "annot"
+                   #'v
+                   (static-infos-and #'static-infos #'((#%indirect-static-info ann-si)))
+                   #'((result-id ([#:repet ()])))
+                   #'empty-oncer
+                   (if (free-identifier=? #'always-succeed #'left-matcher-id)
+                       #'always-succeed
+                       #'annot-def-matcher)
+                   #'thunk
+                   #'annot-def-committer
+                   #'annot-def-binder
+                   #'[thunk converter-id result-id])]))
+
+(define-syntax (annot-def-matcher stx)
+  (syntax-parse stx
+    [(_ arg-id [thunk converter-id result-id]
+        IF success fail)
+     #'(begin
+         (define thunk (converter-id arg-id))
+         (IF thunk success fail))]))
+
+(define-syntax (annot-def-committer stx)
+  #'(begin))
+
+(define-syntax (annot-def-binder stx)
+  (syntax-parse stx
+    [(_ arg-id thunk-id [thunk converter-id result-id])
+     #'(define result-id (thunk-id))]))

--- a/rhombus-lib/rhombus/private/amalgam/annot-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annot-macro.rkt
@@ -29,7 +29,8 @@
          "macro-macro.rkt"
          "wrap-expression.rkt"
          "annot-delayed.rkt"
-         "operator-compare.rkt")
+         "operator-compare.rkt"
+         "annot-def.rkt")
 
 (provide (for-syntax (for-space rhombus/namespace
                                 annot_meta)))
@@ -40,6 +41,8 @@
 (define+provide-space annot rhombus/annot
   #:fields
   (macro
+   ;; "annot-def.rkt"
+   [def annot.def]
    ;; "annot-delayed.rkt"
    delayed_declare
    delayed_complete))

--- a/rhombus-lib/rhombus/private/amalgam/annot.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annot.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+(require "annot-def.rkt")
+
+(provide (for-space rhombus/defn
+                    (rename-out [annot.def annot])))

--- a/rhombus-lib/rhombus/private/amalgam/core.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core.rkt
@@ -171,7 +171,8 @@
         "srcloc-object.rkt"
         "stream.rkt"
         "weak-box.rkt"
-        "ephemeron.rkt")
+        "ephemeron.rkt"
+        "annot.rkt")
 
 (module reader racket/base
   (require (submod rhombus/private/core reader))

--- a/rhombus/rhombus/scribblings/guide/annotation-convert.scrbl
+++ b/rhombus/rhombus/scribblings/guide/annotation-convert.scrbl
@@ -61,9 +61,9 @@ sorted.
 @examples(
   ~eval: bind_eval
   ~defn:
-    annot.macro 'AscendingIntList':
-      'converting(fun (ints :: List.of(Int)) :: List:
-                    ints.sort())'
+    annot AscendingIntList:
+      converting(fun (ints :: List.of(Int)) :: List:
+                   ints.sort())
   ~repl:
     [3, 1, 2] :: AscendingIntList
     fun descending(ints :: AscendingIntList):
@@ -91,9 +91,9 @@ elements, rather than checking and converting separately.
 @examples(
   ~eval: bind_eval
   ~defn:
-    annot.macro 'UTF8BytesAsString_oops':
-      'converting(fun (s :: Bytes):
-                    Bytes.utf8_string(s))'
+    annot UTF8BytesAsString_oops:
+      converting(fun (s :: Bytes):
+                   Bytes.utf8_string(s))
 
   ~repl:
     #"\316\273" :: UTF8BytesAsString_oops
@@ -102,21 +102,21 @@ elements, rather than checking and converting separately.
       #"\316" :: UTF8BytesAsString_oops
 
   ~defn:
-    annot.macro 'MaybeUTF8BytesAsString':
-      'converting(fun (s :: Bytes):
-                    try:
-                      Bytes.utf8_string(s)
-                      ~catch _: #false)'
+    annot MaybeUTF8BytesAsString:
+      converting(fun (s :: Bytes):
+                   try:
+                     Bytes.utf8_string(s)
+                     ~catch _: #false)
 
   ~repl:
     #"\316\273" :: MaybeUTF8BytesAsString
     #"\316" :: MaybeUTF8BytesAsString
 
   ~defn:
-    annot.macro 'UTF8BytesAsString':
+    annot UTF8BytesAsString:
       // matches only when `MaybeUTF8BytesAsString` produces a string
-      'converting(fun (str :: (MaybeUTF8BytesAsString && String)):
-                    str)'
+      converting(fun (str :: (MaybeUTF8BytesAsString && String)):
+                   str)
   ~repl:
     #"\316\273" :: UTF8BytesAsString
     #"\316" is_a UTF8BytesAsString

--- a/rhombus/rhombus/scribblings/guide/annotation-def.scrbl
+++ b/rhombus/rhombus/scribblings/guide/annotation-def.scrbl
@@ -1,0 +1,31 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    "../macro.rhm")
+
+@(def bind_eval = macro.make_macro_eval())
+
+@title(~tag: "annotation-def"){Defining Annotations}
+
+The @rhombus(annot, ~defn) form defines a new annotation in terms of
+existing annotations.
+
+@examples(
+  ~defn:
+    annot EvenInt = Int && satisfying(fun (x): x mod 2 == 0)
+  ~repl:
+    10 :: EvenInt
+    ~error:
+      9 :: EvenInt
+)
+
+The @rhombus(annot.macro, ~defn) form from @rhombusmodname(rhombus/meta)
+also defines an annotation, but as a macro, in which case it can have
+argument forms or other syntactic variations. (See @secref("bind-macro")
+for more information.) The @rhombus(annot, ~defn) form can only bind an
+identifier as a shorthand for another annotation, but that other
+annotation is parsed eagerly and centralizes run-time support for the
+annotation. Also, @rhombus(annot, ~defn) is provided by
+@rhombuslangname(rhombus), so @rhombusmodname(rhombus/meta) does not
+need to be imported to use it. Prefer @rhombus(annot, ~defn) to
+@rhombus(annot.macro, ~defn).

--- a/rhombus/rhombus/scribblings/guide/annotation-overview.scrbl
+++ b/rhombus/rhombus/scribblings/guide/annotation-overview.scrbl
@@ -11,5 +11,6 @@ and @secref("annotation"), and annotation macros are described in
 @include_section("annotation-combine.scrbl")
 @include_section("annotation-maybe.scrbl")
 @include_section("annotation-satisfying.scrbl")
+@include_section("annotation-def.scrbl")
 @include_section("annotation-convert.scrbl")
 @include_section("annotation-list.scrbl")

--- a/rhombus/rhombus/scribblings/guide/bind-macro.scrbl
+++ b/rhombus/rhombus/scribblings/guide/bind-macro.scrbl
@@ -39,10 +39,10 @@ annotations.
 @rhombusblock(
   use_static
 
-  annot.macro 'PosnList': 'List.of(Posn)'
+  annot.macro 'PosnOfList($x, $y)': 'List.of(Posn.of($x, $y))'
 
-  fun nth_x(ps :~ PosnList, n):
-    ps[n].x
+  fun nth_x(ps :~ PosnOfList(Flonum, Flonum), n, scale :: Flonum):
+    ps[n].x * scale
 )
 
 Annotations and binding patterns serve similar and interacting purposes.
@@ -61,9 +61,9 @@ specialization, but the @rhombus(Map) binding pattern can.
   ~hidden:
     class Posn(x, y)
   ~defn:
-    annot.macro 'PersonList':
-      'List.of(matching({"name": (_ :: String),
-                         "location": (_ :: Posn)}))'
+    annot PersonList:
+      List.of(matching({"name": (_ :: String),
+                        "location": (_ :: Posn)}))
 
     def players :: PersonList:
       [{"name": "alice", "location": Posn(1, 2)},
@@ -76,7 +76,7 @@ could be implemented if @rhombus(List.of, ~annot) did not exist already:
 @examples(
   ~eval: macro_eval
   ~defn:
-    annot.macro 'ListOf ($ann ...)':
+    annot.macro 'ListOf($ann ...)':
       'matching([_ :: ($ann ...), $('...')])'
 )
 

--- a/rhombus/rhombus/scribblings/meta/annotation-macro.scrbl
+++ b/rhombus/rhombus/scribblings/meta/annotation-macro.scrbl
@@ -35,6 +35,39 @@
 
 @doc(
   ~nonterminal:
+    as_annot: :: annot
+  defn.macro 'annot.def $id_name = $as_annot'
+  defn.macro 'annot.def $id_name: $as_annot'
+){
+
+ Defines @rhombus(id_name) as equivalent to @rhombus(as_annot).
+
+ Unlike @rhombus(annot.macro '$id_name' = '$as_annot'), @rhombus(as_annot) is
+ parsed once at the definition, instead of delayed until each use of
+ @rhombus(id_name), and only one copy of each run-time component of
+ @rhombus(as_annot) is generated.
+
+ The @rhombus(annot, ~defn) form provided by @rhombuslangname(rhombus) is an
+ alias of @rhombus(annot.def)
+
+@examples(
+  ~eval: macro_eval
+  ~defn:
+    annot.def TwoInt = [Int, Int]
+  ~repl:
+    [1, 2] :: TwoInt
+    ~error:
+      [1, 2, 3] :: TwoInt
+)
+
+@(history:
+    ~added "1.0.0.1")
+
+}
+
+
+@doc(
+  ~nonterminal:
     macro_patterns: expr.macro ~defn
     option: macro ~defn
 
@@ -47,18 +80,27 @@
 
  Like @rhombus(expr.macro), but defines an identifier or operator as an
  annotation form in the @rhombus(annot, ~space) @tech{space}.
- The result of the macro expansion can be a result
- created with @rhombus(annot_meta.pack_predicate).
+ The result of the macro expansion can be a syntax object to
+ further expand, or it can be a result created with
+ @rhombus(annot_meta.pack_predicate) or
+ @rhombus(annot_meta.pack_converter).
+
+ Use @rhombus(annot.def, ~defn) when possible, instead of
+ @rhombus(annot.macro, ~defn), since @rhombus(annot.def, ~defn) avoids
+ duplicating implementation. The @rhombus(annot.macro, ~defn) form is
+ more general, however.
 
 @examples(
   ~eval: macro_eval
-  annot.macro 'two_of($ann)':
-    'matching(List[_ :: $ann, _ :: $ann])'
-  [1, 2] :: two_of(Number)
-  ~error:
-    [1, 2, 3] :: two_of(Number)
-  ~error:
-    [1, "x"] :: two_of(Number)
+  ~defn:
+    annot.macro 'two_of($ann)':
+      'matching(List[_ :: $ann, _ :: $ann])'
+  ~repl:
+    [1, 2] :: two_of(Number)
+    ~error:
+      [1, 2, 3] :: two_of(Number)
+    ~error:
+      [1, "x"] :: two_of(Number)
 )
 
  See @secref("stxobj-track") for information about expansion tracking,
@@ -76,7 +118,6 @@
  be passed along.
 
 }
-
 
 @doc(
   ~meta

--- a/rhombus/rhombus/scribblings/reference/annotation.scrbl
+++ b/rhombus/rhombus/scribblings/reference/annotation.scrbl
@@ -84,6 +84,34 @@
 }
 
 @doc(
+  ~nonterminal:
+    as_annot: :: annot
+  defn.macro 'annot $id_name = $as_annot'
+  defn.macro 'annot $id_name: $as_annot'
+){
+
+ Defines @rhombus(id_name) as equivalent to @rhombus(as_annot).
+
+ The @rhombusmodname(rhombus/meta) module provides
+ @rhombus(annot.def, ~defn), which is equivalent to
+ @rhombus(annot, ~defn), and @rhombus(annot.macro, ~defn), which is more
+ general.
+
+@examples(
+  ~defn:
+    annot TwoInt = [Int, Int]
+  ~repl:
+    [1, 2] :: TwoInt
+    ~error:
+      [1, 2, 3] :: TwoInt
+)
+
+@(history:
+    ~added "1.0.0.1")
+
+}
+
+@doc(
   annot.macro 'Any'
   annot.macro 'Any.of($expr, ...)'
   annot.macro 'Any.to_boolean'

--- a/rhombus/rhombus/tests/annot-def.rhm
+++ b/rhombus/rhombus/tests/annot-def.rhm
@@ -1,0 +1,57 @@
+#lang rhombus
+
+block:
+  annot Digit = Int.in(0..=9)
+  check:
+    0 is_a Digit ~is #true
+    10 is_a Digit ~is #false
+    0 :: Digit ~is 0
+    -1 :: Digit ~throws error.annot_msg()
+  check:
+    use_static
+    fun f(x :: Digit, y :: Digit):
+      x < y
+    f(1, 2)
+    ~is #true
+
+block:
+  annot Evened = converting(fun (x :: Int): (x div 2) * 2)
+  check 4 :: Evened ~is 4
+  check 3 :: Evened ~is 2
+  check:
+    match 5
+    | x :: Evened: x
+    | ~else: 0
+    ~is 4
+  check:
+    match "5"
+    | x :: Evened: x
+    | ~else: 0
+    ~is 0
+
+block:
+  def mutable recent_count = 0
+  annot Even = satisfying(block:
+                            def mutable count = 0
+                            fun (x :: Int):
+                              count := count + 1
+                              recent_count := count
+                              x mod 2 == 0)
+  check 4 :: Even ~is 4
+  check 3 :: Even ~throws error.annot_msg()
+  check recent_count ~is 2
+  check 4 :~ Even ~is 4
+  check recent_count ~is 2
+  check:
+    match 7
+    | x :: Even: x
+    | ~else: "no"
+    ~is "no"
+  check recent_count ~is 3
+
+namespace ~open:
+  import:
+    rhombus/meta
+  meta.annot.def Even = satisfying(fun (x): x is_a Int && x mod 2 == 0)
+  check 10 :: Even ~is 10
+  check "10" is_a Even ~is #false


### PR DESCRIPTION
An `annot` form
```
annot <name> = <annot>
```
is like
```
annot.macro '<name>' = '<annot>'
```
except that `<annot>` is parsed eagerly once and its run-time support is created only once. An `annot` form can only define a name (i.e., no arguments or subforms), but it should be preferred to `annot.macro` whenever `annot` suffices. For example, `PosnList` and `PersonList` in https://docs.racket-lang.org/rhombus-guide/bind-macro.html should use `annot`.

The `annot` form from `rhombus` is an alias for `annot.def` from `rhombus/meta`. In part, the `annot.def` binding is intended to help discoverability. From another perspective, the name `annot.def` is the most consistent one, but the intent of `annot` is to have a way to define an annotation without `rhombus/meta` or expand-time code.

I'm not sure it's a good idea to overload `annot` this way, but I think it works out well. There are many precedents for a name having a binding both as a namespace and in other spaces, but it's rare for the different bindings to come from different modules. Then again, `meta` is provided for export from `rhombus` and as a declaration from from `rhombus/meta`.
