### PR TITLE
ffi: add initialized-array variant of `new`

### DIFF
--- a/rhombus-ffi-lib/info.rkt
+++ b/rhombus-ffi-lib/info.rkt
@@ -5,7 +5,7 @@
 (define deps
   '(["base" #:version "9.2"]
     "rhombus-lib"
-    ["ffi2-lib" #:version "0.2"]))
+    ["ffi2-lib" #:version "1.1"]))
 
 (define pkg-desc "implementation (no documentation) part of \"rhombus-ffi\"")
 

--- a/rhombus-ffi-lib/rhombus/ffi/private/pointer.rhm
+++ b/rhombus-ffi-lib/rhombus/ffi/private/pointer.rhm
@@ -7,6 +7,7 @@ import:
   lib("ffi2/main.rkt")!unsafe as ffi2_unsafe:
     expose:
       #{unsafe-ffi2-malloc} as ffi2_malloc
+      #{unsafe-ffi2-new} as ffi2_new
       #{unsafe-ffi2-ref} as #{|mem reference|}
       #{unsafe-ffi2-set!} as #{|mem assignment|}
       #{unsafe-ffi2-add} as #{|mem shift|}
@@ -182,8 +183,7 @@ expr.macro 'new $(m :: MallocMode) $(t :: type_meta.AfterPrefixParsed('int_t')) 
       | add_annot(m_e, 'PointerOf($(type_meta.unpack_annot(t)),
                                   $(type_meta.unpack_type(t)),
                                   $(type_meta.unpack_array_length(t)))')
-    values(m_e,
-           tail)
+    values(m_e, tail)
   match tail
   | '($(field_id :: Identifier): $e) $tail ...' when type_meta.unpack_union_proc_ids(t):
       match type_meta.unpack_union_proc_ids(t)
@@ -201,6 +201,17 @@ expr.macro 'new $(m :: MallocMode) $(t :: type_meta.AfterPrefixParsed('int_t')) 
                     type_meta.unpack_annot(t))
       | ~else:
           default()
+  | '{$e, ...} $tail ...':
+      let m_e:
+        expr_meta.pack_s_exp(['ffi2_new',
+                              m.mode,
+                              type_meta.s_exp(type_meta.unpack_type(t)),
+                              expr_meta.pack_expr(e), ...])
+      let m_e:
+        add_annot(m_e, 'PointerOf($(type_meta.unpack_annot(t)),
+                                  $(type_meta.unpack_type(t)),
+                                  $(type_meta.unpack_array_length(t)))')
+      values(m_e, '$tail ...')
   | ~else:
       default()
 

--- a/rhombus-ffi/rhombus/ffi/scribblings/overview.scrbl
+++ b/rhombus-ffi/rhombus/ffi/scribblings/overview.scrbl
@@ -955,7 +955,8 @@ when it is no longer needed.
 @examples(
   ~eval: ffi_eval
   ~defn:
-    def the_counter = new ~manual int_t
+    :
+      def the_counter = new ~manual int_t { 0 } // allocate and initialize
     :
       // ...
       def end_count = the_counter[0]
@@ -970,7 +971,7 @@ not allowed to relocate the object as long as it is live.
 @examples(
   ~eval: ffi_eval
   ~defn:
-    def the_counter = new ~immobile int_t
+    def the_counter = new ~immobile int_t { 0 }
 )
 
 The constructor created by @rhombus(foreign.struct) uses @rhombus(new),

--- a/rhombus-ffi/rhombus/ffi/scribblings/pointer.scrbl
+++ b/rhombus-ffi/rhombus/ffi/scribblings/pointer.scrbl
@@ -134,11 +134,13 @@ garbage collector is independent of its tags.
 @doc(
   ~nonterminal:
     field_expr: block expr
+    element_expr: block expr
     variant_id: block id
     type: * type ~at rhombus/ffi/type
   expr.macro 'new $maybe_mode $type'
   expr.macro 'new $maybe_mode $type($field_expr, ...)'
   expr.macro 'new $maybe_mode $type($variant_id: $field_expr)'
+  expr.macro 'new $maybe_mode $type { $element_expr, ...}'
   grammar maybe_mode
   | ~manual
   | ~gcable
@@ -155,10 +157,14 @@ garbage collector is independent of its tags.
 
  The amount of allocated memory depends on @rhombus(type), where the
  allocated memory spans as many bytes as the C representation of
- @rhombus(type). A type of the form
+ @rhombus(type), times eiher @rhombus(1) or the number of
+ @rhombus(element_expr)s provided. A type of the form
  @rhombus(#,(@rhombus(elem_type, ~var))[#,(@rhombus(expr, ~var))]) is
  allowed with a non-literal @rhombus(expr, ~var) to allocate the
- indicated multiple of the C size of @rhombus(elem_type, ~var) in bytes.
+ indicated multiple of the C size of @rhombus(elem_type, ~var) in bytes,
+ instead of providing the corresponding number of @rhombus(element_expr)s.
+ If @rhombus(element_expr)s are provided, they are installed into the
+ allocated memory as by @rhombus(mem .... := ....).
 
  By default, allocation uses @rhombus(~gcable) mode, but a
  @rhombus(maybe_mode) specification can pick any of the supported modes:
@@ -192,6 +198,10 @@ garbage collector is independent of its tags.
 
 )
 
+ Unless @rhombus(element_expr)s are provided, the initial content of
+ allocated memory is unspecified, except that it is safe (effectively
+ zeroed) in @rhombus(~traced) and @rhombus(~traced_immobile) modes.
+
 @examples(
   ~eval: ffi_eval,
   ~repl:
@@ -206,6 +216,9 @@ garbage collector is independent of its tags.
     def p3 = new int_t[1+2]
     p3[2] := 20
     p3[2]
+  ~repl:
+    def p4 = new int_t { 101, 102, 103, 104 }
+    p4[2]
   ~repl:
     def p1_imm = new ~immobile int_t
     def i1_imm = ptr_to_uintptr(p1_imm)

--- a/rhombus-ffi/rhombus/ffi/tests/pointer.rhm
+++ b/rhombus-ffi/rhombus/ffi/tests/pointer.rhm
@@ -16,6 +16,9 @@ block:
   let p_is = new int_t[5+5]
   check p_is ~is_a ptr_t
 
+  let p_is_init = new int_t { 1, 2, 3, 4 }
+  check p_is_init ~is_a ptr_t
+
   check mem *(int_t*)p_i := 10 ~is #void
   check mem *(int_t*)p_i ~is 10
 
@@ -35,6 +38,9 @@ block:
 
   check mem p_is[1] := 345 ~is #void
   check mem (mem &p_is[1])[0] ~is 345
+
+  check p_is_init[0] ~is 1
+  check p_is_init[3] ~is 4
 
   check mem *(p_i) := 20 + 30 ~is #void
   check mem *(p_i) ~is 50

--- a/rhombus-ffi/rhombus/ffi/tests/struct.rhm
+++ b/rhombus-ffi/rhombus/ffi/tests/struct.rhm
@@ -56,3 +56,10 @@ block:
   foreign.type Size_t
   check r.size is_a foreign.type Size_t* ~is #false
   check r2.size is_a foreign.type Size_t* ~is #true
+
+block:
+  let ps = new Point_t { new Point_t(1, 2), new Point_t(3, 4) }
+  check ps[0].x ~is 1
+  check ps[0].y ~is 2
+  check ps[1].x ~is 3
+  check ps[1].y ~is 4


### PR DESCRIPTION
An allocation `new int_t { 1, 2, 3 }` maps to `ffi2-new`, for example. Depends on racket/racket#5549.