### PR TITLE
docs: add missing "or" between the two risks of importing with "open"

### DIFF
--- a/rhombus/rhombus/scribblings/guide/module.scrbl
+++ b/rhombus/rhombus/scribblings/guide/module.scrbl
@@ -121,7 +121,7 @@ supply an explicit prefix, use the @rhombus(as, ~impo) modifier:
 )
 
 Use the @rhombus(open, ~impo) modifier to import without a prefix,
-albeit at the risk of creating import conflicts of obscuring the origin
+albeit at the risk of creating import conflicts or of obscuring the origin
 of a binding.
 
 @rhombusblock(


### PR DESCRIPTION
This way, it's more clear that importing with the "open" modifier has two separate risks:

 * creating import conflicts
 * obscuring the origin of a binding

Without the "or", these two risks seem linked to each other in an unclear (or maybe just nonsensical) way. (At least to me it's unclear what "import conflicts of obscuring *&lt;something>*" would be supposed to mean.)