### PR TITLE
add `as` binding form

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/boolean-pattern.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/boolean-pattern.rkt
@@ -15,6 +15,7 @@
 (provide (for-space rhombus/bind
                     &&
                     \|\|
+                    as
                     !
                     is_now))
 
@@ -163,6 +164,34 @@
   (syntax-parse stx
     [(_ arg-id () (lhs rhs))
      #'(begin)]))
+
+;; ----------------------------------------
+;; as
+
+(define-binding-syntax as
+  (binding-prefix+infix-operator
+   (binding-transformer
+    (lambda (stx)
+      (syntax-parse stx
+        [(form-id . tail)
+         (values (make-identifier-binding #'form-id)
+                 #'tail)])))
+   (binding-infix-operator
+    (lambda () (order-quote logical_conjunction))
+    null
+    'macro
+    (lambda (lhs stx)
+      (syntax-parse stx
+        [(form-id name:id . tail)
+         (define rhs (make-identifier-binding #'name))
+         (values
+          (transfer-origins
+           (list lhs rhs)
+           (binding-form
+            #'and-infoer
+            #`(#,lhs #,rhs)))
+          #'tail)]))
+    'left)))
 
 ;; ----------------------------------------
 ;; !

--- a/rhombus/rhombus/scribblings/reference/def.scrbl
+++ b/rhombus/rhombus/scribblings/reference/def.scrbl
@@ -107,3 +107,39 @@
 )
 
 }
+
+@doc(
+  bind.macro '$bind as $id'
+  bind.macro 'as'
+){
+
+ A binding @rhombus(bind as id, ~bind) is essentially the same as
+ @rhombus(bind && id, ~bind): it binds according the left-hand
+ @rhombus(bind) as well as binding its right-hand @rhombus(id) as a match
+ to anything. The difference is that @rhombus(as, ~bind) always treats
+ its right-hand @rhombus(id) as a pattern variable, and never as a
+ (prefix) binding operator, so it could be used to bind names like
+ @rhombus(_, ~datum) (which would otherwise refer to the
+ @rhombus(_, ~bind) binding form) and @rhombus(mutable, ~datum) (which
+ would otherwise refer to the @rhombus(mutable, ~bind) binding form).
+ Even when @rhombus(id) is not already bound, using @rhombus(as, ~bind)
+ is potentially clearer than using @rhombus(&&) when giving a name to a
+ value whose components are matched in the left-hand @rhombus(bind).
+
+ By itself, @rhombus(as, ~bind) binds the name @rhombus(as, ~datum).
+ That is, @rhombus(as, ~bind) by itself is equivalent to
+ @rhombus(_ as as, ~bind).
+
+@examples(
+  block:
+    let _ as x = 10
+    x
+  block:
+    let _ as _ = 10
+    _
+  block:
+    let as = ["a", "a", "a"]
+    as
+)
+
+}

--- a/rhombus/rhombus/tests/def.rhm
+++ b/rhombus/rhombus/tests/def.rhm
@@ -156,3 +156,31 @@ check:
     "expected: 1",
     "received: 2",
   )
+
+check:
+  def _ as _ = 10
+  _
+  ~is 10
+
+check:
+  def as = ["a", "a", "a"]
+  as
+  ~is ["a", "a", "a"]
+
+check:
+  use_static
+  def _ as x = 10
+  x < x
+  ~is #false
+
+check:
+  use_static
+  def _ as x :: Int = dynamic(10)
+  x < x
+  ~is #false
+
+check:
+  use_static
+  def _ :: Int as x = dynamic(10)
+  x < x
+  ~is #false


### PR DESCRIPTION
The infix `as` binding form is like `&&`, but it treats its right-hand side always as an identifier to bind.

Example:
```
> def [x, ...] as xs = [1, 2, 3]
> xs
[1, 2, 3]
> [x+1, ...]
[2, 3, 4]
> def _ as _ = [1, 2, 3]
> _
[1, 2, 3]
```

For backward compatibility and to avoid disallowing `as` as a variable name (often useful to mean "many `a`s"), a prefix `as` essentially expands to `_ as as`.

```
> def as = ["a", "a", "a"]
> as
["a", "a", "a"]
```