### PR TITLE
Repair annot docs for `Bytes.to_list` and `Bytes.from_list`

### DIFF
--- a/rhombus/rhombus/scribblings/reference/bytes.scrbl
+++ b/rhombus/rhombus/scribblings/reference/bytes.scrbl
@@ -328,8 +328,8 @@ like @rhombus(<) and @rhombus(>) work on byte strings.
 }
 
 @doc(
-  method Bytes.to_list(str :: Bytes) :: List.of(Char)
-  fun Bytes.from_list(lst :: List.of(Char)) :: Bytes
+  method Bytes.to_list(str :: Bytes) :: List.of(Byte)
+  fun Bytes.from_list(lst :: List.of(Byte)) :: Bytes
 ){
 
  Converts a byte string to or from a list of bytes.


### PR DESCRIPTION
Reported by a user in Discord.