### PR TITLE
Fix lead_in bug with can_page_mode

### DIFF
--- a/rhombus-slideshow-lib/rhombus/slideshow.rhm
+++ b/rhombus-slideshow-lib/rhombus/slideshow.rhm
@@ -119,7 +119,9 @@ fun slide(~title: title :: maybe(String || Pict) = #false,
   | rkt_play.#{play-n}(~name: name,
                        ~#{skip-first?}: #true,
                        ~#{skip-last?}: #true,
-                       ~#{page-mode}: #'none,
+                       ~& if can_page_mode
+                       | { #'~#{page-mode}: #'none }
+                       | {},
                        fun (n): p.snapshot(-1, n).draw_handle)
   for (i in 0..p.duration):
     let continued = p.epoch_metadata(i).get(#'continued, #false)


### PR DESCRIPTION
From claude: 
lead_in crashed outright: slideshow.rhm guards ~page-mode with can_page_mode in its
  epoch loop, but the lead-in play-n call ten lines above passed it unconditionally, and your installed slideshow/play
  predates that keyword. I applied the same guard used below it — you've since committed it as f3cabe85. Without that,
  no slide_transition returning lead_in: #true can work at all.
