### PR TITLE
pict: add `as_rebuildable`

### DIFF
--- a/rhombus-pict-lib/info.rkt
+++ b/rhombus-pict-lib/info.rkt
@@ -15,6 +15,6 @@
 
 (define license '(Apache-2.0 OR MIT))
 
-(define version "1.2")
+(define version "1.3")
 
 (define language-families '("Rhombus"))

--- a/rhombus-pict-lib/rhombus/pict/private/anim.rhm
+++ b/rhombus-pict-lib/rhombus/pict/private/anim.rhm
@@ -35,6 +35,7 @@ export:
 
   animate
   rebuildable
+  as_rebuildable
   animate_map
   sequential
   concurrent
@@ -106,6 +107,11 @@ fun rebuildable(~deps: children :: List.of(Pict) = [],
                                   || (~config: maybe(Map)) -> Pict
                                   || (~deps: List.of(Pict), ~config: maybe(Map)) -> Pict)) :~ Pict:
   rebuildable_anim(children, config, proc)
+
+expr.macro 'as_rebuildable ($(id :: Identifier), ...): $body':
+  'rebuildable(~deps: [$id :: Pict, ...],
+               fun (~deps: [$id :~ Pict, ...]):
+                 $body)'
 
 fun rebuildable_anim(children :~ List, config, proc):
   let p:

--- a/rhombus-pict/rhombus/pict/scribblings/rebuild.scrbl
+++ b/rhombus-pict/rhombus/pict/scribblings/rebuild.scrbl
@@ -147,6 +147,9 @@
 }
 
 @doc(
+  ~nonterminal:
+    id: block id
+    body: block
   fun rebuildable(
     rebuild
       :: (~deps: List.of(Pict)) -> Pict
@@ -155,9 +158,13 @@
     ~deps: deps :: List.of(Pict) = [],
     ~config: config :: maybe(Map) = #false
   ) :: Pict
+  expr.macro 'as_rebuildable ($id, ...):
+                $body
+                ...'
 ){
 
- Creates a pict that is the same as the result of
+ The @rhombus(rebuildable) function
+ creates a pict that is the same as the result of
  @rhombus(rebuild(~deps: deps)), @rhombus(rebuild(~config: config)) or
  @rhombus(rebuild(~deps: deps, ~config: config)), but where
  @rhombus(deps) contains picts that can be adjusted via
@@ -167,8 +174,22 @@
  the result of @rhombus(rebuildable) itself; see also
  @secref("identity").
 
- The given @rhombus(deps) list determines the @tech{replaceable dependencies} of the
- result pict, but the result from @rhombus(proc) determines the
+ The given @rhombus(deps) list for @rhombus(rebuildable) determines the @tech{replaceable dependencies} of the
+ result pict, but the result from @rhombus(build) determines the
  @tech{findable children}.
+
+ The @rhombus(as_rebuildable) form is a shorthand for calling
+ @rhombus(rebuildable) with @rhombus([id, ...]) as @rhombus(deps) and the
+ @rhombus(body) sequence as the body of the @rhombus(rebuild) function:
+
+@rhombusblock(
+  rebuildable(~deps: [id :: Pict, ...],
+              fun (id :: Pict, ...):
+                body
+                ...)
+)
+
+@(history:
+    ~added "1.3")
 
 }


### PR DESCRIPTION
The `as_rebuildable` form is a shorthand for the most common kind of use of `rebuildable`.